### PR TITLE
Add Vulkan surface abstraction and GLFW window provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(PICTOR_BUILD_BENCHMARK "Build 1M Spheres benchmark" ON)
+option(PICTOR_BUILD_DEMO      "Build Vulkan window demo"   ON)
 option(PICTOR_ENABLE_PROFILER "Enable built-in profiler" ON)
 option(PICTOR_USE_LARGE_PAGES "Enable large page support" OFF)
 
@@ -56,6 +57,10 @@ add_library(pictor STATIC
     src/profiler/overlay_renderer.cpp
     src/profiler/data_exporter.cpp
 
+    # Surface Abstraction
+    src/surface/vulkan_context.cpp
+    src/surface/glfw_surface_provider.cpp
+
     # Public API
     src/core/pictor_renderer.cpp
 )
@@ -85,7 +90,22 @@ elseif(MSVC)
     target_compile_options(pictor PRIVATE /W4 /arch:AVX2)
 endif()
 
+# GLFW (required for demo, optional for library)
+find_package(glfw3 QUIET)
+
+if(glfw3_FOUND)
+    target_link_libraries(pictor PUBLIC glfw)
+endif()
+
 if(PICTOR_BUILD_BENCHMARK)
     add_executable(pictor_benchmark benchmark/main.cpp)
     target_link_libraries(pictor_benchmark PRIVATE pictor)
+endif()
+
+if(PICTOR_BUILD_DEMO AND Vulkan_FOUND AND glfw3_FOUND)
+    add_executable(pictor_demo demo/main.cpp)
+    target_link_libraries(pictor_demo PRIVATE pictor)
+    message(STATUS "Pictor: Vulkan window demo enabled")
+elseif(PICTOR_BUILD_DEMO)
+    message(STATUS "Pictor: Demo disabled (requires Vulkan + GLFW3)")
 endif()

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1,0 +1,210 @@
+/// Pictor Vulkan Window Demo
+///
+/// Opens a GLFW window, initializes a Vulkan swapchain via
+/// the ISurfaceProvider abstraction, and renders a clear-color
+/// animation to prove the pipeline is running.
+
+#include "pictor/pictor.h"
+#include "pictor/surface/vulkan_context.h"
+#include "pictor/surface/glfw_surface_provider.h"
+
+#include <cstdio>
+#include <cmath>
+#include <chrono>
+
+using namespace pictor;
+
+// ---------------------------------------------------------------------------
+// Animated clear-color: slowly cycles through hues so you can instantly
+// see that the Vulkan pipeline is alive.
+// ---------------------------------------------------------------------------
+static void hue_to_rgb(float h, float& r, float& g, float& b) {
+    float s = 0.7f, v = 0.9f;
+    int   i = static_cast<int>(h * 6.0f);
+    float f = h * 6.0f - static_cast<float>(i);
+    float p = v * (1.0f - s);
+    float q = v * (1.0f - f * s);
+    float t = v * (1.0f - (1.0f - f) * s);
+    switch (i % 6) {
+        case 0: r = v; g = t; b = p; break;
+        case 1: r = q; g = v; b = p; break;
+        case 2: r = p; g = v; b = t; break;
+        case 3: r = p; g = q; b = v; break;
+        case 4: r = t; g = p; b = v; break;
+        case 5: r = v; g = p; b = q; break;
+        default: r = g = b = 0; break;
+    }
+}
+
+int main() {
+    printf("=== Pictor Vulkan Window Demo ===\n\n");
+
+    // ---- 1. GLFW Window ----
+    GlfwSurfaceProvider surface_provider;
+    GlfwWindowConfig win_cfg;
+    win_cfg.width  = 1280;
+    win_cfg.height = 720;
+    win_cfg.title  = "Pictor — Vulkan Window Demo";
+    win_cfg.vsync  = true;
+
+    if (!surface_provider.create(win_cfg)) {
+        fprintf(stderr, "Failed to create GLFW window\n");
+        return 1;
+    }
+
+    // ---- 2. Vulkan Context ----
+    VulkanContext vk_ctx;
+    VulkanContextConfig vk_cfg;
+    vk_cfg.app_name   = "Pictor Demo";
+    vk_cfg.validation = true; // enable validation in demo
+
+    if (!vk_ctx.initialize(&surface_provider, vk_cfg)) {
+        fprintf(stderr, "Failed to initialize Vulkan context\n");
+        surface_provider.destroy();
+        return 1;
+    }
+
+    printf("Vulkan context initialized successfully.\n");
+    printf("Swapchain: %ux%u\n\n",
+           vk_ctx.swapchain_extent().width,
+           vk_ctx.swapchain_extent().height);
+
+    // ---- 3. Pictor Renderer (pipeline only — no actual draw yet) ----
+    RendererConfig pictor_cfg;
+    pictor_cfg.initial_profile = "Standard";
+    pictor_cfg.screen_width    = vk_ctx.swapchain_extent().width;
+    pictor_cfg.screen_height   = vk_ctx.swapchain_extent().height;
+    pictor_cfg.profiler_enabled = true;
+    pictor_cfg.overlay_mode    = OverlayMode::MINIMAL;
+
+    PictorRenderer renderer;
+    renderer.initialize(pictor_cfg);
+
+    // ---- 4. Register a few test objects so profiler has something to report ----
+    constexpr uint32_t TEST_OBJECTS = 1000;
+    for (uint32_t i = 0; i < TEST_OBJECTS; ++i) {
+        float x = static_cast<float>(i % 10) * 2.0f - 10.0f;
+        float y = static_cast<float>((i / 10) % 10) * 2.0f - 10.0f;
+        float z = static_cast<float>(i / 100) * 2.0f - 10.0f;
+
+        ObjectDescriptor desc;
+        desc.mesh      = 0;
+        desc.material  = 0;
+        desc.transform = float4x4::identity();
+        desc.transform.set_translation(x, y, z);
+        desc.bounds.min = {x - 0.5f, y - 0.5f, z - 0.5f};
+        desc.bounds.max = {x + 0.5f, y + 0.5f, z + 0.5f};
+        desc.flags = ObjectFlags::DYNAMIC | ObjectFlags::INSTANCED;
+        renderer.register_object(desc);
+    }
+
+    Camera camera;
+    camera.position = {0.0f, 20.0f, 40.0f};
+    for (int i = 0; i < 6; ++i) {
+        camera.frustum.planes[i].normal   = {0, 0, 0};
+        camera.frustum.planes[i].distance = 10000.0f;
+    }
+    camera.frustum.planes[0] = {{1, 0, 0}, 100.0f};
+    camera.frustum.planes[1] = {{-1, 0, 0}, 100.0f};
+    camera.frustum.planes[2] = {{0, 1, 0}, 100.0f};
+    camera.frustum.planes[3] = {{0, -1, 0}, 100.0f};
+    camera.frustum.planes[4] = {{0, 0, 1}, 0.1f};
+    camera.frustum.planes[5] = {{0, 0, -1}, 500.0f};
+
+    // ---- 5. Main loop ----
+    auto start = std::chrono::high_resolution_clock::now();
+    uint64_t frame_count = 0;
+
+    printf("Entering main loop. Close the window to exit.\n");
+
+    while (!surface_provider.should_close()) {
+        surface_provider.poll_events();
+
+        // Elapsed time for hue animation
+        auto now = std::chrono::high_resolution_clock::now();
+        float elapsed = std::chrono::duration<float>(now - start).count();
+        float hue = std::fmod(elapsed * 0.1f, 1.0f); // one full cycle every 10s
+
+        float r, g, b;
+        hue_to_rgb(hue, r, g, b);
+
+        // Acquire swapchain image
+        uint32_t image_idx = vk_ctx.acquire_next_image();
+        if (image_idx == UINT32_MAX) continue; // swapchain was recreated
+
+        // Record command buffer: clear to animated colour
+#ifdef PICTOR_HAS_VULKAN
+        auto cmd = vk_ctx.command_buffers()[image_idx];
+        vkResetCommandBuffer(cmd, 0);
+
+        VkCommandBufferBeginInfo begin_info{};
+        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        vkBeginCommandBuffer(cmd, &begin_info);
+
+        VkClearValue clear_color = {{{r, g, b, 1.0f}}};
+
+        VkRenderPassBeginInfo rp_info{};
+        rp_info.sType       = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp_info.renderPass  = vk_ctx.default_render_pass();
+        rp_info.framebuffer = vk_ctx.framebuffers()[image_idx];
+        rp_info.renderArea  = {{0, 0}, vk_ctx.swapchain_extent()};
+        rp_info.clearValueCount = 1;
+        rp_info.pClearValues    = &clear_color;
+
+        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+        // (Future: Pictor would record draw commands here)
+        vkCmdEndRenderPass(cmd);
+
+        vkEndCommandBuffer(cmd);
+
+        // Submit
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSemaphore wait_sem  = vk_ctx.image_available_semaphore();
+        VkSemaphore sig_sem   = vk_ctx.render_finished_semaphore();
+
+        VkSubmitInfo submit_info{};
+        submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.waitSemaphoreCount   = 1;
+        submit_info.pWaitSemaphores      = &wait_sem;
+        submit_info.pWaitDstStageMask    = &wait_stage;
+        submit_info.commandBufferCount   = 1;
+        submit_info.pCommandBuffers      = &cmd;
+        submit_info.signalSemaphoreCount = 1;
+        submit_info.pSignalSemaphores    = &sig_sem;
+
+        vkQueueSubmit(vk_ctx.graphics_queue(), 1, &submit_info, vk_ctx.in_flight_fence());
+#endif
+
+        // Present
+        vk_ctx.present(image_idx);
+
+        // Run Pictor pipeline (data-only, no GPU draw yet)
+        float dt = 1.0f / 60.0f;
+        renderer.begin_frame(dt);
+        renderer.render(camera);
+        renderer.end_frame();
+
+        ++frame_count;
+
+        // Print stats every 120 frames
+        if (frame_count % 120 == 0) {
+            const auto& stats = renderer.get_frame_stats();
+            printf("[Frame %llu] FPS: %.1f  Visible: %u/%u  Batches: %u\n",
+                   static_cast<unsigned long long>(frame_count),
+                   stats.fps,
+                   stats.visible_objects,
+                   TEST_OBJECTS,
+                   stats.batch_count);
+        }
+    }
+
+    // ---- 6. Cleanup ----
+    vk_ctx.device_wait_idle();
+    renderer.shutdown();
+    vk_ctx.shutdown();
+    surface_provider.destroy();
+
+    printf("\nDemo finished. %llu frames rendered.\n",
+           static_cast<unsigned long long>(frame_count));
+    return 0;
+}

--- a/docs/design/webgl_backend.md
+++ b/docs/design/webgl_backend.md
@@ -1,0 +1,517 @@
+# Pictor WebGL バックエンド設計書
+
+## 1. 概要
+
+Pictor の描画バックエンドとして WebGL (WebGL2 / WebGPU 拡張対応) を追加し、
+ブラウザ上での描画を実現する。Rust + WebAssembly (wasm32-unknown-unknown) で実装し、
+既存の C++ コアとはデータフォーマット互換を維持する。
+
+### 1.1 目的
+
+| 目的 | 詳細 |
+|------|------|
+| ブラウザ描画 | デスクトップアプリなしで Pictor シーンを可視化 |
+| クロスプラットフォーム | OS に依存しない描画パス |
+| 組み込み用途 | Web アプリケーションへの埋め込みレンダラ |
+| 将来の WebGPU 移行パス | WebGL2 → WebGPU への段階的移行を見据えた設計 |
+
+### 1.2 スコープ
+
+- **対象**: WebGL2 (ES 3.0 相当)
+- **言語**: Rust (stable)
+- **ターゲット**: `wasm32-unknown-unknown`
+- **JS 連携**: `wasm-bindgen` + `web-sys`
+- **対象外**: WebGPU 実装（将来ブランチで対応）
+
+---
+
+## 2. アーキテクチャ
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Host Web Application (JavaScript / TypeScript)                 │
+│  ┌───────────────┐  ┌──────────────────────────────────┐       │
+│  │  <canvas>      │  │  pictor_webgl.js (wasm-bindgen)  │       │
+│  │  element       │  │  - init(canvas)                  │       │
+│  │                │  │  - load_scene(data)              │       │
+│  └───────┬───────┘  │  - render_frame(dt)               │       │
+│          │          │  - resize(w, h)                   │       │
+│          │          └──────────┬───────────────────────┘       │
+│          │                     │  wasm-bindgen FFI             │
+└──────────┼─────────────────────┼───────────────────────────────┘
+           │                     │
+┌──────────┼─────────────────────┼───────────────────────────────┐
+│  WASM Module (Rust)            │                                │
+│          │                     │                                │
+│  ┌───────▼─────────────────────▼───────────────────────┐       │
+│  │  pictor-webgl crate                                  │       │
+│  │                                                      │       │
+│  │  ┌──────────────┐  ┌─────────────┐  ┌────────────┐ │       │
+│  │  │ WebGlContext  │  │ ShaderMgr   │  │ BufferMgr  │ │       │
+│  │  │ (web-sys)     │  │ (GLSL ES)   │  │ (VBO/IBO)  │ │       │
+│  │  └──────┬───────┘  └──────┬──────┘  └─────┬──────┘ │       │
+│  │         │                 │                │        │       │
+│  │  ┌──────▼─────────────────▼────────────────▼──────┐ │       │
+│  │  │ RenderPipeline                                 │ │       │
+│  │  │ - Batch → DrawCall 変換                        │ │       │
+│  │  │ - Instanced Drawing (ANGLE_instanced_arrays)   │ │       │
+│  │  │ - Multi-Draw Emulation                         │ │       │
+│  │  └────────────────────────────────────────────────┘ │       │
+│  │                                                      │       │
+│  │  ┌────────────────────────────────────────────────┐ │       │
+│  │  │ pictor-core (Rust port / shared data types)    │ │       │
+│  │  │ - SoA Streams, AABB, float4x4                  │ │       │
+│  │  │ - Frustum Culling (CPU, WASM SIMD)              │ │       │
+│  │  │ - Radix Sort (key-index)                        │ │       │
+│  │  │ - Batch Builder                                 │ │       │
+│  │  └────────────────────────────────────────────────┘ │       │
+│  └──────────────────────────────────────────────────────┘       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. クレート構成
+
+```
+pictor-web/
+├── Cargo.toml                   # workspace
+├── crates/
+│   ├── pictor-core/             # プラットフォーム非依存のコアロジック
+│   │   ├── Cargo.toml
+│   │   └── src/
+│   │       ├── lib.rs
+│   │       ├── types.rs         # float3, float4x4, AABB, ObjectDescriptor
+│   │       ├── frustum.rs       # Frustum culling (CPU)
+│   │       ├── radix_sort.rs    # Radix Sort (key-index pairs)
+│   │       ├── batch.rs         # BatchBuilder
+│   │       ├── soa.rs           # SoA stream management
+│   │       └── scene.rs         # SceneRegistry
+│   │
+│   └── pictor-webgl/            # WebGL2 バックエンド
+│       ├── Cargo.toml
+│       └── src/
+│           ├── lib.rs           # wasm-bindgen エントリポイント
+│           ├── context.rs       # WebGL2RenderingContext ラッパー
+│           ├── shader.rs        # GLSL ES 3.00 シェーダ管理
+│           ├── buffer.rs        # VBO / IBO / UBO 管理
+│           ├── texture.rs       # テクスチャ管理
+│           ├── pipeline.rs      # Draw 発行 + state 管理
+│           ├── instancing.rs    # Instanced Draw 実装
+│           └── camera.rs        # View/Projection 行列
+│
+├── www/                          # デモ HTML + JS
+│   ├── index.html
+│   ├── main.js
+│   └── style.css
+│
+└── shaders/                      # GLSL ES 3.00 シェーダ
+    ├── basic.vert
+    ├── basic.frag
+    ├── instanced.vert
+    └── instanced.frag
+```
+
+### 3.1 依存関係
+
+```toml
+# pictor-core/Cargo.toml
+[dependencies]
+# no_std 互換、プラットフォーム非依存
+
+# pictor-webgl/Cargo.toml
+[dependencies]
+pictor-core = { path = "../pictor-core" }
+wasm-bindgen = "0.2"
+web-sys = { version = "0.3", features = [
+    "Window", "Document", "HtmlCanvasElement",
+    "WebGl2RenderingContext", "WebGlProgram", "WebGlShader",
+    "WebGlBuffer", "WebGlUniformLocation", "WebGlVertexArrayObject",
+    "WebGlTexture", "WebGlFramebuffer",
+] }
+js-sys = "0.3"
+glam = { version = "0.29", features = ["bytemuck"] }
+bytemuck = { version = "1", features = ["derive"] }
+```
+
+---
+
+## 4. 主要コンポーネント詳細
+
+### 4.1 pictor-core (Rust ポート)
+
+C++ の Pictor コアロジックのうち、GPU 非依存な部分を Rust に移植する。
+C++ 側とのデータレイアウト互換性を `#[repr(C)]` で保証する。
+
+```rust
+// types.rs
+#[repr(C)]
+#[derive(Clone, Copy, Default, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Float3 {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+#[repr(C, align(64))]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Float4x4 {
+    pub m: [[f32; 4]; 4],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Aabb {
+    pub min: Float3,
+    pub max: Float3,
+}
+
+pub type ObjectId = u32;
+pub type MeshHandle = u32;
+pub type MaterialHandle = u32;
+```
+
+### 4.2 WebGL2 コンテキスト
+
+```rust
+// context.rs
+use web_sys::WebGl2RenderingContext as GL;
+
+pub struct WebGlContext {
+    gl: GL,
+    canvas_width: u32,
+    canvas_height: u32,
+    max_texture_units: i32,
+    max_uniform_buffer_bindings: i32,
+    supports_instancing: bool, // WebGL2 では常に true
+}
+
+impl WebGlContext {
+    /// <canvas> 要素から WebGL2 コンテキストを取得
+    pub fn from_canvas(canvas: &HtmlCanvasElement) -> Result<Self, String> { ... }
+
+    /// ビューポート設定
+    pub fn set_viewport(&self, w: u32, h: u32) { ... }
+
+    /// フレーム開始 (clear)
+    pub fn begin_frame(&self, r: f32, g: f32, b: f32) { ... }
+}
+```
+
+### 4.3 シェーダ管理
+
+WebGL2 (GLSL ES 3.00) 用のシェーダペアを管理する。
+
+```glsl
+// shaders/instanced.vert — GLSL ES 3.00
+#version 300 es
+precision highp float;
+
+// Per-vertex attributes
+layout(location = 0) in vec3 a_position;
+layout(location = 1) in vec3 a_normal;
+
+// Per-instance attributes (mat4 = 4 × vec4)
+layout(location = 2) in vec4 a_model_0;
+layout(location = 3) in vec4 a_model_1;
+layout(location = 4) in vec4 a_model_2;
+layout(location = 5) in vec4 a_model_3;
+
+// Per-instance colour / material ID
+layout(location = 6) in vec4 a_color;
+
+uniform mat4 u_view_projection;
+
+out vec3 v_normal;
+out vec4 v_color;
+
+void main() {
+    mat4 model = mat4(a_model_0, a_model_1, a_model_2, a_model_3);
+    gl_Position = u_view_projection * model * vec4(a_position, 1.0);
+    v_normal = mat3(model) * a_normal;
+    v_color  = a_color;
+}
+```
+
+### 4.4 インスタンス描画
+
+Pictor の Batch → WebGL2 の `drawElementsInstanced` への変換。
+
+```rust
+// instancing.rs
+pub struct InstanceBatch {
+    pub mesh: MeshHandle,
+    pub instance_count: u32,
+    pub transform_buffer: WebGlBuffer,  // mat4[] packed as vec4×4
+    pub color_buffer: WebGlBuffer,      // vec4[]
+}
+
+impl InstanceBatch {
+    /// RenderBatch から WebGL2 Instanced Draw を発行
+    pub fn draw(&self, gl: &GL, vao: &WebGlVertexArrayObject) {
+        gl.bindVertexArray(vao);
+
+        // Transform attributes (locations 2-5)
+        // 各 vec4 列に divisor=1 を設定
+        for i in 0..4 {
+            let loc = 2 + i;
+            gl.enableVertexAttribArray(loc);
+            gl.vertexAttribDivisor(loc, 1);
+        }
+
+        // Color attribute (location 6)
+        gl.enableVertexAttribArray(6);
+        gl.vertexAttribDivisor(6, 1);
+
+        gl.drawElementsInstanced(
+            GL::TRIANGLES,
+            self.index_count as i32,
+            GL::UNSIGNED_INT,
+            0,
+            self.instance_count as i32,
+        );
+    }
+}
+```
+
+### 4.5 Frustum Culling (WASM SIMD)
+
+WebAssembly SIMD (128-bit) を活用した高速カリング。
+
+```rust
+// frustum.rs
+#[cfg(target_arch = "wasm32")]
+use core::arch::wasm32::*;
+
+pub fn cull_aabbs_simd(
+    planes: &[Plane; 6],
+    bounds: &[Aabb],
+    visibility: &mut [u8],
+) {
+    // WASM SIMD: 4 つの AABB を同時にテスト
+    // f32x4 で plane.normal.dot(p-vertex) + d を並列計算
+    for chunk in bounds.chunks(4) {
+        // ... SIMD 実装 ...
+    }
+}
+```
+
+---
+
+## 5. JavaScript API 設計
+
+```typescript
+// TypeScript 型定義 (pictor_webgl.d.ts)
+
+export class PictorWebGL {
+    /** canvas 要素を指定して初期化 */
+    static init(canvas: HTMLCanvasElement): PictorWebGL;
+
+    /** シーンデータ (バイナリ) をロード */
+    loadScene(data: ArrayBuffer): void;
+
+    /** オブジェクトを登録 */
+    registerObject(desc: ObjectDescriptor): number;
+
+    /** オブジェクトの Transform を更新 */
+    updateTransform(id: number, matrix: Float32Array): void;
+
+    /** 1 フレーム描画 */
+    renderFrame(deltaTime: number): void;
+
+    /** canvas リサイズ通知 */
+    resize(width: number, height: number): void;
+
+    /** カメラ設定 */
+    setCamera(eye: Float32Array, target: Float32Array, up: Float32Array): void;
+
+    /** パフォーマンス統計取得 */
+    getStats(): FrameStats;
+
+    /** リソース解放 */
+    destroy(): void;
+}
+
+interface ObjectDescriptor {
+    mesh: number;
+    material: number;
+    transform: Float32Array;  // 16 floats (4x4 matrix)
+    flags: number;
+}
+
+interface FrameStats {
+    fps: number;
+    frameTimeMs: number;
+    drawCalls: number;
+    triangles: number;
+    visibleObjects: number;
+    totalObjects: number;
+}
+```
+
+### 5.1 使用例
+
+```html
+<canvas id="pictor-canvas" width="1280" height="720"></canvas>
+<script type="module">
+import init, { PictorWebGL } from './pictor_webgl.js';
+
+await init();  // WASM モジュールロード
+
+const canvas = document.getElementById('pictor-canvas');
+const renderer = PictorWebGL.init(canvas);
+
+// シーン登録
+for (let i = 0; i < 1000; i++) {
+    const transform = new Float32Array(16);
+    // ... identity + translation ...
+    renderer.registerObject({
+        mesh: 0,
+        material: 0,
+        transform,
+        flags: 0x02,  // DYNAMIC
+    });
+}
+
+// メインループ
+let lastTime = performance.now();
+function frame(now) {
+    const dt = (now - lastTime) / 1000;
+    lastTime = now;
+
+    renderer.renderFrame(dt);
+
+    requestAnimationFrame(frame);
+}
+requestAnimationFrame(frame);
+</script>
+```
+
+---
+
+## 6. WebGL2 制約と対策
+
+| C++ Pictor 機能 | WebGL2 制約 | 対策 |
+|------------------|-------------|------|
+| Compute Shader (GPU Update/Cull) | WebGL2 未サポート | CPU (WASM SIMD) でカリング・ソート実行 |
+| SSBO | WebGL2 未サポート | UBO (std140) + テクスチャバッファ で代替 |
+| Multi-Draw Indirect | WebGL2 未サポート | ループ + `drawElementsInstanced` で発行 |
+| 64-bit Sort Key | JS の Number は 53-bit | Rust 内部で u64、JS 境界は BigInt or 2×u32 |
+| Non-Temporal Store | WASM 未対応 | 通常の memcpy（WASM 最適化に任せる） |
+| 1M Objects | 描画コスト大 | LOD 強化 + CPU カリングで描画数抑制、目標 10K draw calls/frame |
+| Large Page | WASM Memory 非対応 | 標準 WASM Linear Memory |
+
+---
+
+## 7. ビルド・デプロイ
+
+### 7.1 ビルドコマンド
+
+```bash
+# 開発ビルド
+wasm-pack build crates/pictor-webgl --target web --dev
+
+# リリースビルド (最適化 + wasm-opt)
+wasm-pack build crates/pictor-webgl --target web --release
+
+# WASM SIMD 有効化 (Nightly)
+RUSTFLAGS="-C target-feature=+simd128" \
+  wasm-pack build crates/pictor-webgl --target web --release
+```
+
+### 7.2 出力物
+
+```
+pkg/
+├── pictor_webgl_bg.wasm    # WASM バイナリ (~200KB gzip 目標)
+├── pictor_webgl.js          # JS グルーコード
+├── pictor_webgl.d.ts        # TypeScript 型定義
+└── package.json             # npm パッケージメタデータ
+```
+
+### 7.3 WASM サイズ最適化
+
+```toml
+# Cargo.toml
+[profile.release]
+opt-level = "s"         # サイズ最適化
+lto = true              # Link-Time Optimization
+codegen-units = 1
+strip = true
+
+[profile.release.package.pictor-webgl]
+opt-level = "z"         # 最大サイズ圧縮
+```
+
+---
+
+## 8. パフォーマンス目標
+
+| メトリクス | 目標値 | 備考 |
+|-----------|--------|------|
+| 初期化時間 | < 500ms | WASM ロード + コンパイル含む |
+| 10K オブジェクト描画 | 60fps | Instanced Drawing 使用 |
+| 100K オブジェクト描画 | 30fps | LOD + Frustum Culling 必須 |
+| WASM バイナリサイズ | < 500KB (gzip) | wasm-opt + strip 適用 |
+| メモリ使用量 | < 64MB (10K objects) | SoA レイアウト維持 |
+| JS ↔ WASM コピー | 最小化 | SharedArrayBuffer 活用検討 |
+
+---
+
+## 9. 将来の WebGPU 拡張パス
+
+WebGL2 バックエンドの設計は WebGPU への移行を考慮する。
+
+```
+pictor-webgl (現在)        pictor-webgpu (将来)
+─────────────────          ──────────────────
+drawElementsInstanced  →   renderPass.draw (Indirect)
+UBO (std140)           →   Storage Buffer
+GLSL ES 3.00           →   WGSL
+CPU Frustum Cull       →   Compute Shader Cull
+CPU Radix Sort         →   Compute Shader Sort
+```
+
+### 9.1 共通抽象レイヤー
+
+`pictor-core` クレートはバックエンド非依存に設計し、
+WebGL2 / WebGPU / ネイティブ Vulkan すべてから利用可能にする。
+
+```rust
+// pictor-core/src/backend.rs (将来)
+pub trait RenderBackend {
+    type Buffer;
+    type Shader;
+    type Pipeline;
+
+    fn create_buffer(&self, size: usize, usage: BufferUsage) -> Self::Buffer;
+    fn upload_data(&self, buffer: &Self::Buffer, data: &[u8]);
+    fn draw_instanced(&self, mesh: &MeshData, instances: u32);
+}
+```
+
+---
+
+## 10. 実装フェーズ
+
+### Phase 1: 基盤 (MVP)
+- [ ] `pictor-core` クレート作成 (types, frustum, batch)
+- [ ] `pictor-webgl` クレート作成 (context, shader, basic draw)
+- [ ] 静的シーン描画 (単一メッシュ + 単一マテリアル)
+- [ ] デモ HTML ページ
+
+### Phase 2: インスタンシング
+- [ ] Instanced Drawing 実装
+- [ ] Pictor BatchBuilder → WebGL2 Draw 変換
+- [ ] 1K〜10K オブジェクト描画検証
+
+### Phase 3: カリング・最適化
+- [ ] CPU Frustum Culling (WASM SIMD)
+- [ ] LOD 選択
+- [ ] パフォーマンスプロファイリング
+
+### Phase 4: 統合
+- [ ] npm パッケージ公開準備
+- [ ] TypeScript 型定義の充実
+- [ ] E2E テスト (headless Chrome + WebGL)
+- [ ] ドキュメント整備

--- a/include/pictor/pictor.h
+++ b/include/pictor/pictor.h
@@ -46,5 +46,8 @@
 #include "pictor/profiler/overlay_renderer.h"
 #include "pictor/profiler/data_exporter.h"
 
+// Surface abstraction
+#include "pictor/surface/surface_provider.h"
+
 // Public API
 #include "pictor/core/pictor_renderer.h"

--- a/include/pictor/surface/glfw_surface_provider.h
+++ b/include/pictor/surface/glfw_surface_provider.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "pictor/surface/surface_provider.h"
+#include <string>
+
+// Forward-declare GLFW types to keep GLFW out of the public header.
+struct GLFWwindow;
+
+namespace pictor {
+
+/// Configuration for the GLFW-based window.
+struct GlfwWindowConfig {
+    uint32_t    width       = 1280;
+    uint32_t    height      = 720;
+    std::string title       = "Pictor";
+    bool        resizable   = true;
+    bool        vsync       = true;
+};
+
+/// Concrete ISurfaceProvider backed by a GLFW window.
+///
+/// Owns the GLFW window.  Suitable for demos and standalone tools;
+/// not intended for production embedding (the host would implement
+/// ISurfaceProvider directly in that case).
+class GlfwSurfaceProvider : public ISurfaceProvider {
+public:
+    GlfwSurfaceProvider();
+    ~GlfwSurfaceProvider() override;
+
+    GlfwSurfaceProvider(const GlfwSurfaceProvider&) = delete;
+    GlfwSurfaceProvider& operator=(const GlfwSurfaceProvider&) = delete;
+
+    /// Create the GLFW window (calls glfwInit on first use).
+    bool create(const GlfwWindowConfig& config = {});
+
+    /// Destroy the GLFW window.
+    void destroy();
+
+    // -- ISurfaceProvider --
+    NativeWindowHandle get_native_handle() const override;
+    SwapchainConfig    get_swapchain_config() const override;
+    void               on_swapchain_created(uint32_t w, uint32_t h) override;
+    void               poll_events() override;
+    bool               should_close() const override;
+    uint32_t           get_required_instance_extensions(
+                           const char** out, uint32_t max) const override;
+
+    GLFWwindow* glfw_window() const { return window_; }
+
+private:
+    static void framebuffer_size_callback(GLFWwindow* win, int w, int h);
+
+    GLFWwindow* window_ = nullptr;
+    uint32_t    fb_width_  = 0;
+    uint32_t    fb_height_ = 0;
+    bool        vsync_ = true;
+};
+
+} // namespace pictor

--- a/include/pictor/surface/surface_provider.h
+++ b/include/pictor/surface/surface_provider.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pictor {
+
+/// Platform-agnostic native window handle.
+///
+/// Pictor is an embeddable rendering module — the host application owns
+/// the window.  This struct carries whatever OS-specific handles the
+/// Vulkan back-end needs to create a VkSurfaceKHR.
+///
+/// Usage:
+///   NativeWindowHandle h{};
+///   h.type = NativeWindowHandle::Type::WIN32;
+///   h.win32.hwnd      = myHwnd;
+///   h.win32.hinstance = myHinstance;
+struct NativeWindowHandle {
+    enum class Type : uint8_t {
+        NONE    = 0,
+        WIN32   = 1,   // VK_KHR_win32_surface
+        XLIB    = 2,   // VK_KHR_xlib_surface
+        XCB     = 3,   // VK_KHR_xcb_surface
+        WAYLAND = 4,   // VK_KHR_wayland_surface
+        COCOA   = 5,   // VK_MVK_macos_surface / VK_EXT_metal_surface
+        ANDROID = 6,   // VK_KHR_android_surface
+    };
+
+    Type type = Type::NONE;
+
+    // Win32
+    struct Win32 {
+        void* hwnd      = nullptr;   // HWND
+        void* hinstance = nullptr;   // HINSTANCE
+    };
+
+    // Xlib
+    struct Xlib {
+        void*    display = nullptr;  // Display*
+        uint64_t window  = 0;        // Window (XID)
+    };
+
+    // XCB
+    struct Xcb {
+        void*    connection = nullptr; // xcb_connection_t*
+        uint32_t window     = 0;       // xcb_window_t
+    };
+
+    // Wayland
+    struct Wayland {
+        void* display = nullptr; // wl_display*
+        void* surface = nullptr; // wl_surface*
+    };
+
+    // macOS / Metal
+    struct Cocoa {
+        void* ns_view = nullptr; // NSView* (or CAMetalLayer*)
+    };
+
+    // Android
+    struct Android {
+        void* native_window = nullptr; // ANativeWindow*
+    };
+
+    union {
+        Win32   win32;
+        Xlib    xlib;
+        Xcb     xcb;
+        Wayland wayland;
+        Cocoa   cocoa;
+        Android android;
+    };
+
+    NativeWindowHandle() : win32{} {}
+};
+
+/// Swapchain configuration requested by the host.
+struct SwapchainConfig {
+    uint32_t width          = 0;
+    uint32_t height         = 0;
+    bool     vsync          = true;
+    uint32_t image_count    = 3;   // triple-buffering default
+};
+
+/// ISurfaceProvider — abstraction that decouples Pictor from windowing.
+///
+/// Two usage patterns:
+///
+/// 1. **External window (embedded)** — The host creates the window,
+///    implements ISurfaceProvider, and passes it to PictorRenderer.
+///    Pictor only calls get_native_handle() / get_swapchain_config()
+///    and creates a Vulkan surface internally.
+///
+/// 2. **Built-in GLFW window (demo/standalone)** — Pictor ships a
+///    GlfwSurfaceProvider that owns a GLFW window and implements
+///    this interface.
+class ISurfaceProvider {
+public:
+    virtual ~ISurfaceProvider() = default;
+
+    /// Return the platform-specific handle Pictor needs for VkSurfaceKHR.
+    virtual NativeWindowHandle get_native_handle() const = 0;
+
+    /// Return desired swapchain dimensions + settings.
+    virtual SwapchainConfig get_swapchain_config() const = 0;
+
+    /// Notify the provider that the swapchain was (re-)created with
+    /// the given actual dimensions (may differ from requested ones).
+    virtual void on_swapchain_created(uint32_t width, uint32_t height) {
+        (void)width; (void)height;
+    }
+
+    /// Called once per frame — lets a GLFW provider poll events.
+    virtual void poll_events() {}
+
+    /// Should the application keep running?  (e.g. !glfwWindowShouldClose)
+    virtual bool should_close() const { return false; }
+
+    /// Query the current required Vulkan instance extensions
+    /// (e.g. VK_KHR_surface + platform extension).
+    /// Returns count; fills out_names up to max_count.
+    virtual uint32_t get_required_instance_extensions(
+        const char** out_names, uint32_t max_count) const {
+        (void)out_names; (void)max_count;
+        return 0;
+    }
+};
+
+} // namespace pictor

--- a/include/pictor/surface/vulkan_context.h
+++ b/include/pictor/surface/vulkan_context.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "pictor/surface/surface_provider.h"
+#include <cstdint>
+#include <vector>
+#include <string>
+#include <functional>
+
+#ifdef PICTOR_HAS_VULKAN
+#include <vulkan/vulkan.h>
+#endif
+
+namespace pictor {
+
+/// Configuration for Vulkan instance / device creation.
+struct VulkanContextConfig {
+    const char* app_name    = "Pictor";
+    uint32_t    app_version = 1;
+    bool        validation  = false;  // VK_LAYER_KHRONOS_validation
+};
+
+/// Manages the Vulkan instance, physical/logical device, queue,
+/// surface and swapchain.
+///
+/// Ownership model:
+///   - VulkanContext **owns** VkInstance, VkDevice, VkSurfaceKHR, VkSwapchainKHR.
+///   - The ISurfaceProvider is **borrowed** (host retains ownership).
+class VulkanContext {
+public:
+    VulkanContext();
+    ~VulkanContext();
+
+    VulkanContext(const VulkanContext&) = delete;
+    VulkanContext& operator=(const VulkanContext&) = delete;
+
+    /// Full initialization: instance → surface → device → swapchain.
+    bool initialize(ISurfaceProvider* provider, const VulkanContextConfig& cfg = {});
+
+    /// Tear down everything in reverse order.
+    void shutdown();
+
+    /// Recreate swapchain (e.g. after window resize).
+    bool recreate_swapchain();
+
+    /// Acquire the next swapchain image. Returns image index, or UINT32_MAX on failure.
+    uint32_t acquire_next_image();
+
+    /// Present the given swapchain image.
+    bool present(uint32_t image_index);
+
+    /// Wait for device idle.
+    void device_wait_idle();
+
+    bool is_initialized() const { return initialized_; }
+
+#ifdef PICTOR_HAS_VULKAN
+    VkInstance       instance()        const { return instance_; }
+    VkPhysicalDevice physical_device() const { return physical_device_; }
+    VkDevice         device()          const { return device_; }
+    VkQueue          graphics_queue()  const { return graphics_queue_; }
+    uint32_t         queue_family()    const { return queue_family_index_; }
+    VkSwapchainKHR   swapchain()       const { return swapchain_; }
+    VkFormat         swapchain_format()const { return swapchain_format_; }
+    VkExtent2D       swapchain_extent()const { return swapchain_extent_; }
+    const std::vector<VkImageView>& swapchain_image_views() const { return swapchain_image_views_; }
+    VkRenderPass     default_render_pass() const { return render_pass_; }
+    const std::vector<VkFramebuffer>& framebuffers() const { return framebuffers_; }
+    VkCommandPool    command_pool() const { return command_pool_; }
+    const std::vector<VkCommandBuffer>& command_buffers() const { return command_buffers_; }
+
+    // Per-frame sync objects
+    VkSemaphore image_available_semaphore() const { return image_available_sem_; }
+    VkSemaphore render_finished_semaphore() const { return render_finished_sem_; }
+    VkFence     in_flight_fence()           const { return in_flight_fence_; }
+#endif
+
+private:
+#ifdef PICTOR_HAS_VULKAN
+    bool create_instance(const VulkanContextConfig& cfg);
+    bool create_surface();
+    bool pick_physical_device();
+    bool create_logical_device();
+    bool create_swapchain();
+    bool create_image_views();
+    bool create_render_pass();
+    bool create_framebuffers();
+    bool create_command_pool_and_buffers();
+    bool create_sync_objects();
+    void cleanup_swapchain();
+
+    ISurfaceProvider* provider_ = nullptr;
+
+    VkInstance               instance_           = VK_NULL_HANDLE;
+    VkDebugUtilsMessengerEXT debug_messenger_    = VK_NULL_HANDLE;
+    VkSurfaceKHR             surface_            = VK_NULL_HANDLE;
+    VkPhysicalDevice         physical_device_    = VK_NULL_HANDLE;
+    VkDevice                 device_             = VK_NULL_HANDLE;
+    VkQueue                  graphics_queue_     = VK_NULL_HANDLE;
+    VkQueue                  present_queue_      = VK_NULL_HANDLE;
+    uint32_t                 queue_family_index_ = UINT32_MAX;
+
+    VkSwapchainKHR           swapchain_          = VK_NULL_HANDLE;
+    VkFormat                 swapchain_format_   = VK_FORMAT_B8G8R8A8_SRGB;
+    VkExtent2D               swapchain_extent_   = {0, 0};
+    std::vector<VkImage>     swapchain_images_;
+    std::vector<VkImageView> swapchain_image_views_;
+
+    VkRenderPass             render_pass_        = VK_NULL_HANDLE;
+    std::vector<VkFramebuffer> framebuffers_;
+
+    VkCommandPool            command_pool_       = VK_NULL_HANDLE;
+    std::vector<VkCommandBuffer> command_buffers_;
+
+    VkSemaphore              image_available_sem_ = VK_NULL_HANDLE;
+    VkSemaphore              render_finished_sem_ = VK_NULL_HANDLE;
+    VkFence                  in_flight_fence_     = VK_NULL_HANDLE;
+#endif
+
+    bool initialized_ = false;
+};
+
+} // namespace pictor

--- a/src/surface/glfw_surface_provider.cpp
+++ b/src/surface/glfw_surface_provider.cpp
@@ -1,0 +1,173 @@
+#include "pictor/surface/glfw_surface_provider.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#define GLFW_INCLUDE_VULKAN
+#include <GLFW/glfw3.h>
+#include <cstdio>
+
+// Platform-specific native access (for NativeWindowHandle)
+#if defined(_WIN32)
+  #define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined(__linux__)
+  // Detect Wayland vs X11 at runtime via GLFW
+  #if defined(GLFW_EXPOSE_NATIVE_WAYLAND)
+    // already defined
+  #else
+    #define GLFW_EXPOSE_NATIVE_X11
+  #endif
+#elif defined(__APPLE__)
+  #define GLFW_EXPOSE_NATIVE_COCOA
+#endif
+#include <GLFW/glfw3native.h>
+
+namespace pictor {
+
+GlfwSurfaceProvider::GlfwSurfaceProvider() = default;
+
+GlfwSurfaceProvider::~GlfwSurfaceProvider() {
+    destroy();
+}
+
+bool GlfwSurfaceProvider::create(const GlfwWindowConfig& config) {
+    if (!glfwInit()) {
+        fprintf(stderr, "[Pictor/GLFW] glfwInit failed\n");
+        return false;
+    }
+
+    if (!glfwVulkanSupported()) {
+        fprintf(stderr, "[Pictor/GLFW] Vulkan not supported by this GLFW build\n");
+        glfwTerminate();
+        return false;
+    }
+
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API); // No OpenGL context
+    glfwWindowHint(GLFW_RESIZABLE, config.resizable ? GLFW_TRUE : GLFW_FALSE);
+
+    window_ = glfwCreateWindow(
+        static_cast<int>(config.width),
+        static_cast<int>(config.height),
+        config.title.c_str(),
+        nullptr, nullptr);
+
+    if (!window_) {
+        fprintf(stderr, "[Pictor/GLFW] Failed to create window\n");
+        glfwTerminate();
+        return false;
+    }
+
+    // Store this pointer for callbacks
+    glfwSetWindowUserPointer(window_, this);
+    glfwSetFramebufferSizeCallback(window_, framebuffer_size_callback);
+
+    // Query actual framebuffer size (may differ on HiDPI)
+    int w, h;
+    glfwGetFramebufferSize(window_, &w, &h);
+    fb_width_  = static_cast<uint32_t>(w);
+    fb_height_ = static_cast<uint32_t>(h);
+    vsync_     = config.vsync;
+
+    printf("[Pictor/GLFW] Window created: %ux%u (fb %ux%u)\n",
+           config.width, config.height, fb_width_, fb_height_);
+    return true;
+}
+
+void GlfwSurfaceProvider::destroy() {
+    if (window_) {
+        glfwDestroyWindow(window_);
+        window_ = nullptr;
+        glfwTerminate();
+    }
+}
+
+NativeWindowHandle GlfwSurfaceProvider::get_native_handle() const {
+    NativeWindowHandle h{};
+    if (!window_) return h;
+
+#if defined(_WIN32)
+    h.type = NativeWindowHandle::Type::WIN32;
+    h.win32.hwnd      = glfwGetWin32Window(window_);
+    h.win32.hinstance = GetModuleHandle(nullptr);
+#elif defined(__linux__)
+    // X11 path (most common with GLFW on Linux)
+    h.type = NativeWindowHandle::Type::XLIB;
+    h.xlib.display = glfwGetX11Display();
+    h.xlib.window  = glfwGetX11Window(window_);
+#elif defined(__APPLE__)
+    h.type = NativeWindowHandle::Type::COCOA;
+    h.cocoa.ns_view = glfwGetCocoaWindow(window_); // NSWindow* — MoltenVK accepts this
+#endif
+
+    return h;
+}
+
+SwapchainConfig GlfwSurfaceProvider::get_swapchain_config() const {
+    SwapchainConfig sc{};
+    sc.width       = fb_width_;
+    sc.height      = fb_height_;
+    sc.vsync       = vsync_;
+    sc.image_count = 3;
+    return sc;
+}
+
+void GlfwSurfaceProvider::on_swapchain_created(uint32_t w, uint32_t h) {
+    fb_width_  = w;
+    fb_height_ = h;
+}
+
+void GlfwSurfaceProvider::poll_events() {
+    glfwPollEvents();
+}
+
+bool GlfwSurfaceProvider::should_close() const {
+    return window_ ? glfwWindowShouldClose(window_) : true;
+}
+
+uint32_t GlfwSurfaceProvider::get_required_instance_extensions(
+    const char** out, uint32_t max) const
+{
+    uint32_t glfw_ext_count = 0;
+    const char** glfw_exts = glfwGetRequiredInstanceExtensions(&glfw_ext_count);
+    uint32_t copy_count = (glfw_ext_count < max) ? glfw_ext_count : max;
+    for (uint32_t i = 0; i < copy_count; ++i) {
+        out[i] = glfw_exts[i];
+    }
+    return copy_count;
+}
+
+void GlfwSurfaceProvider::framebuffer_size_callback(GLFWwindow* win, int w, int h) {
+    auto* self = static_cast<GlfwSurfaceProvider*>(glfwGetWindowUserPointer(win));
+    if (self) {
+        self->fb_width_  = static_cast<uint32_t>(w);
+        self->fb_height_ = static_cast<uint32_t>(h);
+    }
+}
+
+} // namespace pictor
+
+#else // !PICTOR_HAS_VULKAN
+
+#include <cstdio>
+
+namespace pictor {
+
+GlfwSurfaceProvider::GlfwSurfaceProvider() = default;
+GlfwSurfaceProvider::~GlfwSurfaceProvider() = default;
+
+bool GlfwSurfaceProvider::create(const GlfwWindowConfig&) {
+    fprintf(stderr, "[Pictor/GLFW] Vulkan not available\n");
+    return false;
+}
+
+void GlfwSurfaceProvider::destroy() {}
+NativeWindowHandle GlfwSurfaceProvider::get_native_handle() const { return {}; }
+SwapchainConfig    GlfwSurfaceProvider::get_swapchain_config() const { return {}; }
+void               GlfwSurfaceProvider::on_swapchain_created(uint32_t, uint32_t) {}
+void               GlfwSurfaceProvider::poll_events() {}
+bool               GlfwSurfaceProvider::should_close() const { return true; }
+uint32_t           GlfwSurfaceProvider::get_required_instance_extensions(
+                       const char**, uint32_t) const { return 0; }
+
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -1,0 +1,620 @@
+#include "pictor/surface/vulkan_context.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace pictor {
+
+// ---------- helpers ----------
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+    VkDebugUtilsMessageTypeFlagsEXT /*type*/,
+    const VkDebugUtilsMessengerCallbackDataEXT* data,
+    void* /*user*/)
+{
+    if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) {
+        fprintf(stderr, "[Vulkan Validation] %s\n", data->pMessage);
+    }
+    return VK_FALSE;
+}
+
+// ---------- public ----------
+
+VulkanContext::VulkanContext() = default;
+
+VulkanContext::~VulkanContext() {
+    if (initialized_) shutdown();
+}
+
+bool VulkanContext::initialize(ISurfaceProvider* provider,
+                               const VulkanContextConfig& cfg)
+{
+    if (!provider) return false;
+    provider_ = provider;
+
+    if (!create_instance(cfg))              return false;
+    if (!create_surface())                  return false;
+    if (!pick_physical_device())            return false;
+    if (!create_logical_device())           return false;
+    if (!create_swapchain())                return false;
+    if (!create_image_views())              return false;
+    if (!create_render_pass())              return false;
+    if (!create_framebuffers())             return false;
+    if (!create_command_pool_and_buffers()) return false;
+    if (!create_sync_objects())             return false;
+
+    initialized_ = true;
+    return true;
+}
+
+void VulkanContext::shutdown() {
+    if (!initialized_) return;
+
+    vkDeviceWaitIdle(device_);
+
+    // Sync objects
+    if (render_finished_sem_) vkDestroySemaphore(device_, render_finished_sem_, nullptr);
+    if (image_available_sem_) vkDestroySemaphore(device_, image_available_sem_, nullptr);
+    if (in_flight_fence_)     vkDestroyFence(device_, in_flight_fence_, nullptr);
+
+    // Command pool (frees command buffers implicitly)
+    if (command_pool_) vkDestroyCommandPool(device_, command_pool_, nullptr);
+
+    cleanup_swapchain();
+
+    if (device_)  vkDestroyDevice(device_, nullptr);
+    if (surface_) vkDestroySurfaceKHR(instance_, surface_, nullptr);
+
+    if (debug_messenger_) {
+        auto func = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(instance_, "vkDestroyDebugUtilsMessengerEXT"));
+        if (func) func(instance_, debug_messenger_, nullptr);
+    }
+
+    if (instance_) vkDestroyInstance(instance_, nullptr);
+
+    initialized_ = false;
+}
+
+bool VulkanContext::recreate_swapchain() {
+    vkDeviceWaitIdle(device_);
+    cleanup_swapchain();
+
+    if (!create_swapchain())    return false;
+    if (!create_image_views())  return false;
+    if (!create_render_pass())  return false;
+    if (!create_framebuffers()) return false;
+
+    return true;
+}
+
+uint32_t VulkanContext::acquire_next_image() {
+    vkWaitForFences(device_, 1, &in_flight_fence_, VK_TRUE, UINT64_MAX);
+    vkResetFences(device_, 1, &in_flight_fence_);
+
+    uint32_t index = 0;
+    VkResult result = vkAcquireNextImageKHR(
+        device_, swapchain_, UINT64_MAX,
+        image_available_sem_, VK_NULL_HANDLE, &index);
+
+    if (result == VK_ERROR_OUT_OF_DATE_KHR) {
+        recreate_swapchain();
+        return UINT32_MAX;
+    }
+    return index;
+}
+
+bool VulkanContext::present(uint32_t image_index) {
+    VkPresentInfoKHR info{};
+    info.sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+    info.waitSemaphoreCount = 1;
+    info.pWaitSemaphores    = &render_finished_sem_;
+    info.swapchainCount     = 1;
+    info.pSwapchains        = &swapchain_;
+    info.pImageIndices      = &image_index;
+
+    VkResult result = vkQueuePresentKHR(present_queue_, &info);
+    if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
+        recreate_swapchain();
+    }
+    return result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR;
+}
+
+void VulkanContext::device_wait_idle() {
+    if (device_) vkDeviceWaitIdle(device_);
+}
+
+// ---------- private: instance ----------
+
+bool VulkanContext::create_instance(const VulkanContextConfig& cfg) {
+    VkApplicationInfo app_info{};
+    app_info.sType              = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName   = cfg.app_name;
+    app_info.applicationVersion = cfg.app_version;
+    app_info.pEngineName        = "Pictor";
+    app_info.engineVersion      = VK_MAKE_VERSION(2, 1, 0);
+    app_info.apiVersion         = VK_API_VERSION_1_2;
+
+    // Collect extensions from provider
+    const char* ext_names[16] = {};
+    uint32_t ext_count = provider_->get_required_instance_extensions(ext_names, 16);
+
+    std::vector<const char*> extensions(ext_names, ext_names + ext_count);
+
+    std::vector<const char*> layers;
+    if (cfg.validation) {
+        layers.push_back("VK_LAYER_KHRONOS_validation");
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    }
+
+    VkInstanceCreateInfo create_info{};
+    create_info.sType                   = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create_info.pApplicationInfo        = &app_info;
+    create_info.enabledExtensionCount   = static_cast<uint32_t>(extensions.size());
+    create_info.ppEnabledExtensionNames = extensions.data();
+    create_info.enabledLayerCount       = static_cast<uint32_t>(layers.size());
+    create_info.ppEnabledLayerNames     = layers.data();
+
+    if (vkCreateInstance(&create_info, nullptr, &instance_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create Vulkan instance\n");
+        return false;
+    }
+
+    // Debug messenger
+    if (cfg.validation) {
+        VkDebugUtilsMessengerCreateInfoEXT dbg{};
+        dbg.sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+        dbg.messageSeverity  = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        dbg.messageType      = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+        dbg.pfnUserCallback  = debug_callback;
+
+        auto func = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(instance_, "vkCreateDebugUtilsMessengerEXT"));
+        if (func) func(instance_, &dbg, nullptr, &debug_messenger_);
+    }
+
+    return true;
+}
+
+// ---------- private: surface ----------
+
+bool VulkanContext::create_surface() {
+    auto handle = provider_->get_native_handle();
+
+    switch (handle.type) {
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    case NativeWindowHandle::Type::WIN32: {
+        VkWin32SurfaceCreateInfoKHR info{};
+        info.sType     = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+        info.hwnd      = static_cast<HWND>(handle.win32.hwnd);
+        info.hinstance = static_cast<HINSTANCE>(handle.win32.hinstance);
+        if (vkCreateWin32SurfaceKHR(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create Win32 surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_XLIB_KHR
+    case NativeWindowHandle::Type::XLIB: {
+        VkXlibSurfaceCreateInfoKHR info{};
+        info.sType  = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+        info.dpy    = static_cast<Display*>(handle.xlib.display);
+        info.window = static_cast<Window>(handle.xlib.window);
+        if (vkCreateXlibSurfaceKHR(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create Xlib surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_XCB_KHR
+    case NativeWindowHandle::Type::XCB: {
+        VkXcbSurfaceCreateInfoKHR info{};
+        info.sType      = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+        info.connection = static_cast<xcb_connection_t*>(handle.xcb.connection);
+        info.window     = static_cast<xcb_window_t>(handle.xcb.window);
+        if (vkCreateXcbSurfaceKHR(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create XCB surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    case NativeWindowHandle::Type::WAYLAND: {
+        VkWaylandSurfaceCreateInfoKHR info{};
+        info.sType   = VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR;
+        info.display = static_cast<wl_display*>(handle.wayland.display);
+        info.surface = static_cast<wl_surface*>(handle.wayland.surface);
+        if (vkCreateWaylandSurfaceKHR(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create Wayland surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_MACOS_MVK
+    case NativeWindowHandle::Type::COCOA: {
+        VkMacOSSurfaceCreateInfoMVK info{};
+        info.sType = VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK;
+        info.pView = handle.cocoa.ns_view;
+        if (vkCreateMacOSSurfaceMVK(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create macOS surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    case NativeWindowHandle::Type::ANDROID: {
+        VkAndroidSurfaceCreateInfoKHR info{};
+        info.sType  = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR;
+        info.window = static_cast<ANativeWindow*>(handle.android.native_window);
+        if (vkCreateAndroidSurfaceKHR(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create Android surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+    default:
+        fprintf(stderr, "[Pictor] Unsupported or unavailable platform surface type %d\n",
+                static_cast<int>(handle.type));
+        return false;
+    }
+}
+
+// ---------- private: physical device ----------
+
+bool VulkanContext::pick_physical_device() {
+    uint32_t count = 0;
+    vkEnumeratePhysicalDevices(instance_, &count, nullptr);
+    if (count == 0) {
+        fprintf(stderr, "[Pictor] No Vulkan-capable GPU found\n");
+        return false;
+    }
+
+    std::vector<VkPhysicalDevice> devices(count);
+    vkEnumeratePhysicalDevices(instance_, &count, devices.data());
+
+    // Pick first device that has a graphics queue supporting present
+    for (auto& dev : devices) {
+        uint32_t qf_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(dev, &qf_count, nullptr);
+        std::vector<VkQueueFamilyProperties> qf_props(qf_count);
+        vkGetPhysicalDeviceQueueFamilyProperties(dev, &qf_count, qf_props.data());
+
+        for (uint32_t i = 0; i < qf_count; ++i) {
+            VkBool32 present_support = VK_FALSE;
+            vkGetPhysicalDeviceSurfaceSupportKHR(dev, i, surface_, &present_support);
+
+            if ((qf_props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) && present_support) {
+                physical_device_    = dev;
+                queue_family_index_ = i;
+
+                VkPhysicalDeviceProperties props;
+                vkGetPhysicalDeviceProperties(dev, &props);
+                printf("[Pictor] Using GPU: %s\n", props.deviceName);
+                return true;
+            }
+        }
+    }
+
+    fprintf(stderr, "[Pictor] No suitable GPU found (need graphics + present)\n");
+    return false;
+}
+
+// ---------- private: logical device ----------
+
+bool VulkanContext::create_logical_device() {
+    float priority = 1.0f;
+    VkDeviceQueueCreateInfo queue_info{};
+    queue_info.sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_info.queueFamilyIndex = queue_family_index_;
+    queue_info.queueCount       = 1;
+    queue_info.pQueuePriorities = &priority;
+
+    VkPhysicalDeviceFeatures features{};
+
+    const char* dev_extensions[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+
+    VkDeviceCreateInfo create_info{};
+    create_info.sType                   = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    create_info.queueCreateInfoCount    = 1;
+    create_info.pQueueCreateInfos       = &queue_info;
+    create_info.pEnabledFeatures        = &features;
+    create_info.enabledExtensionCount   = 1;
+    create_info.ppEnabledExtensionNames = dev_extensions;
+
+    if (vkCreateDevice(physical_device_, &create_info, nullptr, &device_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create Vulkan logical device\n");
+        return false;
+    }
+
+    vkGetDeviceQueue(device_, queue_family_index_, 0, &graphics_queue_);
+    present_queue_ = graphics_queue_;
+    return true;
+}
+
+// ---------- private: swapchain ----------
+
+bool VulkanContext::create_swapchain() {
+    VkSurfaceCapabilitiesKHR caps;
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device_, surface_, &caps);
+
+    uint32_t fmt_count = 0;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, nullptr);
+    std::vector<VkSurfaceFormatKHR> formats(fmt_count);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, formats.data());
+
+    uint32_t pm_count = 0;
+    vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, nullptr);
+    std::vector<VkPresentModeKHR> present_modes(pm_count);
+    vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, present_modes.data());
+
+    // Choose format
+    swapchain_format_ = formats[0].format;
+    VkColorSpaceKHR color_space = formats[0].colorSpace;
+    for (auto& f : formats) {
+        if (f.format == VK_FORMAT_B8G8R8A8_SRGB &&
+            f.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+            swapchain_format_ = f.format;
+            color_space = f.colorSpace;
+            break;
+        }
+    }
+
+    // Choose present mode
+    auto sc_config = provider_->get_swapchain_config();
+    VkPresentModeKHR present_mode = VK_PRESENT_MODE_FIFO_KHR; // guaranteed
+    if (!sc_config.vsync) {
+        for (auto m : present_modes) {
+            if (m == VK_PRESENT_MODE_MAILBOX_KHR) { present_mode = m; break; }
+        }
+    }
+
+    // Choose extent
+    if (caps.currentExtent.width != UINT32_MAX) {
+        swapchain_extent_ = caps.currentExtent;
+    } else {
+        swapchain_extent_.width  = std::clamp(sc_config.width,
+            caps.minImageExtent.width, caps.maxImageExtent.width);
+        swapchain_extent_.height = std::clamp(sc_config.height,
+            caps.minImageExtent.height, caps.maxImageExtent.height);
+    }
+
+    uint32_t image_count = std::max(sc_config.image_count, caps.minImageCount);
+    if (caps.maxImageCount > 0) image_count = std::min(image_count, caps.maxImageCount);
+
+    VkSwapchainCreateInfoKHR sc_info{};
+    sc_info.sType            = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    sc_info.surface          = surface_;
+    sc_info.minImageCount    = image_count;
+    sc_info.imageFormat      = swapchain_format_;
+    sc_info.imageColorSpace  = color_space;
+    sc_info.imageExtent      = swapchain_extent_;
+    sc_info.imageArrayLayers = 1;
+    sc_info.imageUsage       = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    sc_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    sc_info.preTransform     = caps.currentTransform;
+    sc_info.compositeAlpha   = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    sc_info.presentMode      = present_mode;
+    sc_info.clipped          = VK_TRUE;
+    sc_info.oldSwapchain     = VK_NULL_HANDLE;
+
+    if (vkCreateSwapchainKHR(device_, &sc_info, nullptr, &swapchain_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create swapchain\n");
+        return false;
+    }
+
+    vkGetSwapchainImagesKHR(device_, swapchain_, &image_count, nullptr);
+    swapchain_images_.resize(image_count);
+    vkGetSwapchainImagesKHR(device_, swapchain_, &image_count, swapchain_images_.data());
+
+    provider_->on_swapchain_created(swapchain_extent_.width, swapchain_extent_.height);
+    return true;
+}
+
+// ---------- private: image views ----------
+
+bool VulkanContext::create_image_views() {
+    swapchain_image_views_.resize(swapchain_images_.size());
+    for (size_t i = 0; i < swapchain_images_.size(); ++i) {
+        VkImageViewCreateInfo info{};
+        info.sType    = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        info.image    = swapchain_images_[i];
+        info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        info.format   = swapchain_format_;
+        info.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
+                           VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
+        info.subresourceRange.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
+        info.subresourceRange.baseMipLevel   = 0;
+        info.subresourceRange.levelCount     = 1;
+        info.subresourceRange.baseArrayLayer = 0;
+        info.subresourceRange.layerCount     = 1;
+
+        if (vkCreateImageView(device_, &info, nullptr, &swapchain_image_views_[i]) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create image view %zu\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---------- private: render pass ----------
+
+bool VulkanContext::create_render_pass() {
+    VkAttachmentDescription color_attachment{};
+    color_attachment.format         = swapchain_format_;
+    color_attachment.samples        = VK_SAMPLE_COUNT_1_BIT;
+    color_attachment.loadOp         = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_attachment.storeOp        = VK_ATTACHMENT_STORE_OP_STORE;
+    color_attachment.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    color_attachment.initialLayout  = VK_IMAGE_LAYOUT_UNDEFINED;
+    color_attachment.finalLayout    = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout     = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint    = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments    = &color_ref;
+
+    VkSubpassDependency dependency{};
+    dependency.srcSubpass    = VK_SUBPASS_EXTERNAL;
+    dependency.dstSubpass    = 0;
+    dependency.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.srcAccessMask = 0;
+    dependency.dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo info{};
+    info.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    info.attachmentCount = 1;
+    info.pAttachments    = &color_attachment;
+    info.subpassCount    = 1;
+    info.pSubpasses      = &subpass;
+    info.dependencyCount = 1;
+    info.pDependencies   = &dependency;
+
+    if (vkCreateRenderPass(device_, &info, nullptr, &render_pass_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create render pass\n");
+        return false;
+    }
+    return true;
+}
+
+// ---------- private: framebuffers ----------
+
+bool VulkanContext::create_framebuffers() {
+    framebuffers_.resize(swapchain_image_views_.size());
+    for (size_t i = 0; i < swapchain_image_views_.size(); ++i) {
+        VkFramebufferCreateInfo info{};
+        info.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        info.renderPass      = render_pass_;
+        info.attachmentCount = 1;
+        info.pAttachments    = &swapchain_image_views_[i];
+        info.width           = swapchain_extent_.width;
+        info.height          = swapchain_extent_.height;
+        info.layers          = 1;
+
+        if (vkCreateFramebuffer(device_, &info, nullptr, &framebuffers_[i]) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create framebuffer %zu\n", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---------- private: command pool ----------
+
+bool VulkanContext::create_command_pool_and_buffers() {
+    VkCommandPoolCreateInfo pool_info{};
+    pool_info.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_info.flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    pool_info.queueFamilyIndex = queue_family_index_;
+
+    if (vkCreateCommandPool(device_, &pool_info, nullptr, &command_pool_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create command pool\n");
+        return false;
+    }
+
+    command_buffers_.resize(swapchain_images_.size());
+    VkCommandBufferAllocateInfo alloc_info{};
+    alloc_info.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    alloc_info.commandPool        = command_pool_;
+    alloc_info.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    alloc_info.commandBufferCount = static_cast<uint32_t>(command_buffers_.size());
+
+    if (vkAllocateCommandBuffers(device_, &alloc_info, command_buffers_.data()) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to allocate command buffers\n");
+        return false;
+    }
+    return true;
+}
+
+// ---------- private: sync objects ----------
+
+bool VulkanContext::create_sync_objects() {
+    VkSemaphoreCreateInfo sem_info{};
+    sem_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+    VkFenceCreateInfo fence_info{};
+    fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fence_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+    if (vkCreateSemaphore(device_, &sem_info, nullptr, &image_available_sem_) != VK_SUCCESS ||
+        vkCreateSemaphore(device_, &sem_info, nullptr, &render_finished_sem_) != VK_SUCCESS ||
+        vkCreateFence(device_, &fence_info, nullptr, &in_flight_fence_) != VK_SUCCESS) {
+        fprintf(stderr, "[Pictor] Failed to create sync objects\n");
+        return false;
+    }
+    return true;
+}
+
+// ---------- private: cleanup ----------
+
+void VulkanContext::cleanup_swapchain() {
+    for (auto fb : framebuffers_) {
+        if (fb) vkDestroyFramebuffer(device_, fb, nullptr);
+    }
+    framebuffers_.clear();
+
+    if (render_pass_) {
+        vkDestroyRenderPass(device_, render_pass_, nullptr);
+        render_pass_ = VK_NULL_HANDLE;
+    }
+
+    for (auto iv : swapchain_image_views_) {
+        if (iv) vkDestroyImageView(device_, iv, nullptr);
+    }
+    swapchain_image_views_.clear();
+    swapchain_images_.clear();
+
+    if (swapchain_) {
+        vkDestroySwapchainKHR(device_, swapchain_, nullptr);
+        swapchain_ = VK_NULL_HANDLE;
+    }
+}
+
+} // namespace pictor
+
+#else // !PICTOR_HAS_VULKAN
+
+namespace pictor {
+
+VulkanContext::VulkanContext() = default;
+VulkanContext::~VulkanContext() = default;
+
+bool VulkanContext::initialize(ISurfaceProvider*, const VulkanContextConfig&) {
+    fprintf(stderr, "[Pictor] Vulkan not available (PICTOR_HAS_VULKAN not defined)\n");
+    return false;
+}
+
+void VulkanContext::shutdown() {}
+bool VulkanContext::recreate_swapchain() { return false; }
+uint32_t VulkanContext::acquire_next_image() { return UINT32_MAX; }
+bool VulkanContext::present(uint32_t) { return false; }
+void VulkanContext::device_wait_idle() {}
+
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN


### PR DESCRIPTION
## Summary

This PR introduces a platform-agnostic surface abstraction layer for Pictor's Vulkan backend, along with a concrete GLFW-based window provider implementation. This decouples the rendering engine from windowing concerns, enabling both embedded use cases (where the host provides the window) and standalone demos (using GLFW).

## Key Changes

- **Surface Provider Abstraction** (`include/pictor/surface/surface_provider.h`)
  - `ISurfaceProvider` interface for platform-agnostic window/surface queries
  - `NativeWindowHandle` union supporting Win32, Xlib, XCB, Wayland, Cocoa, and Android
  - `SwapchainConfig` for communicating desired framebuffer dimensions and vsync settings

- **Vulkan Context Manager** (`include/pictor/surface/vulkan_context.h` + `src/surface/vulkan_context.cpp`)
  - Complete Vulkan initialization pipeline: instance → surface → physical device → logical device → swapchain
  - Swapchain recreation on window resize
  - Per-frame synchronization (semaphores, fences)
  - Render pass, framebuffers, and command pool management
  - Optional validation layer support with debug callback
  - ~620 lines of robust Vulkan boilerplate

- **GLFW Window Provider** (`include/pictor/surface/glfw_surface_provider.h` + `src/surface/glfw_surface_provider.cpp`)
  - Concrete `ISurfaceProvider` implementation wrapping GLFW
  - Platform-specific native handle extraction (Win32, X11, Cocoa)
  - Framebuffer size tracking and resize callbacks
  - Vulkan instance extension enumeration via GLFW

- **Demo Application** (`demo/main.cpp`)
  - Standalone example showing full initialization flow
  - GLFW window creation → Vulkan context setup → animated clear-color rendering
  - Registers test objects and demonstrates profiler integration
  - ~210 lines of reference implementation

- **Build System Updates** (`CMakeLists.txt`)
  - New `PICTOR_BUILD_DEMO` option (enabled by default)
  - Vulkan surface source files added to library
  - GLFW and Vulkan dependencies linked when available

- **Design Documentation** (`docs/design/webgl_backend.md`)
  - Comprehensive WebGL2/WebGPU backend design (future work)
  - Architecture, crate structure, shader design, and performance targets
  - Establishes foundation for cross-platform rendering backends

## Implementation Details

- **Ownership Model**: VulkanContext owns Vulkan resources; ISurfaceProvider is borrowed from the host
- **Platform Support**: Conditional compilation via `PICTOR_HAS_VULKAN` guards; graceful fallback when Vulkan unavailable
- **Error Handling**: Comprehensive validation with stderr logging for debugging
- **Extensibility**: Surface provider pattern allows custom window implementations without modifying Pictor core

https://claude.ai/code/session_01Am279scmeTabftH9pK4YW6