### PR TITLE
Add PBR and Toon shader samples

### DIFF
--- a/shaders/common.glsl
+++ b/shaders/common.glsl
@@ -1,0 +1,104 @@
+// Pictor — Common Shader Utilities
+// Shared constants and functions used by PBR and Toon shaders.
+// Include via: #include "common.glsl" (requires GL_GOOGLE_include_directive)
+
+#ifndef PICTOR_COMMON_GLSL
+#define PICTOR_COMMON_GLSL
+
+// ============================================================
+// Constants
+// ============================================================
+
+const float PI      = 3.14159265358979323846;
+const float INV_PI  = 0.31830988618379067154;
+const float EPSILON = 1e-6;
+
+// ============================================================
+// Scene Uniforms (set = 0, binding = 0)
+// Common to all material shaders.
+// ============================================================
+
+struct DirectionalLight {
+    vec4 direction;   // xyz = direction (world space, toward light), w = unused
+    vec4 color;       // rgb = color, a = intensity
+};
+
+struct PointLight {
+    vec4 position;    // xyz = position, w = radius
+    vec4 color;       // rgb = color, a = intensity
+};
+
+layout(set = 0, binding = 0) uniform SceneParams {
+    mat4  view;
+    mat4  projection;
+    mat4  viewProjection;
+    vec4  cameraPosition;       // xyz = world pos, w = unused
+    vec4  ambientColor;         // rgb = ambient, a = intensity
+    DirectionalLight sun;
+    PointLight pointLights[4];
+    uint  activePointLights;
+    float time;
+    float pad0, pad1;
+};
+
+// ============================================================
+// Per-Object Push Constants
+// ============================================================
+
+layout(push_constant) uniform ObjectParams {
+    mat4  model;
+    mat4  normalMatrix;         // transpose(inverse(model)), upper 3x3
+    uint  materialId;
+    uint  pad2, pad3, pad4;
+};
+
+// ============================================================
+// Utility Functions
+// ============================================================
+
+// Reconstruct world-space normal from tangent-space normal map sample
+vec3 perturbNormal(vec3 N, vec3 T, vec3 B, vec3 mapNormal) {
+    return normalize(T * mapNormal.x + B * mapNormal.y + N * mapNormal.z);
+}
+
+// Schlick approximation for Fresnel reflectance
+vec3 fresnelSchlick(float cosTheta, vec3 F0) {
+    return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+// Schlick approximation with roughness for IBL
+vec3 fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness) {
+    return F0 + (max(vec3(1.0 - roughness), F0) - F0)
+               * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
+}
+
+// sRGB <-> Linear conversion
+vec3 srgbToLinear(vec3 srgb) {
+    return pow(srgb, vec3(2.2));
+}
+
+vec3 linearToSrgb(vec3 linear) {
+    return pow(linear, vec3(1.0 / 2.2));
+}
+
+// ACES filmic tone mapping
+vec3 toneMapACES(vec3 color) {
+    const float a = 2.51;
+    const float b = 0.03;
+    const float c = 2.43;
+    const float d = 0.59;
+    const float e = 0.14;
+    return clamp((color * (a * color + b)) / (color * (c * color + d) + e),
+                 0.0, 1.0);
+}
+
+// Point light attenuation (inverse-square with radius falloff)
+float attenuatePoint(float distance, float radius) {
+    float d2 = distance * distance;
+    float r2 = radius * radius;
+    float attenuation = 1.0 / (d2 + 1.0);
+    float falloff = clamp(1.0 - (d2 / r2), 0.0, 1.0);
+    return attenuation * falloff * falloff;
+}
+
+#endif // PICTOR_COMMON_GLSL

--- a/shaders/pbr.frag
+++ b/shaders/pbr.frag
@@ -1,0 +1,170 @@
+// Pictor — PBR Fragment Shader
+// Cook-Torrance BRDF with metallic-roughness workflow.
+// Supports: albedo, normal, metallic-roughness, AO, emissive maps.
+
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "common.glsl"
+
+// ============================================================
+// Fragment Input
+// ============================================================
+
+layout(location = 0) in vec3 fragWorldPos;
+layout(location = 1) in vec2 fragTexCoord;
+layout(location = 2) in vec3 fragNormal;
+layout(location = 3) in vec3 fragTangent;
+layout(location = 4) in vec3 fragBitangent;
+
+// ============================================================
+// Material Textures (set = 1)
+// ============================================================
+
+layout(set = 1, binding = 0) uniform sampler2D albedoMap;
+layout(set = 1, binding = 1) uniform sampler2D normalMap;
+layout(set = 1, binding = 2) uniform sampler2D metallicRoughnessMap; // G = roughness, B = metallic
+layout(set = 1, binding = 3) uniform sampler2D aoMap;
+layout(set = 1, binding = 4) uniform sampler2D emissiveMap;
+
+// ============================================================
+// Material Parameters (set = 1, binding = 5)
+// ============================================================
+
+layout(set = 1, binding = 5) uniform MaterialParams {
+    vec4  baseColorFactor;     // linear-space RGBA multiplier
+    float metallicFactor;
+    float roughnessFactor;
+    float aoStrength;
+    float emissiveStrength;
+    vec4  emissiveFactor;      // RGB emissive multiplier
+};
+
+// ============================================================
+// Output
+// ============================================================
+
+layout(location = 0) out vec4 outColor;
+
+// ============================================================
+// GGX / Cook-Torrance BRDF
+// ============================================================
+
+// GGX Normal Distribution Function
+float distributionGGX(vec3 N, vec3 H, float roughness) {
+    float a  = roughness * roughness;
+    float a2 = a * a;
+    float NdotH  = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH * NdotH;
+
+    float denom = NdotH2 * (a2 - 1.0) + 1.0;
+    return a2 / (PI * denom * denom + EPSILON);
+}
+
+// Smith's geometry function (Schlick-GGX)
+float geometrySchlickGGX(float NdotV, float roughness) {
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotV / (NdotV * (1.0 - k) + k + EPSILON);
+}
+
+// Smith's method for combined geometry obstruction
+float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness) {
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotL = max(dot(N, L), 0.0);
+    return geometrySchlickGGX(NdotV, roughness) *
+           geometrySchlickGGX(NdotL, roughness);
+}
+
+// ============================================================
+// Lighting Calculation
+// ============================================================
+
+vec3 evaluateBRDF(vec3 N, vec3 V, vec3 L, vec3 radiance,
+                  vec3 albedo, float metallic, float roughness) {
+    vec3 H = normalize(V + L);
+
+    // Dielectric F0 = 0.04, metallic F0 = albedo
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+
+    // Cook-Torrance specular
+    float D = distributionGGX(N, H, roughness);
+    float G = geometrySmith(N, V, L, roughness);
+    vec3  F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+    float NdotL = max(dot(N, L), 0.0);
+    float NdotV = max(dot(N, V), 0.0);
+
+    vec3 numerator  = D * G * F;
+    float denominator = 4.0 * NdotV * NdotL + EPSILON;
+    vec3 specular = numerator / denominator;
+
+    // Energy conservation: diffuse is reduced by specular reflection
+    vec3 kD = (vec3(1.0) - F) * (1.0 - metallic);
+
+    // Lambertian diffuse
+    vec3 diffuse = kD * albedo * INV_PI;
+
+    return (diffuse + specular) * radiance * NdotL;
+}
+
+void main() {
+    // Sample material textures
+    vec4 albedoSample = texture(albedoMap, fragTexCoord);
+    vec3 albedo       = srgbToLinear(albedoSample.rgb) * baseColorFactor.rgb;
+    float alpha       = albedoSample.a * baseColorFactor.a;
+
+    vec2 mr       = texture(metallicRoughnessMap, fragTexCoord).gb;
+    float metallic  = mr.y * metallicFactor;
+    float roughness = mr.x * roughnessFactor;
+    roughness = clamp(roughness, 0.04, 1.0);
+
+    float ao       = mix(1.0, texture(aoMap, fragTexCoord).r, aoStrength);
+    vec3 emissive  = srgbToLinear(texture(emissiveMap, fragTexCoord).rgb)
+                     * emissiveFactor.rgb * emissiveStrength;
+
+    // Reconstruct TBN normal
+    vec3 N = fragNormal;
+    vec3 T = fragTangent;
+    vec3 B = fragBitangent;
+    vec3 mapN = texture(normalMap, fragTexCoord).rgb * 2.0 - 1.0;
+    N = perturbNormal(normalize(N), normalize(T), normalize(B), mapN);
+
+    vec3 V = normalize(cameraPosition.xyz - fragWorldPos);
+
+    // ---- Accumulate lighting ----
+    vec3 Lo = vec3(0.0);
+
+    // Directional light (sun)
+    {
+        vec3 L = normalize(sun.direction.xyz);
+        vec3 radiance = sun.color.rgb * sun.color.a;
+        Lo += evaluateBRDF(N, V, L, radiance, albedo, metallic, roughness);
+    }
+
+    // Point lights
+    for (uint i = 0; i < activePointLights; i++) {
+        vec3 lightVec = pointLights[i].position.xyz - fragWorldPos;
+        float dist    = length(lightVec);
+        vec3 L        = lightVec / dist;
+
+        float atten   = attenuatePoint(dist, pointLights[i].position.w);
+        vec3 radiance = pointLights[i].color.rgb * pointLights[i].color.a * atten;
+
+        Lo += evaluateBRDF(N, V, L, radiance, albedo, metallic, roughness);
+    }
+
+    // Ambient (simplified IBL substitute)
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    vec3 kS = fresnelSchlickRoughness(max(dot(N, V), 0.0), F0, roughness);
+    vec3 kD = (1.0 - kS) * (1.0 - metallic);
+    vec3 ambient = (kD * albedo + kS * 0.03) * ambientColor.rgb * ambientColor.a * ao;
+
+    vec3 color = ambient + Lo + emissive;
+
+    // Tone mapping and gamma correction
+    color = toneMapACES(color);
+    color = linearToSrgb(color);
+
+    outColor = vec4(color, alpha);
+}

--- a/shaders/pbr.vert
+++ b/shaders/pbr.vert
@@ -1,0 +1,40 @@
+// Pictor — PBR Vertex Shader
+// Standard vertex transform with TBN output for normal mapping.
+
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "common.glsl"
+
+// ============================================================
+// Vertex Input (location matches Pictor vertex layout)
+// ============================================================
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec4 inTangent;    // xyz = tangent, w = handedness (+1/-1)
+layout(location = 3) in vec2 inTexCoord0;
+
+// ============================================================
+// Vertex Output
+// ============================================================
+
+layout(location = 0) out vec3 fragWorldPos;
+layout(location = 1) out vec2 fragTexCoord;
+layout(location = 2) out vec3 fragNormal;
+layout(location = 3) out vec3 fragTangent;
+layout(location = 4) out vec3 fragBitangent;
+
+void main() {
+    vec4 worldPos = model * vec4(inPosition, 1.0);
+    fragWorldPos  = worldPos.xyz;
+    fragTexCoord  = inTexCoord0;
+
+    // Transform normal and tangent to world space
+    mat3 nMat    = mat3(normalMatrix);
+    fragNormal   = normalize(nMat * inNormal);
+    fragTangent  = normalize(nMat * inTangent.xyz);
+    fragBitangent = cross(fragNormal, fragTangent) * inTangent.w;
+
+    gl_Position = viewProjection * worldPos;
+}

--- a/shaders/toon.frag
+++ b/shaders/toon.frag
@@ -1,0 +1,163 @@
+// Pictor — Toon Fragment Shader
+// Cel-shading with configurable band count, rim lighting, and specular highlight.
+// Outline pass outputs a solid color (combined with front-face culling).
+
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "common.glsl"
+
+// ============================================================
+// Specialization Constants
+// ============================================================
+
+layout(constant_id = 0) const uint OUTLINE_PASS = 0;
+
+// ============================================================
+// Fragment Input
+// ============================================================
+
+layout(location = 0) in vec3 fragWorldPos;
+layout(location = 1) in vec2 fragTexCoord;
+layout(location = 2) in vec3 fragNormal;
+layout(location = 3) in vec3 fragViewDir;
+
+// ============================================================
+// Material Textures (set = 1)
+// ============================================================
+
+layout(set = 1, binding = 0) uniform sampler2D albedoMap;
+layout(set = 1, binding = 1) uniform sampler2D rampMap;         // 1D shading ramp (optional)
+
+// ============================================================
+// Material Parameters (set = 1, binding = 5)
+// ============================================================
+
+layout(set = 1, binding = 5) uniform MaterialParams {
+    vec4  baseColorFactor;
+    float shadowThreshold;     // NdotL threshold for shadow band (default 0.0)
+    float shadowSmoothness;    // anti-alias width for shadow edge
+    uint  bandCount;           // number of discrete shading bands (2-8)
+    float specularSize;        // specular highlight size (0.0-1.0)
+    float specularSmoothness;  // specular edge smoothness
+    float rimPower;            // rim light exponent
+    float rimStrength;         // rim light intensity
+    float pad8;
+};
+
+// ============================================================
+// Toon Outline Parameters (set = 1, binding = 6)
+// ============================================================
+
+layout(set = 1, binding = 6) uniform ToonParams {
+    vec4  outlineColor;
+    float outlineWidth;
+    float pad5, pad6, pad7;
+};
+
+// ============================================================
+// Output
+// ============================================================
+
+layout(location = 0) out vec4 outColor;
+
+// ============================================================
+// Toon Shading Functions
+// ============================================================
+
+// Quantize a value into discrete bands
+float quantize(float value, uint bands) {
+    float stepped = floor(value * float(bands)) / float(bands);
+    return stepped;
+}
+
+// Smooth step between shadow and lit regions
+float toonDiffuse(float NdotL) {
+    // Method 1: Band-based quantization
+    float lit = clamp((NdotL - shadowThreshold) / (shadowSmoothness + EPSILON)
+                      * 0.5 + 0.5, 0.0, 1.0);
+    return quantize(lit, bandCount);
+}
+
+// Ramp-based shading (sample from 1D ramp texture)
+float toonDiffuseRamp(float NdotL) {
+    float u = NdotL * 0.5 + 0.5; // remap [-1,1] -> [0,1]
+    return texture(rampMap, vec2(u, 0.5)).r;
+}
+
+// Toon specular highlight (hard-edged)
+float toonSpecular(vec3 N, vec3 H) {
+    float NdotH = max(dot(N, H), 0.0);
+    float spec  = pow(NdotH, 1.0 / (specularSize + EPSILON));
+    return smoothstep(0.5 - specularSmoothness, 0.5 + specularSmoothness, spec);
+}
+
+// Rim lighting (Fresnel-based edge glow)
+float rimLight(vec3 N, vec3 V) {
+    float NdotV = max(dot(N, V), 0.0);
+    return pow(1.0 - NdotV, rimPower) * rimStrength;
+}
+
+void main() {
+    // ---- Outline pass: solid color output ----
+    if (OUTLINE_PASS == 1) {
+        outColor = outlineColor;
+        return;
+    }
+
+    // ---- Main toon shading ----
+    vec3 N = normalize(fragNormal);
+    vec3 V = normalize(fragViewDir);
+
+    // Sample albedo
+    vec4 albedoSample = texture(albedoMap, fragTexCoord);
+    vec3 albedo = albedoSample.rgb * baseColorFactor.rgb;
+    float alpha = albedoSample.a * baseColorFactor.a;
+
+    vec3 Lo = vec3(0.0);
+
+    // Directional light (sun)
+    {
+        vec3 L = normalize(sun.direction.xyz);
+        vec3 H = normalize(V + L);
+        float NdotL = dot(N, L);
+
+        float diffuse = toonDiffuse(NdotL);
+        float spec    = toonSpecular(N, H);
+
+        vec3 lightColor = sun.color.rgb * sun.color.a;
+        Lo += albedo * lightColor * diffuse;
+        Lo += lightColor * spec;
+    }
+
+    // Point lights
+    for (uint i = 0; i < activePointLights; i++) {
+        vec3 lightVec = pointLights[i].position.xyz - fragWorldPos;
+        float dist    = length(lightVec);
+        vec3 L        = lightVec / dist;
+        vec3 H        = normalize(V + L);
+        float NdotL   = dot(N, L);
+
+        float atten   = attenuatePoint(dist, pointLights[i].position.w);
+        float diffuse = toonDiffuse(NdotL);
+        float spec    = toonSpecular(N, H);
+
+        vec3 lightColor = pointLights[i].color.rgb * pointLights[i].color.a * atten;
+        Lo += albedo * lightColor * diffuse;
+        Lo += lightColor * spec;
+    }
+
+    // Rim lighting
+    float rim = rimLight(N, V);
+    Lo += albedo * rim;
+
+    // Ambient
+    vec3 ambient = albedo * ambientColor.rgb * ambientColor.a;
+
+    vec3 color = ambient + Lo;
+
+    // Gamma correction (toon shading typically works in sRGB space directly)
+    color = linearToSrgb(color);
+
+    outColor = vec4(color, alpha);
+}

--- a/shaders/toon.vert
+++ b/shaders/toon.vert
@@ -1,0 +1,63 @@
+// Pictor — Toon Vertex Shader
+// Standard transform + outline pass support via vertex extrusion.
+
+#version 450
+#extension GL_GOOGLE_include_directive : require
+
+#include "common.glsl"
+
+// ============================================================
+// Specialization Constants
+// ============================================================
+
+// Set to 1 to enable outline extrusion pass
+layout(constant_id = 0) const uint OUTLINE_PASS = 0;
+
+// ============================================================
+// Vertex Input
+// ============================================================
+
+layout(location = 0) in vec3 inPosition;
+layout(location = 1) in vec3 inNormal;
+layout(location = 2) in vec4 inTangent;
+layout(location = 3) in vec2 inTexCoord0;
+
+// ============================================================
+// Vertex Output
+// ============================================================
+
+layout(location = 0) out vec3 fragWorldPos;
+layout(location = 1) out vec2 fragTexCoord;
+layout(location = 2) out vec3 fragNormal;
+layout(location = 3) out vec3 fragViewDir;
+
+// ============================================================
+// Toon Outline Parameters (set = 1, binding = 6)
+// ============================================================
+
+layout(set = 1, binding = 6) uniform ToonParams {
+    vec4  outlineColor;        // RGB = color, A = unused
+    float outlineWidth;        // world-space extrusion width
+    float pad5, pad6, pad7;
+};
+
+void main() {
+    mat3 nMat = mat3(normalMatrix);
+    vec3 worldNormal = normalize(nMat * inNormal);
+
+    vec3 pos = inPosition;
+
+    // Outline pass: extrude vertices along normal direction
+    if (OUTLINE_PASS == 1) {
+        pos += inNormal * outlineWidth;
+    }
+
+    vec4 worldPos = model * vec4(pos, 1.0);
+
+    fragWorldPos = worldPos.xyz;
+    fragTexCoord = inTexCoord0;
+    fragNormal   = worldNormal;
+    fragViewDir  = normalize(cameraPosition.xyz - worldPos.xyz);
+
+    gl_Position = viewProjection * worldPos;
+}


### PR DESCRIPTION
Add vertex/fragment shader pairs for two material models:

- common.glsl: Shared utilities (Fresnel, tone mapping, scene uniforms,
  light attenuation) used by all material shaders
- PBR (pbr.vert/frag): Cook-Torrance BRDF with metallic-roughness
  workflow, normal mapping, AO, and emissive support
- Toon (toon.vert/frag): Cel-shading with configurable band count,
  rim lighting, specular highlight, and outline pass via vertex extrusion

These serve as base material templates for the upcoming node-based
shader system.

https://claude.ai/code/session_01WgFHiX8hZFL4LLBjW3j72n