### PR TITLE
fix: UTF-8 BOM 付与と /utf-8 フラグで MSVC 文字コード警告を解消

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     target_compile_options(pictor PRIVATE -Wall -Wextra -mavx2)
 elseif(MSVC)
     target_compile_options(pictor PRIVATE /W4 /arch:AVX2)
+    add_compile_options(/utf-8)
 endif()
 
 if(glfw3_FOUND)

--- a/demo/benchmark/main.cpp
+++ b/demo/benchmark/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor 1M Spheres Benchmark (§14)
+﻿/// Pictor 1M Spheres Benchmark (§14)
 ///
 /// Stress test: 1,000,000 independent spheres moving on 3D Lissajous curves.
 /// All updates via GPU Compute Shader. CPU frame time target: < 0.5ms.

--- a/demo/graphics/main.cpp
+++ b/demo/graphics/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor Graphics Demo — PBR + Shadow + GI
+﻿/// Pictor Graphics Demo — PBR + Shadow + GI
 ///
 /// Demonstrates:
 ///   - PBR metallic cube (high metalness Cook-Torrance BRDF)

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor Vulkan Window Demo
+﻿/// Pictor Vulkan Window Demo
 ///
 /// Opens a GLFW window, initializes a Vulkan swapchain via
 /// the ISurfaceProvider abstraction, and renders a clear-color

--- a/demo/ocean/main.cpp
+++ b/demo/ocean/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor Ocean Demo — Tessellation + Gerstner Waves
+﻿/// Pictor Ocean Demo — Tessellation + Gerstner Waves
 ///
 /// Demonstrates:
 ///   - Hardware tessellation (TCS + TES) for adaptive LOD

--- a/demo/postprocess/main.cpp
+++ b/demo/postprocess/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor Post-Process Demo
+﻿/// Pictor Post-Process Demo
 ///
 /// Demonstrates the post-processing pipeline with:
 ///   - HDR rendering with bright emissive objects (for bloom)

--- a/demo/text/main.cpp
+++ b/demo/text/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor Text Rendering Demo
+﻿/// Pictor Text Rendering Demo
 ///
 /// Demonstrates two text rendering approaches:
 ///

--- a/demo/texture2d/main.cpp
+++ b/demo/texture2d/main.cpp
@@ -1,4 +1,4 @@
-/// Pictor 2D Texture Rendering Demo
+﻿/// Pictor 2D Texture Rendering Demo
 ///
 /// Loads sample1-5.png textures and renders them as 2D quads.
 /// Controls:

--- a/demo/texture2d/texture2d_renderer.cpp
+++ b/demo/texture2d/texture2d_renderer.cpp
@@ -1,4 +1,4 @@
-#include "texture2d_renderer.h"
+﻿#include "texture2d_renderer.h"
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/demo/webgl/main.cpp
+++ b/demo/webgl/main.cpp
@@ -1,4 +1,4 @@
-#ifdef PICTOR_HAS_WEBGL
+﻿#ifdef PICTOR_HAS_WEBGL
 
 #include "pictor/webgl/webgl_renderer.h"
 #include <emscripten.h>

--- a/include/pictor/animation/animation_2d.h
+++ b/include/pictor/animation/animation_2d.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <vector>

--- a/include/pictor/animation/animation_clip.h
+++ b/include/pictor/animation/animation_clip.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <algorithm>

--- a/include/pictor/animation/animation_system.h
+++ b/include/pictor/animation/animation_system.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include "pictor/animation/animation_clip.h"

--- a/include/pictor/animation/animation_types.h
+++ b/include/pictor/animation/animation_types.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include <cstdint>

--- a/include/pictor/animation/bvh_importer.h
+++ b/include/pictor/animation/bvh_importer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include "pictor/animation/animation_clip.h"

--- a/include/pictor/animation/fbx_importer.h
+++ b/include/pictor/animation/fbx_importer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include "pictor/animation/animation_clip.h"

--- a/include/pictor/animation/ik_solver.h
+++ b/include/pictor/animation/ik_solver.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include "pictor/animation/skeleton.h"

--- a/include/pictor/animation/lottie_animation.h
+++ b/include/pictor/animation/lottie_animation.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <string>

--- a/include/pictor/animation/motion_estimator.h
+++ b/include/pictor/animation/motion_estimator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include "pictor/animation/animation_clip.h"

--- a/include/pictor/animation/rive_animation.h
+++ b/include/pictor/animation/rive_animation.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <string>

--- a/include/pictor/animation/skeleton.h
+++ b/include/pictor/animation/skeleton.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <vector>

--- a/include/pictor/animation/vector_animation.h
+++ b/include/pictor/animation/vector_animation.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/animation/animation_types.h"
 #include <vector>

--- a/include/pictor/batch/batch_builder.h
+++ b/include/pictor/batch/batch_builder.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/batch/radix_sort.h"

--- a/include/pictor/batch/radix_sort.h
+++ b/include/pictor/batch/radix_sort.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include <cstddef>

--- a/include/pictor/core/pictor_renderer.h
+++ b/include/pictor/core/pictor_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/memory_subsystem.h"

--- a/include/pictor/core/types.h
+++ b/include/pictor/core/types.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include <cstddef>

--- a/include/pictor/culling/flat_bvh.h
+++ b/include/pictor/culling/flat_bvh.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/pool_allocator.h"

--- a/include/pictor/data/data_handler.h
+++ b/include/pictor/data/data_handler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/data/texture_registry.h"
 #include "pictor/data/vertex_data_uploader.h"

--- a/include/pictor/data/data_query_api.h
+++ b/include/pictor/data/data_query_api.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/data/data_handler.h"
 #include <string>

--- a/include/pictor/data/model_data_handler.h
+++ b/include/pictor/data/model_data_handler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/data/model_data_types.h"
 #include "pictor/data/vertex_data_uploader.h"

--- a/include/pictor/data/model_data_types.h
+++ b/include/pictor/data/model_data_types.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/data/vertex_data_uploader.h"

--- a/include/pictor/data/texture_registry.h
+++ b/include/pictor/data/texture_registry.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/gpu_memory_allocator.h"

--- a/include/pictor/data/vertex_data_uploader.h
+++ b/include/pictor/data/vertex_data_uploader.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/gpu/gpu_buffer_manager.h"

--- a/include/pictor/gi/gi_bake.h
+++ b/include/pictor/gi/gi_bake.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/gpu/gpu_buffer_manager.h"

--- a/include/pictor/gi/gi_lighting_system.h
+++ b/include/pictor/gi/gi_lighting_system.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/gpu/gpu_buffer_manager.h"

--- a/include/pictor/gpu/gpu_buffer_manager.h
+++ b/include/pictor/gpu/gpu_buffer_manager.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/gpu_memory_allocator.h"

--- a/include/pictor/gpu/gpu_driven_pipeline.h
+++ b/include/pictor/gpu/gpu_driven_pipeline.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/gpu/gpu_buffer_manager.h"

--- a/include/pictor/material/base_material_builder.h
+++ b/include/pictor/material/base_material_builder.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/material/material_property.h"
 #include <array>

--- a/include/pictor/material/material_property.h
+++ b/include/pictor/material/material_property.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include <cstdint>

--- a/include/pictor/memory/frame_allocator.h
+++ b/include/pictor/memory/frame_allocator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstddef>
 #include <cstdint>

--- a/include/pictor/memory/gpu_memory_allocator.h
+++ b/include/pictor/memory/gpu_memory_allocator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstddef>
 #include <cstdint>

--- a/include/pictor/memory/memory_subsystem.h
+++ b/include/pictor/memory/memory_subsystem.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/memory/frame_allocator.h"
 #include "pictor/memory/pool_allocator.h"

--- a/include/pictor/memory/pool_allocator.h
+++ b/include/pictor/memory/pool_allocator.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstddef>
 #include <cstdint>

--- a/include/pictor/pictor.h
+++ b/include/pictor/pictor.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 // Pictor — Rendering Pipeline Module v2.1
 // Data-Driven, GPU-Optimized Rendering Architecture

--- a/include/pictor/pipeline/command_encoder.h
+++ b/include/pictor/pipeline/command_encoder.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/batch/batch_builder.h"

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/memory_subsystem.h"

--- a/include/pictor/pipeline/render_pass_scheduler.h
+++ b/include/pictor/pipeline/render_pass_scheduler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/pipeline/pipeline_profile.h"

--- a/include/pictor/postprocess/bloom_effect.h
+++ b/include/pictor/postprocess/bloom_effect.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/postprocess/postprocess_effect.h"
 

--- a/include/pictor/postprocess/depth_of_field_effect.h
+++ b/include/pictor/postprocess/depth_of_field_effect.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/postprocess/postprocess_effect.h"
 

--- a/include/pictor/postprocess/gaussian_blur_effect.h
+++ b/include/pictor/postprocess/gaussian_blur_effect.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/postprocess/postprocess_effect.h"
 

--- a/include/pictor/postprocess/postprocess_effect.h
+++ b/include/pictor/postprocess/postprocess_effect.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include <string>

--- a/include/pictor/postprocess/postprocess_pipeline.h
+++ b/include/pictor/postprocess/postprocess_pipeline.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/postprocess/postprocess_effect.h"
 #include "pictor/postprocess/bloom_effect.h"

--- a/include/pictor/postprocess/tone_mapping_effect.h
+++ b/include/pictor/postprocess/tone_mapping_effect.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/postprocess/postprocess_effect.h"
 

--- a/include/pictor/profiler/bitmap_font.h
+++ b/include/pictor/profiler/bitmap_font.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 

--- a/include/pictor/profiler/bitmap_text_renderer.h
+++ b/include/pictor/profiler/bitmap_text_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/include/pictor/profiler/cpu_timer.h
+++ b/include/pictor/profiler/cpu_timer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <chrono>
 #include <cstdint>

--- a/include/pictor/profiler/data_exporter.h
+++ b/include/pictor/profiler/data_exporter.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/profiler/profiler.h"
 #include <string>

--- a/include/pictor/profiler/gpu_timer.h
+++ b/include/pictor/profiler/gpu_timer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include <vector>

--- a/include/pictor/profiler/overlay_renderer.h
+++ b/include/pictor/profiler/overlay_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/profiler/profiler.h"

--- a/include/pictor/profiler/profiler.h
+++ b/include/pictor/profiler/profiler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/profiler/cpu_timer.h"

--- a/include/pictor/profiler/stats_overlay.h
+++ b/include/pictor/profiler/stats_overlay.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/profiler/profiler.h"

--- a/include/pictor/scene/object_classifier.h
+++ b/include/pictor/scene/object_classifier.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 

--- a/include/pictor/scene/object_pool.h
+++ b/include/pictor/scene/object_pool.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/scene/soa_stream.h"

--- a/include/pictor/scene/scene_registry.h
+++ b/include/pictor/scene/scene_registry.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/scene/object_pool.h"

--- a/include/pictor/scene/soa_stream.h
+++ b/include/pictor/scene/soa_stream.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/memory/pool_allocator.h"

--- a/include/pictor/surface/glfw_surface_provider.h
+++ b/include/pictor/surface/glfw_surface_provider.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/surface/surface_provider.h"
 #include <string>

--- a/include/pictor/surface/simple_renderer.h
+++ b/include/pictor/surface/simple_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/include/pictor/surface/surface_provider.h
+++ b/include/pictor/surface/surface_provider.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 

--- a/include/pictor/surface/vulkan_context.h
+++ b/include/pictor/surface/vulkan_context.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/surface/surface_provider.h"
 #include <cstdint>

--- a/include/pictor/text/font_loader.h
+++ b/include/pictor/text/font_loader.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/text/text_types.h"
 #include <string>

--- a/include/pictor/text/text_image_renderer.h
+++ b/include/pictor/text/text_image_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/text/text_types.h"
 #include "pictor/text/font_loader.h"

--- a/include/pictor/text/text_rasterizer.h
+++ b/include/pictor/text/text_rasterizer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/text/text_types.h"
 #include "pictor/text/font_loader.h"

--- a/include/pictor/text/text_svg_renderer.h
+++ b/include/pictor/text/text_svg_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/text/text_types.h"
 #include "pictor/text/font_loader.h"

--- a/include/pictor/text/text_types.h
+++ b/include/pictor/text/text_types.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include <cstdint>

--- a/include/pictor/update/job_dispatcher.h
+++ b/include/pictor/update/job_dispatcher.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include <cstdint>
 #include <functional>

--- a/include/pictor/update/update_scheduler.h
+++ b/include/pictor/update/update_scheduler.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "pictor/core/types.h"
 #include "pictor/update/job_dispatcher.h"

--- a/include/pictor/webgl/webgl_buffer.h
+++ b/include/pictor/webgl/webgl_buffer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_WEBGL
 

--- a/include/pictor/webgl/webgl_context.h
+++ b/include/pictor/webgl/webgl_context.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_WEBGL
 

--- a/include/pictor/webgl/webgl_renderer.h
+++ b/include/pictor/webgl/webgl_renderer.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_WEBGL
 

--- a/include/pictor/webgl/webgl_shader.h
+++ b/include/pictor/webgl/webgl_shader.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #ifdef PICTOR_HAS_WEBGL
 

--- a/src/animation/animation_2d.cpp
+++ b/src/animation/animation_2d.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/animation_2d.h"
+﻿#include "pictor/animation/animation_2d.h"
 #include <cmath>
 #include <algorithm>
 

--- a/src/animation/animation_clip.cpp
+++ b/src/animation/animation_clip.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/animation_clip.h"
+﻿#include "pictor/animation/animation_clip.h"
 #include <cmath>
 #include <algorithm>
 

--- a/src/animation/animation_system.cpp
+++ b/src/animation/animation_system.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/animation_system.h"
+﻿#include "pictor/animation/animation_system.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/animation/bvh_importer.cpp
+++ b/src/animation/bvh_importer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/bvh_importer.h"
+﻿#include "pictor/animation/bvh_importer.h"
 #include <fstream>
 #include <sstream>
 #include <cstring>

--- a/src/animation/fbx_importer.cpp
+++ b/src/animation/fbx_importer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/fbx_importer.h"
+﻿#include "pictor/animation/fbx_importer.h"
 #include <fstream>
 #include <cstring>
 #include <sstream>

--- a/src/animation/ik_solver.cpp
+++ b/src/animation/ik_solver.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/ik_solver.h"
+﻿#include "pictor/animation/ik_solver.h"
 #include <cmath>
 #include <algorithm>
 

--- a/src/animation/lottie_animation.cpp
+++ b/src/animation/lottie_animation.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/lottie_animation.h"
+﻿#include "pictor/animation/lottie_animation.h"
 #include <fstream>
 #include <cstring>
 #include <cmath>

--- a/src/animation/motion_estimator.cpp
+++ b/src/animation/motion_estimator.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/motion_estimator.h"
+﻿#include "pictor/animation/motion_estimator.h"
 #include <cmath>
 #include <algorithm>
 

--- a/src/animation/rive_animation.cpp
+++ b/src/animation/rive_animation.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/rive_animation.h"
+﻿#include "pictor/animation/rive_animation.h"
 #include <fstream>
 #include <cstring>
 #include <algorithm>

--- a/src/animation/skeleton.cpp
+++ b/src/animation/skeleton.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/skeleton.h"
+﻿#include "pictor/animation/skeleton.h"
 
 namespace pictor {
 

--- a/src/animation/vector_animation.cpp
+++ b/src/animation/vector_animation.cpp
@@ -1,4 +1,4 @@
-#include "pictor/animation/vector_animation.h"
+﻿#include "pictor/animation/vector_animation.h"
 #include <cmath>
 #include <cstring>
 #include <algorithm>

--- a/src/batch/batch_builder.cpp
+++ b/src/batch/batch_builder.cpp
@@ -1,4 +1,4 @@
-#include "pictor/batch/batch_builder.h"
+﻿#include "pictor/batch/batch_builder.h"
 
 namespace pictor {
 

--- a/src/batch/radix_sort.cpp
+++ b/src/batch/radix_sort.cpp
@@ -1,4 +1,4 @@
-#include "pictor/batch/radix_sort.h"
+﻿#include "pictor/batch/radix_sort.h"
 #include "pictor/memory/frame_allocator.h"
 #include <cstring>
 

--- a/src/core/pictor_renderer.cpp
+++ b/src/core/pictor_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/core/pictor_renderer.h"
+﻿#include "pictor/core/pictor_renderer.h"
 
 namespace pictor {
 

--- a/src/core/types.cpp
+++ b/src/core/types.cpp
@@ -1,4 +1,4 @@
-#include "pictor/core/types.h"
+﻿#include "pictor/core/types.h"
 
 // Type definitions are header-only.
 // This translation unit ensures the types header compiles cleanly

--- a/src/culling/flat_bvh.cpp
+++ b/src/culling/flat_bvh.cpp
@@ -1,4 +1,4 @@
-#include "pictor/culling/flat_bvh.h"
+﻿#include "pictor/culling/flat_bvh.h"
 #include <algorithm>
 #include <numeric>
 #include <cstring>

--- a/src/culling/frustum_culler.cpp
+++ b/src/culling/frustum_culler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/culling/culling_system.h"
+﻿#include "pictor/culling/culling_system.h"
 #include <cmath>
 
 // Frustum culling helper functions.

--- a/src/data/data_handler.cpp
+++ b/src/data/data_handler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/data/data_handler.h"
+﻿#include "pictor/data/data_handler.h"
 
 namespace pictor {
 

--- a/src/data/data_query_api.cpp
+++ b/src/data/data_query_api.cpp
@@ -1,4 +1,4 @@
-#include "pictor/data/data_query_api.h"
+﻿#include "pictor/data/data_query_api.h"
 #include <sstream>
 
 namespace pictor {

--- a/src/data/model_data_handler.cpp
+++ b/src/data/model_data_handler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/data/model_data_handler.h"
+﻿#include "pictor/data/model_data_handler.h"
 #include <algorithm>
 #include <cstring>
 

--- a/src/data/texture_registry.cpp
+++ b/src/data/texture_registry.cpp
@@ -1,4 +1,4 @@
-#include "pictor/data/texture_registry.h"
+﻿#include "pictor/data/texture_registry.h"
 
 namespace pictor {
 

--- a/src/data/vertex_data_uploader.cpp
+++ b/src/data/vertex_data_uploader.cpp
@@ -1,4 +1,4 @@
-#include "pictor/data/vertex_data_uploader.h"
+﻿#include "pictor/data/vertex_data_uploader.h"
 
 namespace pictor {
 

--- a/src/gi/gi_bake.cpp
+++ b/src/gi/gi_bake.cpp
@@ -1,4 +1,4 @@
-#include "pictor/gi/gi_bake.h"
+﻿#include "pictor/gi/gi_bake.h"
 #include <cmath>
 #include <algorithm>
 #include <chrono>

--- a/src/gi/gi_lighting_system.cpp
+++ b/src/gi/gi_lighting_system.cpp
@@ -1,4 +1,4 @@
-#include "pictor/gi/gi_lighting_system.h"
+﻿#include "pictor/gi/gi_lighting_system.h"
 #include <cmath>
 #include <algorithm>
 #include <cstring>

--- a/src/gpu/gpu_buffer_manager.cpp
+++ b/src/gpu/gpu_buffer_manager.cpp
@@ -1,4 +1,4 @@
-#include "pictor/gpu/gpu_buffer_manager.h"
+﻿#include "pictor/gpu/gpu_buffer_manager.h"
 
 namespace pictor {
 

--- a/src/gpu/gpu_driven_pipeline.cpp
+++ b/src/gpu/gpu_driven_pipeline.cpp
@@ -1,4 +1,4 @@
-#include "pictor/gpu/gpu_driven_pipeline.h"
+﻿#include "pictor/gpu/gpu_driven_pipeline.h"
 
 namespace pictor {
 

--- a/src/material/base_material_builder.cpp
+++ b/src/material/base_material_builder.cpp
@@ -1,4 +1,4 @@
-#include "pictor/material/base_material_builder.h"
+﻿#include "pictor/material/base_material_builder.h"
 #include <algorithm>
 #include <functional>
 

--- a/src/memory/frame_allocator.cpp
+++ b/src/memory/frame_allocator.cpp
@@ -1,4 +1,4 @@
-#include "pictor/memory/frame_allocator.h"
+﻿#include "pictor/memory/frame_allocator.h"
 #include <cstdlib>
 #include <algorithm>
 #include <new>

--- a/src/memory/gpu_memory_allocator.cpp
+++ b/src/memory/gpu_memory_allocator.cpp
@@ -1,4 +1,4 @@
-#include "pictor/memory/gpu_memory_allocator.h"
+﻿#include "pictor/memory/gpu_memory_allocator.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/memory/memory_subsystem.cpp
+++ b/src/memory/memory_subsystem.cpp
@@ -1,4 +1,4 @@
-#include "pictor/memory/memory_subsystem.h"
+﻿#include "pictor/memory/memory_subsystem.h"
 
 namespace pictor {
 

--- a/src/memory/pool_allocator.cpp
+++ b/src/memory/pool_allocator.cpp
@@ -1,4 +1,4 @@
-#include "pictor/memory/pool_allocator.h"
+﻿#include "pictor/memory/pool_allocator.h"
 #include <cstdlib>
 #include <cstring>
 #include <algorithm>

--- a/src/pipeline/command_encoder.cpp
+++ b/src/pipeline/command_encoder.cpp
@@ -1,4 +1,4 @@
-#include "pictor/pipeline/command_encoder.h"
+﻿#include "pictor/pipeline/command_encoder.h"
 
 namespace pictor {
 

--- a/src/pipeline/pipeline_profile.cpp
+++ b/src/pipeline/pipeline_profile.cpp
@@ -1,4 +1,4 @@
-#include "pictor/pipeline/pipeline_profile.h"
+﻿#include "pictor/pipeline/pipeline_profile.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/pipeline/render_pass_scheduler.cpp
+++ b/src/pipeline/render_pass_scheduler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/pipeline/render_pass_scheduler.h"
+﻿#include "pictor/pipeline/render_pass_scheduler.h"
 
 namespace pictor {
 

--- a/src/postprocess/bloom_effect.cpp
+++ b/src/postprocess/bloom_effect.cpp
@@ -1,4 +1,4 @@
-#include "pictor/postprocess/bloom_effect.h"
+﻿#include "pictor/postprocess/bloom_effect.h"
 #include <algorithm>
 #include <cmath>
 

--- a/src/postprocess/depth_of_field_effect.cpp
+++ b/src/postprocess/depth_of_field_effect.cpp
@@ -1,4 +1,4 @@
-#include "pictor/postprocess/depth_of_field_effect.h"
+﻿#include "pictor/postprocess/depth_of_field_effect.h"
 #include <algorithm>
 #include <cmath>
 

--- a/src/postprocess/gaussian_blur_effect.cpp
+++ b/src/postprocess/gaussian_blur_effect.cpp
@@ -1,4 +1,4 @@
-#include "pictor/postprocess/gaussian_blur_effect.h"
+﻿#include "pictor/postprocess/gaussian_blur_effect.h"
 #include <algorithm>
 #include <cmath>
 

--- a/src/postprocess/postprocess_pipeline.cpp
+++ b/src/postprocess/postprocess_pipeline.cpp
@@ -1,4 +1,4 @@
-#include "pictor/postprocess/postprocess_pipeline.h"
+﻿#include "pictor/postprocess/postprocess_pipeline.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/postprocess/tone_mapping_effect.cpp
+++ b/src/postprocess/tone_mapping_effect.cpp
@@ -1,4 +1,4 @@
-#include "pictor/postprocess/tone_mapping_effect.h"
+﻿#include "pictor/postprocess/tone_mapping_effect.h"
 #include <cmath>
 
 namespace pictor {

--- a/src/profiler/bitmap_text_renderer.cpp
+++ b/src/profiler/bitmap_text_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/bitmap_text_renderer.h"
+﻿#include "pictor/profiler/bitmap_text_renderer.h"
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/src/profiler/cpu_timer.cpp
+++ b/src/profiler/cpu_timer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/cpu_timer.h"
+﻿#include "pictor/profiler/cpu_timer.h"
 
 // CpuTimer and ScopedCpuTimer are fully inline (header-only).
 // This translation unit ensures the header compiles cleanly.

--- a/src/profiler/data_exporter.cpp
+++ b/src/profiler/data_exporter.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/data_exporter.h"
+﻿#include "pictor/profiler/data_exporter.h"
 #include <sstream>
 #include <iomanip>
 

--- a/src/profiler/gpu_timer.cpp
+++ b/src/profiler/gpu_timer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/gpu_timer.h"
+﻿#include "pictor/profiler/gpu_timer.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/profiler/overlay_renderer.cpp
+++ b/src/profiler/overlay_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/overlay_renderer.h"
+﻿#include "pictor/profiler/overlay_renderer.h"
 #include <cstdio>
 
 namespace pictor {

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/profiler.h"
+﻿#include "pictor/profiler/profiler.h"
 #include <numeric>
 #include <algorithm>
 

--- a/src/profiler/stats_overlay.cpp
+++ b/src/profiler/stats_overlay.cpp
@@ -1,4 +1,4 @@
-#include "pictor/profiler/stats_overlay.h"
+﻿#include "pictor/profiler/stats_overlay.h"
 #include <cstdio>
 #include <cstring>
 

--- a/src/scene/object_classifier.cpp
+++ b/src/scene/object_classifier.cpp
@@ -1,4 +1,4 @@
-#include "pictor/scene/object_classifier.h"
+﻿#include "pictor/scene/object_classifier.h"
 
 namespace pictor {
 

--- a/src/scene/object_pool.cpp
+++ b/src/scene/object_pool.cpp
@@ -1,4 +1,4 @@
-#include "pictor/scene/object_pool.h"
+﻿#include "pictor/scene/object_pool.h"
 
 namespace pictor {
 

--- a/src/scene/scene_registry.cpp
+++ b/src/scene/scene_registry.cpp
@@ -1,4 +1,4 @@
-#include "pictor/scene/scene_registry.h"
+﻿#include "pictor/scene/scene_registry.h"
 
 namespace pictor {
 

--- a/src/scene/soa_stream.cpp
+++ b/src/scene/soa_stream.cpp
@@ -1,4 +1,4 @@
-#include "pictor/scene/soa_stream.h"
+﻿#include "pictor/scene/soa_stream.h"
 
 // SoAStream is fully template-based (header-only).
 // This translation unit ensures the header compiles cleanly.

--- a/src/surface/glfw_surface_provider.cpp
+++ b/src/surface/glfw_surface_provider.cpp
@@ -1,4 +1,4 @@
-#include "pictor/surface/glfw_surface_provider.h"
+﻿#include "pictor/surface/glfw_surface_provider.h"
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/src/surface/simple_renderer.cpp
+++ b/src/surface/simple_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/surface/simple_renderer.h"
+﻿#include "pictor/surface/simple_renderer.h"
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -1,4 +1,4 @@
-#include "pictor/surface/vulkan_context.h"
+﻿#include "pictor/surface/vulkan_context.h"
 
 #ifdef PICTOR_HAS_VULKAN
 

--- a/src/text/font_loader.cpp
+++ b/src/text/font_loader.cpp
@@ -1,4 +1,4 @@
-#include "pictor/text/font_loader.h"
+﻿#include "pictor/text/font_loader.h"
 #include <fstream>
 #include <cstring>
 #include <algorithm>

--- a/src/text/text_image_renderer.cpp
+++ b/src/text/text_image_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/text/text_image_renderer.h"
+﻿#include "pictor/text/text_image_renderer.h"
 #include <algorithm>
 #include <cmath>
 #include <cstring>

--- a/src/text/text_rasterizer.cpp
+++ b/src/text/text_rasterizer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/text/text_rasterizer.h"
+﻿#include "pictor/text/text_rasterizer.h"
 #include <algorithm>
 #include <cmath>
 #include <cstring>

--- a/src/text/text_svg_renderer.cpp
+++ b/src/text/text_svg_renderer.cpp
@@ -1,4 +1,4 @@
-#include "pictor/text/text_svg_renderer.h"
+﻿#include "pictor/text/text_svg_renderer.h"
 #include <cmath>
 #include <sstream>
 #include <iomanip>

--- a/src/update/job_dispatcher.cpp
+++ b/src/update/job_dispatcher.cpp
@@ -1,4 +1,4 @@
-#include "pictor/update/job_dispatcher.h"
+﻿#include "pictor/update/job_dispatcher.h"
 #include <algorithm>
 
 namespace pictor {

--- a/src/update/update_scheduler.cpp
+++ b/src/update/update_scheduler.cpp
@@ -1,4 +1,4 @@
-#include "pictor/update/update_scheduler.h"
+﻿#include "pictor/update/update_scheduler.h"
 #include <cstring>
 
 #ifdef __AVX2__

--- a/src/webgl/webgl_buffer.cpp
+++ b/src/webgl/webgl_buffer.cpp
@@ -1,4 +1,4 @@
-#ifdef PICTOR_HAS_WEBGL
+﻿#ifdef PICTOR_HAS_WEBGL
 
 #include "pictor/webgl/webgl_buffer.h"
 #include <cstdio>

--- a/src/webgl/webgl_context.cpp
+++ b/src/webgl/webgl_context.cpp
@@ -1,4 +1,4 @@
-#ifdef PICTOR_HAS_WEBGL
+﻿#ifdef PICTOR_HAS_WEBGL
 
 #include "pictor/webgl/webgl_context.h"
 #include <emscripten.h>

--- a/src/webgl/webgl_renderer.cpp
+++ b/src/webgl/webgl_renderer.cpp
@@ -1,4 +1,4 @@
-#ifdef PICTOR_HAS_WEBGL
+﻿#ifdef PICTOR_HAS_WEBGL
 
 #include "pictor/webgl/webgl_renderer.h"
 #include <cmath>

--- a/src/webgl/webgl_shader.cpp
+++ b/src/webgl/webgl_shader.cpp
@@ -1,4 +1,4 @@
-#ifdef PICTOR_HAS_WEBGL
+﻿#ifdef PICTOR_HAS_WEBGL
 
 #include "pictor/webgl/webgl_shader.h"
 #include <cstdio>

--- a/third_party/stb/stb_image.h
+++ b/third_party/stb/stb_image.h
@@ -1,4 +1,4 @@
-/* stb_image - v2.30 - public domain image loader - http://nothings.org/stb
+﻿/* stb_image - v2.30 - public domain image loader - http://nothings.org/stb
                                   no warranty implied; use at your own risk
 
    Do this:

--- a/third_party/stb/stb_image_impl.cpp
+++ b/third_party/stb/stb_image_impl.cpp
@@ -1,2 +1,2 @@
-#define STB_IMAGE_IMPLEMENTATION
+﻿#define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"


### PR DESCRIPTION
## Summary
- 全144ソースファイル (.h/.cpp) に UTF-8 BOM (EF BB BF) を付与し、MSVC のソース文字セット誤認を防止
- CMakeLists.txt に MSVC 向け `/utf-8` コンパイルフラグを追加し、C4566 警告 (U+2014 em dash 等が CP932 で表示不可) を解消

## Test plan
- [x] `cmake --build build` で C4566 警告が出ないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)