### PR TITLE
Add interactive orbit camera and 3-level tessellation system

### DIFF
--- a/demo/benchmark/main.cpp
+++ b/demo/benchmark/main.cpp
@@ -255,12 +255,52 @@ int main(int argc, char* argv[]) {
     camera.frustum.planes[4] = {{0, 0, 1}, 0.1f};
     camera.frustum.planes[5] = {{0, 0, -1}, 1000.0f};
 
+    // ---- Orbit Camera State ----
+    struct OrbitCamera {
+        float yaw   = 0.0f;
+        float pitch = 0.55f;
+        float radius = 250.0f;
+        float center[3] = {0.0f, 0.0f, 0.0f};
+        double lastMouseX = 0.0, lastMouseY = 0.0;
+        bool dragging = false;
+    };
+    static OrbitCamera orbit_cam;
+
+#ifdef PICTOR_HAS_VULKAN
+    if (!headless) {
+        GLFWwindow* win = surface_provider.glfw_window();
+        glfwSetMouseButtonCallback(win, [](GLFWwindow* w, int button, int action, int /*mods*/) {
+            if (button == GLFW_MOUSE_BUTTON_LEFT) {
+                orbit_cam.dragging = (action == GLFW_PRESS);
+                if (orbit_cam.dragging)
+                    glfwGetCursorPos(w, &orbit_cam.lastMouseX, &orbit_cam.lastMouseY);
+            }
+        });
+        glfwSetCursorPosCallback(win, [](GLFWwindow*, double xpos, double ypos) {
+            if (!orbit_cam.dragging) return;
+            double dx = xpos - orbit_cam.lastMouseX;
+            double dy = ypos - orbit_cam.lastMouseY;
+            orbit_cam.lastMouseX = xpos;
+            orbit_cam.lastMouseY = ypos;
+            orbit_cam.yaw   -= static_cast<float>(dx) * 0.005f;
+            orbit_cam.pitch += static_cast<float>(dy) * 0.005f;
+            if (orbit_cam.pitch > 1.5f)  orbit_cam.pitch = 1.5f;
+            if (orbit_cam.pitch < -1.5f) orbit_cam.pitch = -1.5f;
+        });
+        glfwSetScrollCallback(win, [](GLFWwindow*, double /*xoffset*/, double yoffset) {
+            orbit_cam.radius -= static_cast<float>(yoffset) * 15.0f;
+            if (orbit_cam.radius < 50.0f)  orbit_cam.radius = 50.0f;
+            if (orbit_cam.radius > 500.0f) orbit_cam.radius = 500.0f;
+        });
+        printf("Mouse drag: orbit camera, Scroll: zoom\n");
+    }
+#endif
+
     // View/Projection matrices for rendering
     float view_mat[16], proj_mat[16];
     float eye[3] = {0.0f, 150.0f, 250.0f};
-    float center[3] = {0.0f, 0.0f, 0.0f};
     float up[3] = {0.0f, 1.0f, 0.0f};
-    mat4_look_at(view_mat, eye, center, up);
+    mat4_look_at(view_mat, eye, orbit_cam.center, up);
 
     renderer.begin_profiler_recording("benchmark_results");
 
@@ -273,6 +313,16 @@ int main(int argc, char* argv[]) {
     auto bench_start = std::chrono::high_resolution_clock::now();
 
     for (uint32_t frame = 0; frame < BENCHMARK_FRAMES; ++frame) {
+        // Update camera position from orbit state
+        {
+            float cos_pitch = std::cos(orbit_cam.pitch);
+            camera.position = {
+                orbit_cam.center[0] + orbit_cam.radius * cos_pitch * std::sin(orbit_cam.yaw),
+                orbit_cam.center[1] + orbit_cam.radius * std::sin(orbit_cam.pitch),
+                orbit_cam.center[2] + orbit_cam.radius * cos_pitch * std::cos(orbit_cam.yaw)
+            };
+        }
+
         // Run Pictor data pipeline
         renderer.begin_frame(delta_time);
         renderer.render(camera);
@@ -288,11 +338,12 @@ int main(int argc, char* argv[]) {
                          / static_cast<float>(vk_ctx.swapchain_extent().height);
             mat4_perspective(proj_mat, 0.7854f, aspect, 0.1f, 2000.0f); // 45 deg FOV
 
-            // Orbit camera
-            float angle = static_cast<float>(frame) * 0.005f;
-            eye[0] = 250.0f * std::sin(angle);
-            eye[2] = 250.0f * std::cos(angle);
-            mat4_look_at(view_mat, eye, center, up);
+            // Update eye from orbit camera
+            float cos_pitch = std::cos(orbit_cam.pitch);
+            eye[0] = orbit_cam.center[0] + orbit_cam.radius * cos_pitch * std::sin(orbit_cam.yaw);
+            eye[1] = orbit_cam.center[1] + orbit_cam.radius * std::sin(orbit_cam.pitch);
+            eye[2] = orbit_cam.center[2] + orbit_cam.radius * cos_pitch * std::cos(orbit_cam.yaw);
+            mat4_look_at(view_mat, eye, orbit_cam.center, up);
 
             // Upload instance positions
             simple_renderer.update_instances(update_callback.instance_data.data(), OBJECT_COUNT);

--- a/demo/graphics/main.cpp
+++ b/demo/graphics/main.cpp
@@ -1012,6 +1012,42 @@ int main() {
     camera.frustum.planes[4] = {{0, 0, 1}, 0.1f};
     camera.frustum.planes[5] = {{0, 0, -1}, 100.0f};
 
+    // ---- Orbit Camera State ----
+    struct OrbitCamera {
+        float yaw   = 0.0f;
+        float pitch = 0.45f;
+        float radius = 12.0f;
+        float center[3] = {0.0f, 1.0f, 0.0f};
+        double lastMouseX = 0.0, lastMouseY = 0.0;
+        bool dragging = false;
+    };
+    static OrbitCamera orbit_cam;
+
+    GLFWwindow* win = surface_provider.glfw_window();
+    glfwSetMouseButtonCallback(win, [](GLFWwindow* w, int button, int action, int /*mods*/) {
+        if (button == GLFW_MOUSE_BUTTON_LEFT) {
+            orbit_cam.dragging = (action == GLFW_PRESS);
+            if (orbit_cam.dragging)
+                glfwGetCursorPos(w, &orbit_cam.lastMouseX, &orbit_cam.lastMouseY);
+        }
+    });
+    glfwSetCursorPosCallback(win, [](GLFWwindow*, double xpos, double ypos) {
+        if (!orbit_cam.dragging) return;
+        double dx = xpos - orbit_cam.lastMouseX;
+        double dy = ypos - orbit_cam.lastMouseY;
+        orbit_cam.lastMouseX = xpos;
+        orbit_cam.lastMouseY = ypos;
+        orbit_cam.yaw   -= static_cast<float>(dx) * 0.005f;
+        orbit_cam.pitch += static_cast<float>(dy) * 0.005f;
+        if (orbit_cam.pitch > 1.5f)  orbit_cam.pitch = 1.5f;
+        if (orbit_cam.pitch < -0.2f) orbit_cam.pitch = -0.2f;
+    });
+    glfwSetScrollCallback(win, [](GLFWwindow*, double /*xoffset*/, double yoffset) {
+        orbit_cam.radius -= static_cast<float>(yoffset) * 1.5f;
+        if (orbit_cam.radius < 3.0f)  orbit_cam.radius = 3.0f;
+        if (orbit_cam.radius > 50.0f) orbit_cam.radius = 50.0f;
+    });
+
     // ---- 8. Main Loop ----
     auto start = std::chrono::high_resolution_clock::now();
     uint64_t frame_count = 0;
@@ -1026,6 +1062,7 @@ int main() {
     printf("  - Directional light (sun, PCSS shadows)\n");
     printf("  - Spotlight (warm, orbiting cone)\n");
     printf("  - GI: SSAO + hemisphere ambient + baked lightmaps\n");
+    printf("  - Mouse drag: orbit camera, Scroll: zoom\n");
     printf("\nEntering main loop. Close the window to exit.\n\n");
 
     while (!surface_provider.should_close()) {
@@ -1034,22 +1071,17 @@ int main() {
         auto now = std::chrono::high_resolution_clock::now();
         float elapsed = std::chrono::duration<float>(now - start).count();
 
-        // Orbit camera
-        float cam_radius = 12.0f;
-        float cam_height = 6.0f;
-        float cam_speed  = 0.3f;
-        float cam_angle  = elapsed * cam_speed;
-
+        // Compute eye position from orbit camera
+        float cos_pitch = std::cos(orbit_cam.pitch);
         float eye[3] = {
-            cam_radius * std::sin(cam_angle),
-            cam_height,
-            cam_radius * std::cos(cam_angle)
+            orbit_cam.center[0] + orbit_cam.radius * cos_pitch * std::sin(orbit_cam.yaw),
+            orbit_cam.center[1] + orbit_cam.radius * std::sin(orbit_cam.pitch),
+            orbit_cam.center[2] + orbit_cam.radius * cos_pitch * std::cos(orbit_cam.yaw)
         };
-        float center[3] = {0.0f, 1.0f, 0.0f};
-        float up[3]     = {0.0f, 1.0f, 0.0f};
+        float up[3] = {0.0f, 1.0f, 0.0f};
 
         float view_mat[16], proj_mat[16], view_proj[16];
-        mat4_look_at(view_mat, eye, center, up);
+        mat4_look_at(view_mat, eye, orbit_cam.center, up);
 
         float aspect = static_cast<float>(screen_w) / static_cast<float>(screen_h);
         mat4_perspective(proj_mat, 0.7854f, aspect, 0.1f, 200.0f);

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -111,10 +111,47 @@ int main() {
     camera.frustum.planes[4] = {{0, 0, 1}, 0.1f};
     camera.frustum.planes[5] = {{0, 0, -1}, 500.0f};
 
+    // ---- Orbit Camera State ----
+    struct OrbitCamera {
+        float yaw   = 0.0f;
+        float pitch = 0.5f;
+        float radius = 40.0f;
+        float center[3] = {0.0f, 0.0f, 0.0f};
+        double lastMouseX = 0.0, lastMouseY = 0.0;
+        bool dragging = false;
+    };
+    static OrbitCamera orbit_cam;
+
+    GLFWwindow* win = surface_provider.glfw_window();
+    glfwSetMouseButtonCallback(win, [](GLFWwindow* w, int button, int action, int /*mods*/) {
+        if (button == GLFW_MOUSE_BUTTON_LEFT) {
+            orbit_cam.dragging = (action == GLFW_PRESS);
+            if (orbit_cam.dragging)
+                glfwGetCursorPos(w, &orbit_cam.lastMouseX, &orbit_cam.lastMouseY);
+        }
+    });
+    glfwSetCursorPosCallback(win, [](GLFWwindow*, double xpos, double ypos) {
+        if (!orbit_cam.dragging) return;
+        double dx = xpos - orbit_cam.lastMouseX;
+        double dy = ypos - orbit_cam.lastMouseY;
+        orbit_cam.lastMouseX = xpos;
+        orbit_cam.lastMouseY = ypos;
+        orbit_cam.yaw   -= static_cast<float>(dx) * 0.005f;
+        orbit_cam.pitch += static_cast<float>(dy) * 0.005f;
+        if (orbit_cam.pitch > 1.5f)  orbit_cam.pitch = 1.5f;
+        if (orbit_cam.pitch < -1.5f) orbit_cam.pitch = -1.5f;
+    });
+    glfwSetScrollCallback(win, [](GLFWwindow*, double /*xoffset*/, double yoffset) {
+        orbit_cam.radius -= static_cast<float>(yoffset) * 3.0f;
+        if (orbit_cam.radius < 5.0f)   orbit_cam.radius = 5.0f;
+        if (orbit_cam.radius > 200.0f) orbit_cam.radius = 200.0f;
+    });
+
     // ---- 5. Main loop ----
     auto start = std::chrono::high_resolution_clock::now();
     uint64_t frame_count = 0;
 
+    printf("Mouse drag: orbit camera, Scroll: zoom\n");
     printf("Entering main loop. Close the window to exit.\n");
 
     while (!surface_provider.should_close()) {
@@ -124,6 +161,14 @@ int main() {
         auto now = std::chrono::high_resolution_clock::now();
         float elapsed = std::chrono::duration<float>(now - start).count();
         float hue = std::fmod(elapsed * 0.1f, 1.0f); // one full cycle every 10s
+
+        // Update camera from orbit state
+        float cos_pitch = std::cos(orbit_cam.pitch);
+        camera.position = {
+            orbit_cam.center[0] + orbit_cam.radius * cos_pitch * std::sin(orbit_cam.yaw),
+            orbit_cam.center[1] + orbit_cam.radius * std::sin(orbit_cam.pitch),
+            orbit_cam.center[2] + orbit_cam.radius * cos_pitch * std::cos(orbit_cam.yaw)
+        };
 
         float r, g, b;
         hue_to_rgb(hue, r, g, b);

--- a/demo/ocean/main.cpp
+++ b/demo/ocean/main.cpp
@@ -86,11 +86,12 @@ struct OceanSceneUBO {
     float viewProj[16];
     float cameraPos[4];     // xyz + pad
     float time;
-    float maxTessLevel;
-    float minTessLevel;
-    float tessNearDist;
-    float tessFarDist;
-    float pad0, pad1, pad2;
+    float tessLevelHigh;    // tessellation level for near range (e.g. 32)
+    float tessLevelMedium;  // tessellation level for mid range (e.g. 16)
+    float tessLevelLow;     // tessellation level for far range (e.g. 4)
+    float tessDistNearMid;  // distance boundary: high -> medium
+    float tessDistMidFar;   // distance boundary: medium -> low
+    float pad0, pad1;
 };
 
 // ============================================================
@@ -881,13 +882,52 @@ int main() {
     auto start = std::chrono::high_resolution_clock::now();
     uint64_t frame_count = 0;
 
+    // ---- Orbit Camera State ----
+    struct OrbitCamera {
+        float yaw   = 0.0f;
+        float pitch = 0.3f;    // slight downward angle
+        float radius = 40.0f;
+        float center[3] = {0.0f, 0.0f, 0.0f};
+        double lastMouseX = 0.0, lastMouseY = 0.0;
+        bool dragging = false;
+    };
+    static OrbitCamera orbit_cam;
+
+    // Mouse callbacks for orbit camera
+    GLFWwindow* win = surface_provider.glfw_window();
+    glfwSetMouseButtonCallback(win, [](GLFWwindow* w, int button, int action, int /*mods*/) {
+        if (button == GLFW_MOUSE_BUTTON_LEFT) {
+            orbit_cam.dragging = (action == GLFW_PRESS);
+            if (orbit_cam.dragging)
+                glfwGetCursorPos(w, &orbit_cam.lastMouseX, &orbit_cam.lastMouseY);
+        }
+    });
+    glfwSetCursorPosCallback(win, [](GLFWwindow*, double xpos, double ypos) {
+        if (!orbit_cam.dragging) return;
+        double dx = xpos - orbit_cam.lastMouseX;
+        double dy = ypos - orbit_cam.lastMouseY;
+        orbit_cam.lastMouseX = xpos;
+        orbit_cam.lastMouseY = ypos;
+        orbit_cam.yaw   -= static_cast<float>(dx) * 0.005f;
+        orbit_cam.pitch += static_cast<float>(dy) * 0.005f;
+        // Clamp pitch to avoid flipping
+        if (orbit_cam.pitch > 1.5f)  orbit_cam.pitch = 1.5f;
+        if (orbit_cam.pitch < -1.5f) orbit_cam.pitch = -1.5f;
+    });
+    glfwSetScrollCallback(win, [](GLFWwindow*, double /*xoffset*/, double yoffset) {
+        orbit_cam.radius -= static_cast<float>(yoffset) * 3.0f;
+        if (orbit_cam.radius < 5.0f)  orbit_cam.radius = 5.0f;
+        if (orbit_cam.radius > 200.0f) orbit_cam.radius = 200.0f;
+    });
+
     printf("\nOcean setup:\n");
     printf("  - 32x32 quad patch grid (1024 patches)\n");
-    printf("  - Tessellation range: 1 (far) to 32 (near)\n");
+    printf("  - 3-level tessellation: High(32) / Medium(16) / Low(4)\n");
     printf("  - Target: ~100K polygons adaptive LOD\n");
     printf("  - 6-layer Gerstner wave displacement\n");
     printf("  - Physically-based ocean shading (Fresnel + SSS + foam)\n");
     printf("  - Press 'W' to toggle wireframe tessellation view\n");
+    printf("  - Mouse drag: orbit camera, Scroll: zoom\n");
     printf("\nEntering main loop. Close the window to exit.\n\n");
 
     bool w_key_was_pressed = false;
@@ -897,7 +937,6 @@ int main() {
 
         // Toggle wireframe with W key
         {
-            GLFWwindow* win = surface_provider.glfw_window();
             bool w_pressed = glfwGetKey(win, GLFW_KEY_W) == GLFW_PRESS;
             if (w_pressed && !w_key_was_pressed) {
                 ocean_renderer.toggle_wireframe();
@@ -909,28 +948,23 @@ int main() {
         auto now = std::chrono::high_resolution_clock::now();
         float elapsed = std::chrono::duration<float>(now - start).count();
 
-        // Orbit camera over ocean
-        float cam_radius = 40.0f;
-        float cam_height = 15.0f;
-        float cam_speed  = 0.15f;
-        float cam_angle  = elapsed * cam_speed;
-
+        // Compute eye position from orbit camera
+        float cos_pitch = std::cos(orbit_cam.pitch);
         float eye[3] = {
-            cam_radius * std::sin(cam_angle),
-            cam_height + 3.0f * std::sin(elapsed * 0.2f),  // gentle bob
-            cam_radius * std::cos(cam_angle)
+            orbit_cam.center[0] + orbit_cam.radius * cos_pitch * std::sin(orbit_cam.yaw),
+            orbit_cam.center[1] + orbit_cam.radius * std::sin(orbit_cam.pitch),
+            orbit_cam.center[2] + orbit_cam.radius * cos_pitch * std::cos(orbit_cam.yaw)
         };
-        float center[3] = {0.0f, 0.0f, 0.0f};
-        float up[3]     = {0.0f, 1.0f, 0.0f};
+        float up[3] = {0.0f, 1.0f, 0.0f};
 
         float view_mat[16], proj_mat[16], view_proj[16];
-        mat4_look_at(view_mat, eye, center, up);
+        mat4_look_at(view_mat, eye, orbit_cam.center, up);
 
         float aspect = static_cast<float>(screen_w) / static_cast<float>(screen_h);
         mat4_perspective(proj_mat, 0.7854f, aspect, 0.1f, 500.0f);
         mat4_multiply(view_proj, proj_mat, view_mat);
 
-        // Build UBO
+        // Build UBO — 3-level tessellation
         OceanSceneUBO ubo;
         memcpy(ubo.view,    view_mat,  sizeof(view_mat));
         memcpy(ubo.proj,    proj_mat,  sizeof(proj_mat));
@@ -939,12 +973,13 @@ int main() {
         ubo.cameraPos[1] = eye[1];
         ubo.cameraPos[2] = eye[2];
         ubo.cameraPos[3] = 0.0f;
-        ubo.time          = elapsed;
-        ubo.maxTessLevel  = 32.0f;
-        ubo.minTessLevel  = 1.0f;
-        ubo.tessNearDist  = 10.0f;
-        ubo.tessFarDist   = 200.0f;
-        ubo.pad0 = ubo.pad1 = ubo.pad2 = 0.0f;
+        ubo.time            = elapsed;
+        ubo.tessLevelHigh   = 32.0f;
+        ubo.tessLevelMedium = 16.0f;
+        ubo.tessLevelLow    = 4.0f;
+        ubo.tessDistNearMid = 30.0f;
+        ubo.tessDistMidFar  = 100.0f;
+        ubo.pad0 = ubo.pad1 = 0.0f;
 
         // Update Pictor renderer
         camera.position = {eye[0], eye[1], eye[2]};

--- a/demo/ocean/shaders/ocean.frag
+++ b/demo/ocean/shaders/ocean.frag
@@ -14,11 +14,12 @@ layout(set = 0, binding = 0) uniform SceneParams {
     mat4  viewProjection;
     vec4  cameraPosition;
     float time;
-    float maxTessLevel;
-    float minTessLevel;
-    float tessNearDist;
-    float tessFarDist;
-    float pad0, pad1, pad2;
+    float tessLevelHigh;
+    float tessLevelMedium;
+    float tessLevelLow;
+    float tessDistNearMid;
+    float tessDistMidFar;
+    float pad0, pad1;
 };
 
 layout(location = 0) in vec3 fragWorldPos;

--- a/demo/ocean/shaders/ocean.tesc
+++ b/demo/ocean/shaders/ocean.tesc
@@ -1,7 +1,7 @@
 // Pictor — Ocean Wave Tessellation Control Shader
-// Distance-based adaptive tessellation: more polygons near the camera,
-// fewer polygons at distance. Targets ~100K total polygons across the
-// ocean surface.
+// 3-level distance-based adaptive tessellation:
+//   High (near), Medium (mid), Low (far)
+// Tessellation is determined by camera distance to each edge midpoint.
 
 #version 450
 
@@ -13,11 +13,12 @@ layout(set = 0, binding = 0) uniform SceneParams {
     mat4  viewProjection;
     vec4  cameraPosition;
     float time;
-    float maxTessLevel;     // maximum tessellation level (near camera)
-    float minTessLevel;     // minimum tessellation level (far from camera)
-    float tessNearDist;     // distance at which max tessellation is used
-    float tessFarDist;      // distance beyond which min tessellation is used
-    float pad0, pad1, pad2;
+    float tessLevelHigh;    // tessellation level for near range
+    float tessLevelMedium;  // tessellation level for mid range
+    float tessLevelLow;     // tessellation level for far range
+    float tessDistNearMid;  // distance boundary: high -> medium
+    float tessDistMidFar;   // distance boundary: medium -> low
+    float pad0, pad1;
 };
 
 layout(location = 0) in vec3 vsPosition[];
@@ -29,8 +30,17 @@ layout(location = 1) out vec2 tcsTexCoord[];
 float calcTessLevel(vec3 p0, vec3 p1) {
     vec3 midpoint = (p0 + p1) * 0.5;
     float dist = distance(cameraPosition.xyz, midpoint);
-    float t = clamp((dist - tessNearDist) / (tessFarDist - tessNearDist), 0.0, 1.0);
-    return mix(maxTessLevel, minTessLevel, t);
+
+    // 3-level discrete tessellation with smooth transitions
+    if (dist < tessDistNearMid) {
+        float t = clamp(dist / tessDistNearMid, 0.0, 1.0);
+        return mix(tessLevelHigh, tessLevelMedium, t);
+    } else if (dist < tessDistMidFar) {
+        float t = clamp((dist - tessDistNearMid) / (tessDistMidFar - tessDistNearMid), 0.0, 1.0);
+        return mix(tessLevelMedium, tessLevelLow, t);
+    } else {
+        return tessLevelLow;
+    }
 }
 
 void main() {

--- a/demo/ocean/shaders/ocean.tese
+++ b/demo/ocean/shaders/ocean.tese
@@ -12,11 +12,12 @@ layout(set = 0, binding = 0) uniform SceneParams {
     mat4  viewProjection;
     vec4  cameraPosition;
     float time;
-    float maxTessLevel;
-    float minTessLevel;
-    float tessNearDist;
-    float tessFarDist;
-    float pad0, pad1, pad2;
+    float tessLevelHigh;
+    float tessLevelMedium;
+    float tessLevelLow;
+    float tessDistNearMid;
+    float tessDistMidFar;
+    float pad0, pad1;
 };
 
 layout(location = 0) in vec3 tcsPosition[];

--- a/demo/ocean/shaders/ocean_wireframe.frag
+++ b/demo/ocean/shaders/ocean_wireframe.frag
@@ -9,11 +9,12 @@ layout(set = 0, binding = 0) uniform SceneParams {
     mat4  viewProjection;
     vec4  cameraPosition;
     float time;
-    float maxTessLevel;
-    float minTessLevel;
-    float tessNearDist;
-    float tessFarDist;
-    float pad0, pad1, pad2;
+    float tessLevelHigh;
+    float tessLevelMedium;
+    float tessLevelLow;
+    float tessDistNearMid;
+    float tessDistMidFar;
+    float pad0, pad1;
 };
 
 layout(location = 0) in vec3 fragWorldPos;
@@ -24,14 +25,24 @@ layout(location = 3) in float fragFoam;
 layout(location = 0) out vec4 outColor;
 
 void main() {
-    // Distance-based color: near = bright cyan, far = darker blue
+    // 3-level tessellation visualization:
+    //   High (near) = bright green, Medium = yellow, Low (far) = red
     float dist = length(fragWorldPos - cameraPosition.xyz);
-    float t = clamp(dist / tessFarDist, 0.0, 1.0);
 
-    vec3 nearColor = vec3(0.0, 1.0, 0.9);   // bright cyan
-    vec3 farColor  = vec3(0.1, 0.3, 0.6);   // muted blue
+    vec3 highColor   = vec3(0.0, 1.0, 0.5);   // bright green (near / high detail)
+    vec3 mediumColor = vec3(1.0, 1.0, 0.0);   // yellow (medium detail)
+    vec3 lowColor    = vec3(1.0, 0.3, 0.1);   // red-orange (far / low detail)
 
-    vec3 wireColor = mix(nearColor, farColor, t);
+    vec3 wireColor;
+    if (dist < tessDistNearMid) {
+        float t = clamp(dist / tessDistNearMid, 0.0, 1.0);
+        wireColor = mix(highColor, mediumColor, t);
+    } else if (dist < tessDistMidFar) {
+        float t = clamp((dist - tessDistNearMid) / (tessDistMidFar - tessDistNearMid), 0.0, 1.0);
+        wireColor = mix(mediumColor, lowColor, t);
+    } else {
+        wireColor = lowColor;
+    }
 
     // Slight brightness variation based on surface normal for depth perception
     float facing = abs(dot(normalize(fragNormal), vec3(0.0, 1.0, 0.0)));


### PR DESCRIPTION
## Summary
This PR introduces an interactive orbit camera system across all demo applications and refactors the ocean tessellation system from a 2-level linear approach to a 3-level discrete tessellation scheme with smooth transitions.

## Key Changes

### Interactive Orbit Camera
- Added `OrbitCamera` struct with yaw, pitch, radius, and center position to all demo applications (`demo/ocean/main.cpp`, `demo/benchmark/main.cpp`, `demo/graphics/main.cpp`, `demo/main.cpp`)
- Implemented mouse callbacks for camera control:
  - **Left mouse drag**: Rotate camera around target (yaw/pitch)
  - **Scroll wheel**: Zoom in/out (adjust radius)
  - Pitch clamping to prevent camera flipping
  - Radius constraints to maintain reasonable viewing distances
- Updated main loops to compute eye position from orbit state using spherical coordinates

### 3-Level Tessellation System
- Replaced 2-level tessellation (`maxTessLevel`/`minTessLevel`) with 3-level system:
  - `tessLevelHigh` (32): Near range, high detail
  - `tessLevelMedium` (16): Mid range, medium detail
  - `tessLevelLow` (4): Far range, low detail
- Updated distance boundaries:
  - `tessDistNearMid` (30m): Transition from high to medium
  - `tessDistMidFar` (100m): Transition from medium to low
- Modified tessellation control shader (`ocean.tesc`) to use discrete 3-level transitions with smooth interpolation within each range
- Updated wireframe visualization shader (`ocean_wireframe.frag`) with color-coded tessellation levels:
  - Green for high detail (near)
  - Yellow for medium detail (mid)
  - Red-orange for low detail (far)

### Documentation Updates
- Updated console output messages to reflect new tessellation scheme and camera controls
- Added inline comments explaining the 3-level tessellation approach in shaders

## Implementation Details
- Orbit camera uses standard spherical coordinate conversion: `eye = center + radius * (cos(pitch)*sin(yaw), sin(pitch), cos(pitch)*cos(yaw))`
- Tessellation transitions use smooth linear interpolation (`mix`) within each distance band for visual continuity
- All demos maintain consistent orbit camera behavior with scene-specific radius and pitch constraints
- Benchmark application conditionally enables orbit camera only in non-headless mode

https://claude.ai/code/session_01UJFDEWshLDpF33eQPSLJaG