### PR TITLE
Add ModelDataHandler for 3D model resource management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(pictor STATIC
     # Data Handler
     src/data/texture_registry.cpp
     src/data/vertex_data_uploader.cpp
+    src/data/model_data_handler.cpp
     src/data/data_handler.cpp
     src/data/data_query_api.cpp
 

--- a/include/pictor/core/pictor_renderer.h
+++ b/include/pictor/core/pictor_renderer.h
@@ -140,6 +140,10 @@ public:
     MeshHandle register_mesh_data(const MeshDataDescriptor& desc);
     void unregister_mesh_data(MeshHandle handle);
 
+    /// Register a 3D model (skin meshes, rig, animations) via the data handler
+    ModelHandle register_model(const ModelDescriptor& desc);
+    void unregister_model(ModelHandle handle);
+
     /// Access the data handler directly
     DataHandler&       data_handler()       { return *data_handler_; }
     const DataHandler& data_handler() const { return *data_handler_; }

--- a/include/pictor/data/data_handler.h
+++ b/include/pictor/data/data_handler.h
@@ -2,17 +2,21 @@
 
 #include "pictor/data/texture_registry.h"
 #include "pictor/data/vertex_data_uploader.h"
+#include "pictor/data/model_data_handler.h"
 #include <memory>
 
 namespace pictor {
 
-/// Central data handler — facade for texture and vertex data management.
+class AnimationSystem;
+
+/// Central data handler — facade for texture, vertex, and model data management.
 /// Provides a unified interface for registering, uploading, and querying
 /// GPU resources. Designed for use by both the renderer internals and
 /// external tools/editors.
 class DataHandler {
 public:
-    DataHandler(GpuMemoryAllocator& gpu_allocator, GPUBufferManager& buffer_manager);
+    DataHandler(GpuMemoryAllocator& gpu_allocator, GPUBufferManager& buffer_manager,
+                AnimationSystem& animation_system);
     ~DataHandler();
 
     DataHandler(const DataHandler&) = delete;
@@ -33,6 +37,11 @@ public:
     bool update_vertex_region(MeshHandle handle, size_t offset, const void* data, size_t size);
     void unregister_mesh(MeshHandle handle);
 
+    // ---- Model Operations ----
+
+    ModelHandle register_model(const ModelDescriptor& desc);
+    void unregister_model(ModelHandle handle);
+
     // ---- Subsystem Access ----
 
     TextureRegistry&      textures()       { return *texture_registry_; }
@@ -41,11 +50,15 @@ public:
     VertexDataUploader&       meshes()        { return *vertex_uploader_; }
     const VertexDataUploader& meshes() const  { return *vertex_uploader_; }
 
+    ModelDataHandler&       models()        { return *model_handler_; }
+    const ModelDataHandler& models() const  { return *model_handler_; }
+
     // ---- Aggregate Stats ----
 
     struct Stats {
-        TextureRegistry::Stats    texture_stats;
-        VertexDataUploader::Stats mesh_stats;
+        TextureRegistry::Stats     texture_stats;
+        VertexDataUploader::Stats  mesh_stats;
+        ModelDataHandler::Stats    model_stats;
     };
 
     Stats get_stats() const;
@@ -53,6 +66,7 @@ public:
 private:
     std::unique_ptr<TextureRegistry>    texture_registry_;
     std::unique_ptr<VertexDataUploader> vertex_uploader_;
+    std::unique_ptr<ModelDataHandler>   model_handler_;
 };
 
 } // namespace pictor

--- a/include/pictor/data/model_data_handler.h
+++ b/include/pictor/data/model_data_handler.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "pictor/data/model_data_types.h"
+#include "pictor/data/vertex_data_uploader.h"
+#include "pictor/animation/animation_system.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pictor {
+
+/// Configuration for the model data handler
+struct ModelDataHandlerConfig {
+    uint32_t max_models     = 256;
+    uint32_t max_skin_meshes = 1024;
+    uint32_t max_rigs       = 256;
+};
+
+/// Model data handler — manages 3D model resources (FBX/OBJ/MMD etc.).
+/// Handles registration and lifecycle of skin meshes, bones/rigs,
+/// and their associated animation data.
+///
+/// Works in coordination with VertexDataUploader (for GPU mesh data)
+/// and AnimationSystem (for skeletons and clips).
+class ModelDataHandler {
+public:
+    ModelDataHandler(VertexDataUploader& vertex_uploader,
+                     AnimationSystem& animation_system);
+    ~ModelDataHandler();
+
+    ModelDataHandler(const ModelDataHandler&) = delete;
+    ModelDataHandler& operator=(const ModelDataHandler&) = delete;
+
+    // ============================================================
+    // Model Registration
+    // ============================================================
+
+    /// Register a complete model. Internally registers skin meshes,
+    /// rig, and animation clips into the appropriate subsystems.
+    ModelHandle register_model(const ModelDescriptor& desc);
+
+    /// Unregister a model and all its sub-resources.
+    void unregister_model(ModelHandle handle);
+
+    // ============================================================
+    // Skin Mesh Operations
+    // ============================================================
+
+    /// Register a standalone skin mesh.
+    SkinMeshHandle register_skin_mesh(const SkinMeshDescriptor& desc);
+
+    /// Unregister a skin mesh.
+    void unregister_skin_mesh(SkinMeshHandle handle);
+
+    /// Get the underlying GPU mesh handle for a skin mesh.
+    MeshHandle get_gpu_mesh(SkinMeshHandle handle) const;
+
+    /// Get skin weights for a skin mesh.
+    const std::vector<SkinWeight>* get_skin_weights(SkinMeshHandle handle) const;
+
+    /// Get morph target names for a skin mesh.
+    const std::vector<std::string>* get_morph_target_names(SkinMeshHandle handle) const;
+
+    // ============================================================
+    // Rig Operations
+    // ============================================================
+
+    /// Register a rig (bone hierarchy + constraints).
+    RigHandle register_rig(const RigDescriptor& desc);
+
+    /// Unregister a rig.
+    void unregister_rig(RigHandle handle);
+
+    /// Get the AnimationSystem skeleton handle for a rig.
+    SkeletonHandle get_skeleton(RigHandle handle) const;
+
+    /// Get IK chain descriptors for a rig.
+    const std::vector<IKChainDescriptor>* get_ik_chains(RigHandle handle) const;
+
+    // ============================================================
+    // Query
+    // ============================================================
+
+    bool is_valid_model(ModelHandle handle) const;
+    bool is_valid_skin_mesh(SkinMeshHandle handle) const;
+    bool is_valid_rig(RigHandle handle) const;
+
+    const ModelEntry*    get_model_entry(ModelHandle handle) const;
+    const SkinMeshEntry* get_skin_mesh_entry(SkinMeshHandle handle) const;
+    const RigEntry*      get_rig_entry(RigHandle handle) const;
+
+    ModelHandle    find_model_by_name(const std::string& name) const;
+    SkinMeshHandle find_skin_mesh_by_name(const std::string& name) const;
+    RigHandle      find_rig_by_name(const std::string& name) const;
+
+    uint32_t model_count() const     { return static_cast<uint32_t>(models_.size()); }
+    uint32_t skin_mesh_count() const { return static_cast<uint32_t>(skin_meshes_.size()); }
+    uint32_t rig_count() const       { return static_cast<uint32_t>(rigs_.size()); }
+
+    // ============================================================
+    // Stats
+    // ============================================================
+
+    struct Stats {
+        uint32_t model_count     = 0;
+        uint32_t skin_mesh_count = 0;
+        uint32_t rig_count       = 0;
+        uint32_t total_vertices  = 0;
+        uint32_t total_indices   = 0;
+        uint32_t total_bones     = 0;
+    };
+
+    Stats get_stats() const;
+
+    // ============================================================
+    // Format Detection
+    // ============================================================
+
+    /// Detect model format from file extension.
+    static ModelFormat detect_format(const std::string& path);
+
+    /// Detect model format from file header bytes.
+    static ModelFormat detect_format(const uint8_t* data, size_t size);
+
+private:
+    VertexDataUploader& vertex_uploader_;
+    AnimationSystem&    animation_system_;
+
+    std::vector<ModelEntry>    models_;
+    std::vector<SkinMeshEntry> skin_meshes_;
+    std::vector<RigEntry>      rigs_;
+
+    std::unordered_map<std::string, ModelHandle>    model_name_map_;
+    std::unordered_map<std::string, SkinMeshHandle> skin_mesh_name_map_;
+    std::unordered_map<std::string, RigHandle>      rig_name_map_;
+
+    ModelHandle    next_model_handle_     = 0;
+    SkinMeshHandle next_skin_mesh_handle_ = 0;
+    RigHandle      next_rig_handle_       = 0;
+};
+
+} // namespace pictor

--- a/include/pictor/data/model_data_types.h
+++ b/include/pictor/data/model_data_types.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "pictor/core/types.h"
+#include "pictor/data/vertex_data_uploader.h"
+#include "pictor/animation/animation_types.h"
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace pictor {
+
+// ============================================================
+// Model Handle Types
+// ============================================================
+
+using ModelHandle     = uint32_t;
+using SkinMeshHandle  = uint32_t;
+using RigHandle       = uint32_t;
+
+constexpr ModelHandle    INVALID_MODEL     = std::numeric_limits<uint32_t>::max();
+constexpr SkinMeshHandle INVALID_SKIN_MESH = std::numeric_limits<uint32_t>::max();
+constexpr RigHandle      INVALID_RIG       = std::numeric_limits<uint32_t>::max();
+
+// ============================================================
+// Model Source Format
+// ============================================================
+
+enum class ModelFormat : uint8_t {
+    UNKNOWN  = 0,
+    FBX      = 1,
+    OBJ      = 2,
+    MMD_PMX  = 3,  // MikuMikuDance PMX
+    MMD_PMD  = 4,  // MikuMikuDance PMD (legacy)
+    GLTF     = 5,
+    GLB      = 6,
+    COLLADA  = 7   // DAE
+};
+
+// ============================================================
+// Skin Weight — per-vertex bone influence
+// ============================================================
+
+struct SkinWeight {
+    uint32_t bone_indices[4] = {};     // Up to 4 bone influences
+    float    weights[4]      = {};     // Corresponding weights (sum to 1.0)
+};
+
+// ============================================================
+// Skin Mesh Descriptor
+// ============================================================
+
+struct SkinMeshDescriptor {
+    std::string  name;
+    VertexLayout layout;
+
+    const void*  vertex_data      = nullptr;
+    size_t       vertex_data_size = 0;
+    uint32_t     vertex_count     = 0;
+
+    const void*  index_data      = nullptr;
+    size_t       index_data_size = 0;
+    uint32_t     index_count     = 0;
+    bool         index_32bit     = true;
+
+    /// Per-vertex skin weights (vertex_count entries)
+    std::vector<SkinWeight> skin_weights;
+
+    /// Morph target / blend shape names
+    std::vector<std::string> morph_target_names;
+
+    /// Morph target vertex deltas (morph_count * vertex_count * 3 floats)
+    std::vector<float> morph_deltas;
+};
+
+// ============================================================
+// Rig Descriptor — bone hierarchy + constraints
+// ============================================================
+
+struct RigDescriptor {
+    std::string        name;
+    std::vector<Bone>  bones;
+
+    /// IK chain definitions embedded in the model
+    std::vector<IKChainDescriptor> ik_chains;
+};
+
+// ============================================================
+// Model Descriptor — a complete 3D model resource
+// ============================================================
+
+struct ModelDescriptor {
+    std::string  name;
+    ModelFormat  format = ModelFormat::UNKNOWN;
+
+    /// Skin meshes contained in this model
+    std::vector<SkinMeshDescriptor> skin_meshes;
+
+    /// Rig / skeleton
+    RigDescriptor rig;
+
+    /// Embedded animation clips
+    std::vector<AnimationClipDescriptor> animation_clips;
+
+    /// Material slot names (for external material binding)
+    std::vector<std::string> material_slots;
+
+    /// Embedded texture paths (relative to model file)
+    std::vector<std::string> texture_paths;
+};
+
+// ============================================================
+// Skin Mesh Entry — registered skin mesh bookkeeping
+// ============================================================
+
+struct SkinMeshEntry {
+    SkinMeshHandle handle       = INVALID_SKIN_MESH;
+    std::string    name;
+    MeshHandle     gpu_mesh     = INVALID_MESH;     // Underlying vertex data
+    uint32_t       vertex_count = 0;
+    uint32_t       index_count  = 0;
+
+    std::vector<SkinWeight>  skin_weights;
+    std::vector<std::string> morph_target_names;
+    std::vector<float>       morph_deltas;
+};
+
+// ============================================================
+// Rig Entry — registered rig bookkeeping
+// ============================================================
+
+struct RigEntry {
+    RigHandle      handle   = INVALID_RIG;
+    std::string    name;
+    SkeletonHandle skeleton = INVALID_SKELETON;  // AnimationSystem skeleton
+    std::vector<IKChainDescriptor> ik_chains;
+};
+
+// ============================================================
+// Model Entry — registered model bookkeeping
+// ============================================================
+
+struct ModelEntry {
+    ModelHandle  handle = INVALID_MODEL;
+    std::string  name;
+    ModelFormat  format = ModelFormat::UNKNOWN;
+
+    /// Registered skin meshes
+    std::vector<SkinMeshHandle> skin_meshes;
+
+    /// Registered rig
+    RigHandle rig = INVALID_RIG;
+
+    /// Registered animation clips
+    std::vector<AnimationClipHandle> animation_clips;
+
+    /// Material slot names
+    std::vector<std::string> material_slots;
+
+    /// Texture paths
+    std::vector<std::string> texture_paths;
+};
+
+} // namespace pictor

--- a/include/pictor/pictor.h
+++ b/include/pictor/pictor.h
@@ -70,6 +70,8 @@
 // Data handler
 #include "pictor/data/texture_registry.h"
 #include "pictor/data/vertex_data_uploader.h"
+#include "pictor/data/model_data_types.h"
+#include "pictor/data/model_data_handler.h"
 #include "pictor/data/data_handler.h"
 #include "pictor/data/data_query_api.h"
 

--- a/src/core/pictor_renderer.cpp
+++ b/src/core/pictor_renderer.cpp
@@ -84,11 +84,14 @@ void PictorRenderer::initialize(const RendererConfig& config) {
     // 15. Data Exporter
     data_exporter_ = std::make_unique<DataExporter>();
 
-    // 16. Data Handler
-    data_handler_ = std::make_unique<DataHandler>(
-        memory_->gpu_allocator(), *gpu_buffer_manager_);
+    // 16. Animation System (before DataHandler, which depends on it)
+    animation_system_ = std::make_unique<AnimationSystem>(AnimationSystemConfig{});
 
-    // 17. Post-Process Pipeline
+    // 17. Data Handler
+    data_handler_ = std::make_unique<DataHandler>(
+        memory_->gpu_allocator(), *gpu_buffer_manager_, *animation_system_);
+
+    // 18. Post-Process Pipeline
     postprocess_ = std::make_unique<PostProcessPipeline>();
     {
         // Build default post-process config from profile's post_process_stack
@@ -111,9 +114,6 @@ void PictorRenderer::initialize(const RendererConfig& config) {
 
         postprocess_->initialize(config.screen_width, config.screen_height, pp_config);
     }
-
-    // 18. Animation System
-    animation_system_ = std::make_unique<AnimationSystem>(AnimationSystemConfig{});
 
     initialized_ = true;
 }
@@ -451,6 +451,16 @@ MeshHandle PictorRenderer::register_mesh_data(const MeshDataDescriptor& desc) {
 void PictorRenderer::unregister_mesh_data(MeshHandle handle) {
     if (!initialized_) return;
     data_handler_->unregister_mesh(handle);
+}
+
+ModelHandle PictorRenderer::register_model(const ModelDescriptor& desc) {
+    if (!initialized_) return INVALID_MODEL;
+    return data_handler_->register_model(desc);
+}
+
+void PictorRenderer::unregister_model(ModelHandle handle) {
+    if (!initialized_) return;
+    data_handler_->unregister_model(handle);
 }
 
 // ---- GI Lighting ----

--- a/src/data/data_handler.cpp
+++ b/src/data/data_handler.cpp
@@ -2,9 +2,11 @@
 
 namespace pictor {
 
-DataHandler::DataHandler(GpuMemoryAllocator& gpu_allocator, GPUBufferManager& buffer_manager)
+DataHandler::DataHandler(GpuMemoryAllocator& gpu_allocator, GPUBufferManager& buffer_manager,
+                         AnimationSystem& animation_system)
     : texture_registry_(std::make_unique<TextureRegistry>(gpu_allocator))
     , vertex_uploader_(std::make_unique<VertexDataUploader>(buffer_manager))
+    , model_handler_(std::make_unique<ModelDataHandler>(*vertex_uploader_, animation_system))
 {
 }
 
@@ -48,12 +50,23 @@ void DataHandler::unregister_mesh(MeshHandle handle) {
     vertex_uploader_->unregister_mesh(handle);
 }
 
+// ---- Model Operations ----
+
+ModelHandle DataHandler::register_model(const ModelDescriptor& desc) {
+    return model_handler_->register_model(desc);
+}
+
+void DataHandler::unregister_model(ModelHandle handle) {
+    model_handler_->unregister_model(handle);
+}
+
 // ---- Stats ----
 
 DataHandler::Stats DataHandler::get_stats() const {
     Stats stats;
     stats.texture_stats = texture_registry_->get_stats();
     stats.mesh_stats = vertex_uploader_->get_stats();
+    stats.model_stats = model_handler_->get_stats();
     return stats;
 }
 

--- a/src/data/model_data_handler.cpp
+++ b/src/data/model_data_handler.cpp
@@ -1,0 +1,329 @@
+#include "pictor/data/model_data_handler.h"
+#include <algorithm>
+#include <cstring>
+
+namespace pictor {
+
+ModelDataHandler::ModelDataHandler(VertexDataUploader& vertex_uploader,
+                                   AnimationSystem& animation_system)
+    : vertex_uploader_(vertex_uploader)
+    , animation_system_(animation_system)
+{
+}
+
+ModelDataHandler::~ModelDataHandler() = default;
+
+// ============================================================
+// Model Registration
+// ============================================================
+
+ModelHandle ModelDataHandler::register_model(const ModelDescriptor& desc) {
+    ModelEntry entry;
+    entry.handle = next_model_handle_++;
+    entry.name   = desc.name;
+    entry.format = desc.format;
+    entry.material_slots = desc.material_slots;
+    entry.texture_paths  = desc.texture_paths;
+
+    // Register skin meshes
+    for (const auto& sm_desc : desc.skin_meshes) {
+        SkinMeshHandle sm = register_skin_mesh(sm_desc);
+        entry.skin_meshes.push_back(sm);
+    }
+
+    // Register rig
+    if (!desc.rig.bones.empty()) {
+        entry.rig = register_rig(desc.rig);
+    }
+
+    // Register animation clips
+    for (const auto& clip_desc : desc.animation_clips) {
+        AnimationClipHandle clip = animation_system_.register_clip(clip_desc);
+        entry.animation_clips.push_back(clip);
+    }
+
+    if (!desc.name.empty()) {
+        model_name_map_[desc.name] = entry.handle;
+    }
+
+    models_.push_back(std::move(entry));
+    return models_.back().handle;
+}
+
+void ModelDataHandler::unregister_model(ModelHandle handle) {
+    auto it = std::find_if(models_.begin(), models_.end(),
+        [handle](const ModelEntry& e) { return e.handle == handle; });
+    if (it == models_.end()) return;
+
+    // Unregister sub-resources
+    for (auto sm : it->skin_meshes) {
+        unregister_skin_mesh(sm);
+    }
+    if (it->rig != INVALID_RIG) {
+        unregister_rig(it->rig);
+    }
+    for (auto clip : it->animation_clips) {
+        animation_system_.unregister_clip(clip);
+    }
+
+    if (!it->name.empty()) {
+        model_name_map_.erase(it->name);
+    }
+
+    models_.erase(it);
+}
+
+// ============================================================
+// Skin Mesh Operations
+// ============================================================
+
+SkinMeshHandle ModelDataHandler::register_skin_mesh(const SkinMeshDescriptor& desc) {
+    SkinMeshEntry entry;
+    entry.handle       = next_skin_mesh_handle_++;
+    entry.name         = desc.name;
+    entry.vertex_count = desc.vertex_count;
+    entry.index_count  = desc.index_count;
+    entry.skin_weights = desc.skin_weights;
+    entry.morph_target_names = desc.morph_target_names;
+    entry.morph_deltas = desc.morph_deltas;
+
+    // Register the underlying vertex/index data with VertexDataUploader
+    MeshDataDescriptor mesh_desc;
+    mesh_desc.name            = desc.name;
+    mesh_desc.layout          = desc.layout;
+    mesh_desc.vertex_data     = desc.vertex_data;
+    mesh_desc.vertex_data_size = desc.vertex_data_size;
+    mesh_desc.vertex_count    = desc.vertex_count;
+    mesh_desc.index_data      = desc.index_data;
+    mesh_desc.index_data_size = desc.index_data_size;
+    mesh_desc.index_count     = desc.index_count;
+    mesh_desc.index_32bit     = desc.index_32bit;
+
+    entry.gpu_mesh = vertex_uploader_.register_mesh(mesh_desc);
+
+    if (!desc.name.empty()) {
+        skin_mesh_name_map_[desc.name] = entry.handle;
+    }
+
+    skin_meshes_.push_back(std::move(entry));
+    return skin_meshes_.back().handle;
+}
+
+void ModelDataHandler::unregister_skin_mesh(SkinMeshHandle handle) {
+    auto it = std::find_if(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+    if (it == skin_meshes_.end()) return;
+
+    if (it->gpu_mesh != INVALID_MESH) {
+        vertex_uploader_.unregister_mesh(it->gpu_mesh);
+    }
+
+    if (!it->name.empty()) {
+        skin_mesh_name_map_.erase(it->name);
+    }
+
+    skin_meshes_.erase(it);
+}
+
+MeshHandle ModelDataHandler::get_gpu_mesh(SkinMeshHandle handle) const {
+    auto it = std::find_if(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+    return (it != skin_meshes_.end()) ? it->gpu_mesh : INVALID_MESH;
+}
+
+const std::vector<SkinWeight>* ModelDataHandler::get_skin_weights(SkinMeshHandle handle) const {
+    auto it = std::find_if(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+    return (it != skin_meshes_.end()) ? &it->skin_weights : nullptr;
+}
+
+const std::vector<std::string>* ModelDataHandler::get_morph_target_names(SkinMeshHandle handle) const {
+    auto it = std::find_if(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+    return (it != skin_meshes_.end()) ? &it->morph_target_names : nullptr;
+}
+
+// ============================================================
+// Rig Operations
+// ============================================================
+
+RigHandle ModelDataHandler::register_rig(const RigDescriptor& desc) {
+    RigEntry entry;
+    entry.handle    = next_rig_handle_++;
+    entry.name      = desc.name;
+    entry.ik_chains = desc.ik_chains;
+
+    // Register skeleton in AnimationSystem
+    SkeletonDescriptor skel_desc;
+    skel_desc.name  = desc.name;
+    skel_desc.bones = desc.bones;
+    entry.skeleton = animation_system_.register_skeleton(skel_desc);
+
+    if (!desc.name.empty()) {
+        rig_name_map_[desc.name] = entry.handle;
+    }
+
+    rigs_.push_back(std::move(entry));
+    return rigs_.back().handle;
+}
+
+void ModelDataHandler::unregister_rig(RigHandle handle) {
+    auto it = std::find_if(rigs_.begin(), rigs_.end(),
+        [handle](const RigEntry& e) { return e.handle == handle; });
+    if (it == rigs_.end()) return;
+
+    if (it->skeleton != INVALID_SKELETON) {
+        animation_system_.unregister_skeleton(it->skeleton);
+    }
+
+    if (!it->name.empty()) {
+        rig_name_map_.erase(it->name);
+    }
+
+    rigs_.erase(it);
+}
+
+SkeletonHandle ModelDataHandler::get_skeleton(RigHandle handle) const {
+    auto it = std::find_if(rigs_.begin(), rigs_.end(),
+        [handle](const RigEntry& e) { return e.handle == handle; });
+    return (it != rigs_.end()) ? it->skeleton : INVALID_SKELETON;
+}
+
+const std::vector<IKChainDescriptor>* ModelDataHandler::get_ik_chains(RigHandle handle) const {
+    auto it = std::find_if(rigs_.begin(), rigs_.end(),
+        [handle](const RigEntry& e) { return e.handle == handle; });
+    return (it != rigs_.end()) ? &it->ik_chains : nullptr;
+}
+
+// ============================================================
+// Query
+// ============================================================
+
+bool ModelDataHandler::is_valid_model(ModelHandle handle) const {
+    return std::any_of(models_.begin(), models_.end(),
+        [handle](const ModelEntry& e) { return e.handle == handle; });
+}
+
+bool ModelDataHandler::is_valid_skin_mesh(SkinMeshHandle handle) const {
+    return std::any_of(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+}
+
+bool ModelDataHandler::is_valid_rig(RigHandle handle) const {
+    return std::any_of(rigs_.begin(), rigs_.end(),
+        [handle](const RigEntry& e) { return e.handle == handle; });
+}
+
+const ModelEntry* ModelDataHandler::get_model_entry(ModelHandle handle) const {
+    auto it = std::find_if(models_.begin(), models_.end(),
+        [handle](const ModelEntry& e) { return e.handle == handle; });
+    return (it != models_.end()) ? &(*it) : nullptr;
+}
+
+const SkinMeshEntry* ModelDataHandler::get_skin_mesh_entry(SkinMeshHandle handle) const {
+    auto it = std::find_if(skin_meshes_.begin(), skin_meshes_.end(),
+        [handle](const SkinMeshEntry& e) { return e.handle == handle; });
+    return (it != skin_meshes_.end()) ? &(*it) : nullptr;
+}
+
+const RigEntry* ModelDataHandler::get_rig_entry(RigHandle handle) const {
+    auto it = std::find_if(rigs_.begin(), rigs_.end(),
+        [handle](const RigEntry& e) { return e.handle == handle; });
+    return (it != rigs_.end()) ? &(*it) : nullptr;
+}
+
+ModelHandle ModelDataHandler::find_model_by_name(const std::string& name) const {
+    auto it = model_name_map_.find(name);
+    return (it != model_name_map_.end()) ? it->second : INVALID_MODEL;
+}
+
+SkinMeshHandle ModelDataHandler::find_skin_mesh_by_name(const std::string& name) const {
+    auto it = skin_mesh_name_map_.find(name);
+    return (it != skin_mesh_name_map_.end()) ? it->second : INVALID_SKIN_MESH;
+}
+
+RigHandle ModelDataHandler::find_rig_by_name(const std::string& name) const {
+    auto it = rig_name_map_.find(name);
+    return (it != rig_name_map_.end()) ? it->second : INVALID_RIG;
+}
+
+// ============================================================
+// Stats
+// ============================================================
+
+ModelDataHandler::Stats ModelDataHandler::get_stats() const {
+    Stats stats;
+    stats.model_count     = static_cast<uint32_t>(models_.size());
+    stats.skin_mesh_count = static_cast<uint32_t>(skin_meshes_.size());
+    stats.rig_count       = static_cast<uint32_t>(rigs_.size());
+
+    for (const auto& sm : skin_meshes_) {
+        stats.total_vertices += sm.vertex_count;
+        stats.total_indices  += sm.index_count;
+    }
+
+    for (const auto& rig : rigs_) {
+        if (rig.skeleton != INVALID_SKELETON) {
+            const Skeleton* skel = animation_system_.get_skeleton(rig.skeleton);
+            if (skel) {
+                stats.total_bones += skel->bone_count();
+            }
+        }
+    }
+
+    return stats;
+}
+
+// ============================================================
+// Format Detection
+// ============================================================
+
+ModelFormat ModelDataHandler::detect_format(const std::string& path) {
+    auto dot = path.rfind('.');
+    if (dot == std::string::npos) return ModelFormat::UNKNOWN;
+
+    std::string ext = path.substr(dot + 1);
+    // Convert to lowercase
+    for (auto& c : ext) {
+        if (c >= 'A' && c <= 'Z') c += 32;
+    }
+
+    if (ext == "fbx")                 return ModelFormat::FBX;
+    if (ext == "obj")                 return ModelFormat::OBJ;
+    if (ext == "pmx")                 return ModelFormat::MMD_PMX;
+    if (ext == "pmd")                 return ModelFormat::MMD_PMD;
+    if (ext == "gltf")                return ModelFormat::GLTF;
+    if (ext == "glb")                 return ModelFormat::GLB;
+    if (ext == "dae")                 return ModelFormat::COLLADA;
+    return ModelFormat::UNKNOWN;
+}
+
+ModelFormat ModelDataHandler::detect_format(const uint8_t* data, size_t size) {
+    if (!data || size < 4) return ModelFormat::UNKNOWN;
+
+    // FBX binary: starts with "Kaydara FBX Binary"
+    if (size >= 20 && std::memcmp(data, "Kaydara FBX Binary", 18) == 0) {
+        return ModelFormat::FBX;
+    }
+
+    // glTF binary (GLB): magic 0x46546C67
+    if (size >= 4 && data[0] == 0x67 && data[1] == 0x6C &&
+        data[2] == 0x54 && data[3] == 0x46) {
+        return ModelFormat::GLB;
+    }
+
+    // PMX: magic "PMX "
+    if (size >= 4 && data[0] == 'P' && data[1] == 'M' &&
+        data[2] == 'X' && data[3] == ' ') {
+        return ModelFormat::MMD_PMX;
+    }
+
+    // PMD: magic "Pmd"
+    if (size >= 3 && data[0] == 'P' && data[1] == 'm' && data[2] == 'd') {
+        return ModelFormat::MMD_PMD;
+    }
+
+    return ModelFormat::UNKNOWN;
+}
+
+} // namespace pictor


### PR DESCRIPTION
## Summary
Introduces a new `ModelDataHandler` system for managing 3D model resources (FBX, OBJ, MMD, glTF, etc.). This handler manages the lifecycle of skin meshes, bone rigs, and animation clips, coordinating with the `VertexDataUploader` for GPU mesh data and `AnimationSystem` for skeletal animation.

## Key Changes

- **New ModelDataHandler class** (`include/pictor/data/model_data_handler.h`, `src/data/model_data_handler.cpp`)
  - Registers/unregisters complete 3D models with their constituent skin meshes, rigs, and animation clips
  - Provides query APIs for model entries, skin weights, morph targets, and skeleton data
  - Supports name-based lookup via internal hash maps
  - Includes statistics collection (vertex/index/bone counts)

- **New model data types** (`include/pictor/data/model_data_types.h`)
  - Handle types: `ModelHandle`, `SkinMeshHandle`, `RigHandle`
  - Descriptors: `ModelDescriptor`, `SkinMeshDescriptor`, `RigDescriptor`
  - Entry structures for bookkeeping registered resources
  - `ModelFormat` enum supporting FBX, OBJ, MMD (PMX/PMD), glTF, GLB, and COLLADA
  - `SkinWeight` structure for per-vertex bone influences

- **Format detection utilities**
  - Extension-based detection via file path
  - Binary magic number detection from file headers (FBX, GLB, PMX, PMD)

- **Integration with existing systems**
  - `DataHandler` now owns and exposes `ModelDataHandler` via `register_model()`/`unregister_model()`
  - `PictorRenderer` delegates model registration to `DataHandler`
  - `AnimationSystem` initialization moved earlier in renderer setup (required dependency for `DataHandler`)

- **Public API exposure**
  - Added model registration methods to `PictorRenderer`
  - Exported new types and handler in main `pictor.h` header

## Implementation Details

- Uses vector-based storage with linear search for handle validation (suitable for typical model counts)
- Maintains separate name maps for O(1) name-based lookups
- Properly cascades unregistration: models → skin meshes/rigs → GPU meshes/skeletons
- Integrates with `VertexDataUploader` for GPU mesh management and `AnimationSystem` for skeleton/clip management
- Supports morph targets (blend shapes) and IK chains as part of model data

https://claude.ai/code/session_01QBa95MeKdKKgBVJib3tESk