### PR TITLE
feat(animation): FBX Importer (Level 4) + ModelDataHandler wiring + demo #30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,10 @@ if(PICTOR_BUILD_DEMO)
     add_executable(pictor_benchmark demo/benchmark/main.cpp)
     target_link_libraries(pictor_benchmark PRIVATE pictor)
 
+    # FBX loading + animation demo (headless, console output)
+    add_executable(pictor_fbx_demo demo/fbx/main.cpp)
+    target_link_libraries(pictor_fbx_demo PRIVATE pictor)
+
     if(Vulkan_FOUND AND glfw3_FOUND)
         # Vulkan window demo
         add_executable(pictor_demo demo/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(pictor STATIC
     src/animation/motion_estimator.cpp
     src/animation/fbx_importer.cpp
     src/animation/fbx_document.cpp
+    src/animation/fbx_scene.cpp
     src/animation/bvh_importer.cpp
     src/animation/animation_2d.cpp
     src/animation/rive_animation.cpp

--- a/demo/fbx/main.cpp
+++ b/demo/fbx/main.cpp
@@ -1,0 +1,256 @@
+﻿// Pictor FBX Demo
+//
+// Demonstrates the full FBX pipeline:
+//   1. FBXImporter::import_file() -> FBXImportResult (Level 1 + 2+3 + 4)
+//   2. Register skeleton + clips with AnimationSystem
+//   3. Create an animation instance and play the first clip
+//   4. Sample bone transforms over time and print them
+//
+// Usage:
+//   pictor_fbx_demo <path-to-model.fbx>
+//
+// If no file path is provided, the demo synthesizes a minimal skeleton
+// + animation so that the pipeline can be exercised headlessly.
+
+#include "pictor/animation/fbx_importer.h"
+#include "pictor/animation/fbx_scene.h"
+#include "pictor/animation/animation_system.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace pictor;
+
+namespace {
+
+const char* format_name(AnimationFormat f) {
+    switch (f) {
+        case AnimationFormat::FBX_BINARY: return "FBX binary";
+        case AnimationFormat::FBX_ASCII:  return "FBX ASCII";
+        default:                          return "unknown";
+    }
+}
+
+const char* object_type_name(FBXObjectType t) {
+    switch (t) {
+        case FBXObjectType::GLOBAL_SETTINGS:             return "GlobalSettings";
+        case FBXObjectType::MODEL:                       return "Model";
+        case FBXObjectType::GEOMETRY:                    return "Geometry";
+        case FBXObjectType::MATERIAL:                    return "Material";
+        case FBXObjectType::TEXTURE:                     return "Texture";
+        case FBXObjectType::VIDEO:                       return "Video";
+        case FBXObjectType::DEFORMER_SKIN:               return "Skin";
+        case FBXObjectType::DEFORMER_CLUSTER:            return "Cluster";
+        case FBXObjectType::DEFORMER_BLENDSHAPE:         return "BlendShape";
+        case FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL: return "BlendShapeChannel";
+        case FBXObjectType::SHAPE_GEOMETRY:              return "Shape";
+        case FBXObjectType::POSE:                        return "Pose";
+        case FBXObjectType::ANIMATION_STACK:             return "AnimStack";
+        case FBXObjectType::ANIMATION_LAYER:             return "AnimLayer";
+        case FBXObjectType::ANIMATION_CURVE_NODE:        return "AnimCurveNode";
+        case FBXObjectType::ANIMATION_CURVE:             return "AnimCurve";
+        case FBXObjectType::NODE_ATTRIBUTE:              return "NodeAttribute";
+        default:                                         return "Unknown";
+    }
+}
+
+void print_scene_summary(const FBXImportResult& r) {
+    std::printf("== FBX Scene Summary =========================================\n");
+    std::printf("  format : %s (v%u)\n", format_name(r.detected_format),
+                r.scene ? r.scene->file_version : 0);
+    if (r.scene) {
+        std::printf("  creator: %s\n", r.scene->creator.c_str());
+        std::printf("  app    : %s / %s / %s\n",
+                    r.scene->application_name.c_str(),
+                    r.scene->application_vendor.c_str(),
+                    r.scene->application_version.c_str());
+    }
+
+    if (r.scene) {
+        const FBXObjectType types[] = {
+            FBXObjectType::MODEL, FBXObjectType::GEOMETRY, FBXObjectType::MATERIAL,
+            FBXObjectType::TEXTURE, FBXObjectType::VIDEO,
+            FBXObjectType::DEFORMER_SKIN, FBXObjectType::DEFORMER_CLUSTER,
+            FBXObjectType::DEFORMER_BLENDSHAPE, FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL,
+            FBXObjectType::SHAPE_GEOMETRY, FBXObjectType::POSE,
+            FBXObjectType::ANIMATION_STACK, FBXObjectType::ANIMATION_LAYER,
+            FBXObjectType::ANIMATION_CURVE_NODE, FBXObjectType::ANIMATION_CURVE,
+            FBXObjectType::NODE_ATTRIBUTE,
+        };
+        std::printf("  objects:\n");
+        for (FBXObjectType t : types) {
+            auto ids = r.scene->ids_of_type(t);
+            if (!ids.empty()) std::printf("    %-18s x %zu\n", object_type_name(t), ids.size());
+        }
+        std::printf("  root models: %zu\n", r.scene->root_model_ids.size());
+    }
+
+    std::printf("  projected descriptors:\n");
+    std::printf("    bones          : %zu\n", r.skeleton.bones.size());
+    std::printf("    clips          : %zu\n", r.clips.size());
+    for (const auto& c : r.clips) {
+        std::printf("      - %s : %.3fs, %zu channels\n",
+                    c.name.c_str(), c.duration, c.channels.size());
+    }
+    std::printf("    skin meshes    : %zu\n", r.skin_meshes.size());
+    for (const auto& sm : r.skin_meshes) {
+        std::printf("      - %s : %u verts, %u indices, %zu morphs\n",
+                    sm.name.c_str(), sm.vertex_count, sm.index_count, sm.morph_target_names.size());
+    }
+    std::printf("    material slots : %zu\n", r.material_slots.size());
+    std::printf("    texture paths  : %zu\n", r.texture_paths.size());
+    for (const auto& p : r.texture_paths) std::printf("      - %s\n", p.c_str());
+    std::printf("==============================================================\n");
+}
+
+/// Build a minimal synthetic scene (3 bones, single translation clip) so the
+/// demo can be exercised when no FBX file is provided.
+void build_synthetic(FBXImportResult& r) {
+    r.success         = true;
+    r.detected_format = AnimationFormat::UNKNOWN;
+
+    r.skeleton.name = "synthetic";
+    r.skeleton.bones.resize(3);
+    for (int i = 0; i < 3; ++i) {
+        Bone& b = r.skeleton.bones[i];
+        b.name = "bone_" + std::to_string(i);
+        b.parent_index = i - 1;
+        b.bind_pose = Transform::identity();
+        b.bind_pose.translation = {(i == 0 ? 0.0f : 1.0f), 0.0f, 0.0f};
+        b.inverse_bind_matrix = float4x4::identity();
+        b.inverse_bind_matrix.m[3][0] = -(static_cast<float>(i));
+    }
+
+    AnimationClipDescriptor clip;
+    clip.name = "wave";
+    clip.duration = 2.0f;
+    clip.sample_rate = 30.0f;
+    clip.wrap_mode = WrapMode::LOOP;
+
+    AnimationChannel ch;
+    ch.target_index = 2;                           // tip bone
+    ch.target       = ChannelTarget::ROTATION;
+    ch.interpolation = InterpolationMode::LINEAR;
+    for (int k = 0; k <= 4; ++k) {
+        float t = static_cast<float>(k) * 0.5f;
+        float angle = std::sin(t * 3.1415926f) * 0.8f;
+        Quaternion q = Quaternion::from_axis_angle({0, 0, 1}, angle);
+        Keyframe kf;
+        kf.time = t;
+        kf.value[0] = q.x; kf.value[1] = q.y; kf.value[2] = q.z; kf.value[3] = q.w;
+        ch.keyframes.push_back(kf);
+    }
+    clip.channels.push_back(std::move(ch));
+    r.clips.push_back(std::move(clip));
+}
+
+void print_bone_matrix(const char* label, const float4x4& m) {
+    std::printf("    %-20s t=(%+.3f, %+.3f, %+.3f)\n",
+                label, m.m[3][0], m.m[3][1], m.m[3][2]);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::printf("Pictor FBX Demo\n");
+    std::printf("---------------\n");
+
+    FBXImportResult result;
+    if (argc >= 2) {
+        std::printf("Loading: %s\n", argv[1]);
+        FBXImporter importer;
+        result = importer.import_file(argv[1]);
+        if (!result.success) {
+            std::printf("FBX import failed: %s\n", result.error_message.c_str());
+            return 1;
+        }
+    } else {
+        std::printf("No FBX path provided — running with synthetic scene.\n");
+        std::printf("Usage: pictor_fbx_demo <path-to-model.fbx>\n\n");
+        build_synthetic(result);
+    }
+
+    print_scene_summary(result);
+
+    if (result.skeleton.bones.empty()) {
+        std::printf("No bones extracted — nothing to animate.\n");
+        return 0;
+    }
+
+    // ── AnimationSystem ─────────────────────────────────────
+    AnimationSystemConfig cfg;
+    cfg.gpu_skinning_enabled = false;           // CPU path for the demo
+    cfg.max_bones_per_skeleton = 512;
+    cfg.max_active_instances = 16;
+    AnimationSystem anim;
+    anim.initialize(cfg);
+
+    SkeletonHandle sk = anim.register_skeleton(result.skeleton);
+    std::vector<AnimationClipHandle> clip_handles;
+    for (const auto& c : result.clips) clip_handles.push_back(anim.register_clip(c));
+
+    // Bind an instance to a dummy object id.
+    const ObjectId dummy_object = 42;
+    AnimationStateHandle inst = anim.create_instance(dummy_object, sk);
+    if (!clip_handles.empty()) {
+        anim.play(inst, clip_handles[0], /*weight=*/1.0f, /*speed=*/1.0f);
+        std::printf("Playing clip: %s (%.2fs)\n",
+                    result.clips[0].name.c_str(), result.clips[0].duration);
+    } else {
+        std::printf("No clips to play; will print bind pose only.\n");
+    }
+
+    const uint32_t bone_count = anim.get_bone_count(inst);
+    std::printf("Bones in instance: %u\n\n", bone_count);
+
+    // ── Sample animation over a few seconds ────────────────
+    const float dt = 1.0f / 30.0f;                  // 30 fps
+    const int total_frames = 90;                    // 3 seconds
+    const int print_stride = 15;                    // every 0.5s
+
+    for (int frame = 0; frame <= total_frames; ++frame) {
+        anim.update(dt);
+        if (frame % print_stride != 0) continue;
+        float t = frame * dt;
+        std::printf("[t=%.2fs frame=%d]\n", t, frame);
+
+        const float4x4* skin = anim.get_skinning_matrices(inst);
+        if (skin && bone_count > 0) {
+            const uint32_t show = std::min<uint32_t>(bone_count, 4);
+            for (uint32_t i = 0; i < show; ++i) {
+                std::string label = "bone[" + std::to_string(i) + "] " +
+                                     (i < result.skeleton.bones.size() ? result.skeleton.bones[i].name : "");
+                print_bone_matrix(label.c_str(), skin[i]);
+            }
+            if (bone_count > show) {
+                std::printf("    ... (%u more)\n", bone_count - show);
+            }
+        }
+    }
+
+    // ── Resource access demo ───────────────────────────────
+    if (result.scene) {
+        std::printf("\nResource ID access sample:\n");
+        auto mids = result.resource_ids_of_type(FBXObjectType::MODEL);
+        for (size_t i = 0; i < std::min<size_t>(mids.size(), 3); ++i) {
+            const FBXObject* obj = result.get_resource(mids[i]);
+            if (!obj) continue;
+            auto ws = result.scene->evaluate_world_transform(mids[i]);
+            std::printf("  Model[%llu] '%s' (%s)\n",
+                        static_cast<unsigned long long>(mids[i]),
+                        obj->name.c_str(),
+                        obj->model ? obj->model->sub_type.c_str() : "");
+            std::printf("    world_translation=(%+.3f, %+.3f, %+.3f)\n",
+                        ws.m[3][0], ws.m[3][1], ws.m[3][2]);
+        }
+    }
+
+    anim.destroy_instance(inst);
+    anim.shutdown();
+    std::printf("\nDone.\n");
+    return 0;
+}

--- a/include/pictor/animation/fbx_importer.h
+++ b/include/pictor/animation/fbx_importer.h
@@ -1,66 +1,73 @@
-﻿#pragma once
+﻿// FBX Importer -- Level 4 (Facade)
+//
+// Uses FBXDocument (Level 1) + FBXScene (Level 2+3) to project the full
+// FBX content into Pictor runtime descriptors (Skeleton, AnimationClip,
+// SkinMesh, material slots, texture paths).
+#pragma once
 
-#include "pictor/animation/animation_types.h"
 #include "pictor/animation/animation_clip.h"
+#include "pictor/animation/animation_types.h"
+#include "pictor/animation/fbx_scene.h"
 #include "pictor/animation/skeleton.h"
+#include "pictor/data/model_data_types.h"
+
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace pictor {
 
-/// Result of an FBX animation import
+/// Result of an FBX import.
+/// Backward-compatible with the previous skeleton-only fields.
 struct FBXImportResult {
-    bool                          success = false;
-    std::string                   error_message;
-    SkeletonDescriptor            skeleton;
+    bool             success         = false;
+    std::string      error_message;
+    AnimationFormat  detected_format = AnimationFormat::UNKNOWN;
+
+    /// Full typed scene (owns all parsed data).
+    std::shared_ptr<FBXScene>            scene;
+
+    // Projected Pictor runtime descriptors.
+    SkeletonDescriptor                   skeleton;
     std::vector<AnimationClipDescriptor> clips;
-    AnimationFormat               detected_format = AnimationFormat::UNKNOWN;
+    std::vector<SkinMeshDescriptor>      skin_meshes;
+    std::vector<std::string>             material_slots;
+    std::vector<std::string>             texture_paths;
+    std::vector<IKChainDescriptor>       ik_chains;
+
+    /// Materialize a ModelDescriptor suitable for
+    /// ModelDataHandler::register_model().
+    ModelDescriptor to_model_descriptor(const std::string& name) const;
+
+    // Resource ID access (forwards to scene).
+    const FBXObject*         get_resource(FBXObjectId id) const noexcept;
+    std::vector<FBXObjectId> all_resource_ids() const;
+    std::vector<FBXObjectId> resource_ids_of_type(FBXObjectType type) const;
 };
 
-/// FBX animation file importer.
-/// Supports both binary FBX and ASCII FBX formats.
-/// Extracts skeleton hierarchy, bind poses, and animation clips.
 class FBXImporter {
 public:
     FBXImporter() = default;
     ~FBXImporter() = default;
 
-    /// Import from file path
+    /// Import from file path.
     FBXImportResult import_file(const std::string& path) const;
-
-    /// Import from memory buffer
+    /// Import from memory buffer.
     FBXImportResult import_memory(const uint8_t* data, size_t size) const;
-
-    /// Detect whether the data is binary or ASCII FBX
+    /// Detect whether the data is binary or ASCII FBX.
     static AnimationFormat detect_format(const uint8_t* data, size_t size);
 
 private:
-    /// Parse binary FBX format
-    FBXImportResult parse_binary(const uint8_t* data, size_t size) const;
-
-    /// Parse ASCII FBX format
-    FBXImportResult parse_ascii(const uint8_t* data, size_t size) const;
-
-    /// Extract skeleton from FBX node hierarchy
-    bool extract_skeleton(const uint8_t* data, size_t size,
-                          SkeletonDescriptor& out_skeleton) const;
-
-    /// Extract animation curves from FBX takes
-    bool extract_animations(const uint8_t* data, size_t size,
-                            const SkeletonDescriptor& skeleton,
-                            std::vector<AnimationClipDescriptor>& out_clips) const;
-
-    /// Parse FBX node (binary format)
-    struct FBXNode {
-        std::string name;
-        uint64_t    end_offset   = 0;
-        uint32_t    num_properties = 0;
-        std::vector<FBXNode> children;
-    };
-
-    /// Read a binary FBX node
-    bool read_node(const uint8_t* data, size_t size, size_t& offset,
-                   FBXNode& out_node, uint32_t version) const;
+    /// Core projection: consume an FBXScene and populate `out`.
+    void project(const FBXScene& scene, FBXImportResult& out) const;
+    /// Build skeleton from LimbNode Models + (optional) Clusters for bind matrices.
+    void build_skeleton(const FBXScene& scene, FBXImportResult& out) const;
+    /// Build animation clips from AnimationStack / Layer / CurveNode / Curve.
+    void build_clips(const FBXScene& scene, FBXImportResult& out) const;
+    /// Build skinned meshes from Geometry + Skin + Cluster.
+    void build_skin_meshes(const FBXScene& scene, FBXImportResult& out) const;
+    /// Collect material names and texture paths.
+    void collect_materials(const FBXScene& scene, FBXImportResult& out) const;
 };
 
 } // namespace pictor

--- a/include/pictor/animation/fbx_scene.h
+++ b/include/pictor/animation/fbx_scene.h
@@ -1,0 +1,437 @@
+﻿// FBX Scene -- Level 2+3 (Typed Objects + Connections)
+//
+// Interprets an FBXDocument (raw node tree) into typed objects:
+//   Model / Geometry / Material / Texture / Video /
+//   Deformer (Skin + Cluster) / BlendShape / Pose /
+//   AnimStack / AnimLayer / AnimCurveNode / AnimCurve /
+//   NodeAttribute / GlobalSettings
+//
+// Every object is keyed by its FBX UniqueId. The connection graph
+// (Objects/Objects and Object/Property) is parsed and traversable.
+//
+// The upper FBXImporter (Level 4) projects these into Pictor runtime
+// descriptors (Skeleton, AnimationClip, SkinMesh, ...).
+#pragma once
+
+#include "pictor/animation/fbx_document.h"
+#include "pictor/core/types.h"
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace pictor {
+
+/// FBX "UniqueId" — 64-bit stable object identifier used inside an FBX file.
+using FBXObjectId = uint64_t;
+
+/// Discriminator for the typed FBX object variants.
+enum class FBXObjectType : uint8_t {
+    UNKNOWN = 0,
+    GLOBAL_SETTINGS,
+    MODEL,                       ///< Transform node (Mesh / LimbNode / Null / Light / Camera)
+    GEOMETRY,                    ///< Polygon mesh
+    MATERIAL,
+    TEXTURE,
+    VIDEO,                       ///< Texture source (file path + optional embedded bytes)
+    DEFORMER_SKIN,
+    DEFORMER_CLUSTER,            ///< One bone within a skin
+    DEFORMER_BLENDSHAPE,
+    DEFORMER_BLENDSHAPE_CHANNEL,
+    SHAPE_GEOMETRY,              ///< Per-channel morph target (vertex deltas)
+    POSE,                        ///< BindPose: model -> matrix
+    ANIMATION_STACK,
+    ANIMATION_LAYER,
+    ANIMATION_CURVE_NODE,        ///< Groups X/Y/Z curves bound to a Model property
+    ANIMATION_CURVE,
+    NODE_ATTRIBUTE,              ///< LimbNode / Light / Camera metadata attached to a Model
+};
+
+/// Rotation order as specified by FBX `RotationOrder` property.
+/// Values match FBX SDK: 0 XYZ, 1 XZY, 2 YZX, 3 YXZ, 4 ZXY, 5 ZYX, 6 Spheric XYZ.
+enum class FBXRotationOrder : uint8_t {
+    XYZ = 0, XZY = 1, YZX = 2, YXZ = 3, ZXY = 4, ZYX = 5, SPHERIC_XYZ = 6,
+};
+
+// ── Connection graph ────────────────────────────────────────
+
+struct FBXConnection {
+    enum Kind : uint8_t { OO = 0, OP = 1 };
+    Kind        kind = OO;
+    FBXObjectId src  = 0;        ///< "source" — normally the child / owned object
+    FBXObjectId dst  = 0;        ///< "destination" — normally the parent / owner
+    std::string property;        ///< OP only: which Model property the source binds to
+};
+
+// ── Forward decl of the Object variant ─────────────────────
+
+struct FBXObject;
+
+// ── GlobalSettings ─────────────────────────────────────────
+
+struct FBXGlobalSettings {
+    int    up_axis        = 1;     ///< 0=X, 1=Y, 2=Z
+    int    up_axis_sign   = 1;
+    int    front_axis     = 2;
+    int    front_axis_sign = 1;
+    int    coord_axis     = 0;
+    int    coord_axis_sign = 1;
+    int    time_mode      = 6;     ///< 0 default, 6 = 24fps, etc.
+    double unit_scale     = 1.0;   ///< cm per unit (FBX default 1.0 = cm)
+    double original_unit_scale = 1.0;
+    int64_t time_span_start = 0;   ///< KTime
+    int64_t time_span_stop  = 0;
+    double custom_frame_rate = 24.0;
+};
+
+// ── Model (transform node) ─────────────────────────────────
+
+struct FBXModel {
+    std::string          name;
+    std::string          sub_type;      ///< "Mesh" / "LimbNode" / "Null" / "Light" / "Camera" / ...
+
+    float3               translation{0, 0, 0};
+    float3               rotation{0, 0, 0};        ///< Euler degrees
+    float3               scaling{1, 1, 1};
+
+    float3               rotation_offset{0, 0, 0};
+    float3               rotation_pivot{0, 0, 0};
+    float3               scaling_offset{0, 0, 0};
+    float3               scaling_pivot{0, 0, 0};
+    float3               pre_rotation{0, 0, 0};    ///< Euler degrees
+    float3               post_rotation{0, 0, 0};   ///< Euler degrees
+
+    FBXRotationOrder     rotation_order = FBXRotationOrder::XYZ;
+    bool                 visibility = true;
+    bool                 is_root    = false;       ///< No parent Model
+};
+
+// ── Geometry (polygon mesh) ────────────────────────────────
+
+enum class FBXMappingMode : uint8_t {
+    BY_POLYGON_VERTEX = 0,
+    BY_VERTEX,
+    BY_POLYGON,
+    BY_EDGE,
+    ALL_SAME,
+    NONE,
+};
+enum class FBXReferenceMode : uint8_t {
+    DIRECT = 0,
+    INDEX_TO_DIRECT,
+    INDEX,
+};
+
+template <typename T>
+struct FBXLayerElement {
+    std::string              name;
+    FBXMappingMode           mapping   = FBXMappingMode::NONE;
+    FBXReferenceMode         reference = FBXReferenceMode::DIRECT;
+    std::vector<T>           data;          ///< Per the mapping / reference mode
+    std::vector<int32_t>     index;         ///< When reference == INDEX_TO_DIRECT
+};
+
+struct FBXGeometry {
+    std::vector<float3>      positions;
+    /// FBX "PolygonVertexIndex": last index of each polygon is XOR'd with -1
+    /// (bit-not). Values are indices into `positions`.
+    std::vector<int32_t>     polygon_vertex_index;
+    std::vector<int32_t>     edges;
+
+    std::vector<FBXLayerElement<float3>> normals;
+    std::vector<FBXLayerElement<float3>> tangents;
+    std::vector<FBXLayerElement<float3>> binormals;
+    std::vector<FBXLayerElement<float4>> colors;
+    struct UVSet {
+        std::string              name;
+        FBXMappingMode           mapping   = FBXMappingMode::BY_POLYGON_VERTEX;
+        FBXReferenceMode         reference = FBXReferenceMode::INDEX_TO_DIRECT;
+        std::vector<float>       u;
+        std::vector<float>       v;
+        std::vector<int32_t>     index;
+    };
+    std::vector<UVSet>                     uv_sets;
+
+    FBXLayerElement<int32_t>               material_indices;  ///< per-polygon
+    FBXLayerElement<int32_t>               smoothing;
+
+    /// Cached triangulated output (populated by FBXScene::triangulate).
+    struct Triangulated {
+        std::vector<float3>   positions;     ///< Per-tri-vertex, length = indices.size()
+        std::vector<float3>   normals;
+        std::vector<float4>   colors;
+        std::vector<float3>   tangents;
+        std::vector<float3>   binormals;
+        /// First UV set, interleaved (u0,v0,u1,v1,...)
+        std::vector<float>    uv0;
+        std::vector<int32_t>  indices;       ///< 0..N trivial index array for draw calls
+        std::vector<int32_t>  material_per_tri;
+        /// For each tri-vertex: which position index it came from
+        std::vector<int32_t>  original_vertex;
+        /// For each tri: which polygon it was tessellated from
+        std::vector<int32_t>  polygon_of_tri;
+        bool                  valid = false;
+    };
+    mutable Triangulated      triangulated_cache;
+};
+
+// ── Skin / Cluster ─────────────────────────────────────────
+
+struct FBXCluster {
+    std::string              name;
+    FBXObjectId              bone_model_id = 0;  ///< LimbNode Model this cluster is bound to
+    std::vector<int32_t>     indices;            ///< vertex indices into Geometry.positions
+    std::vector<double>      weights;
+    float4x4                 transform           = float4x4::identity();  ///< Mesh -> cluster
+    float4x4                 transform_link      = float4x4::identity();  ///< Bone -> world at bind time
+    float4x4                 transform_associate = float4x4::identity();
+};
+
+struct FBXSkinDeformer {
+    std::string              name;
+    double                   skinning_type_blend_weight = 0.0;
+    std::vector<FBXObjectId> cluster_ids;
+};
+
+// ── BlendShape / Morph ─────────────────────────────────────
+
+struct FBXShapeGeometry {
+    std::vector<int32_t>     indices;   ///< vertex indices the deltas apply to
+    std::vector<float3>      position_deltas;
+    std::vector<float3>      normal_deltas;   ///< may be empty
+};
+
+struct FBXBlendShapeChannel {
+    std::string              name;
+    double                   deform_percent = 0.0;
+    std::vector<double>      full_weights;     ///< per-shape "FullWeights"
+    std::vector<FBXObjectId> shape_ids;        ///< FBXShapeGeometry children
+};
+
+struct FBXBlendShape {
+    std::string              name;
+    std::vector<FBXObjectId> channel_ids;
+};
+
+// ── Material / Texture / Video ─────────────────────────────
+
+struct FBXMaterial {
+    std::string              name;
+    std::string              shading_model;   ///< "Phong" / "Lambert" / ...
+
+    float3                   ambient{0, 0, 0};
+    float3                   diffuse{1, 1, 1};
+    float3                   specular{0, 0, 0};
+    float3                   emissive{0, 0, 0};
+    float3                   reflection{0, 0, 0};
+    float                    opacity       = 1.0f;
+    float                    shininess     = 0.0f;
+    float                    reflectivity  = 0.0f;
+    float                    diffuse_factor  = 1.0f;
+    float                    specular_factor = 1.0f;
+    float                    emissive_factor = 1.0f;
+
+    /// Channel name (e.g. "DiffuseColor", "NormalMap") -> FBXTexture id.
+    std::unordered_map<std::string, FBXObjectId> textures;
+};
+
+struct FBXTexture {
+    std::string              name;
+    std::string              file_name;
+    std::string              relative_filename;
+    std::string              uv_set;
+    int                      wrap_u = 0;   ///< 0 = repeat, 1 = clamp
+    int                      wrap_v = 0;
+    FBXObjectId              video_id = 0;
+};
+
+struct FBXVideo {
+    std::string              name;
+    std::string              file_name;
+    std::string              relative_filename;
+    std::vector<uint8_t>     content;   ///< Embedded image bytes (may be empty)
+};
+
+// ── BindPose ───────────────────────────────────────────────
+
+struct FBXPose {
+    std::string              name;
+    bool                     is_bind_pose = false;
+    std::unordered_map<FBXObjectId, float4x4> model_matrices;
+};
+
+// ── Animation ──────────────────────────────────────────────
+
+struct FBXAnimCurve {
+    /// KTime ticks (46186158000 per second). Convert via FBXScene::ktime_to_seconds().
+    std::vector<int64_t>     key_time;
+    std::vector<float>       key_value;
+    std::vector<int32_t>     key_flag;
+    std::vector<int32_t>     key_attr_flag;
+    std::vector<float>       key_attr_data;
+    std::vector<int32_t>     key_attr_ref_count;
+};
+
+struct FBXAnimCurveNode {
+    std::string              name;
+    /// "d|X", "d|Y", "d|Z", "X", "Y", "Z", "DeformPercent", ... -> curve id
+    std::unordered_map<std::string, FBXObjectId> curves;
+    /// Default values read from Properties70 (e.g. "d|X", "d|Y", "d|Z").
+    std::unordered_map<std::string, double> default_values;
+};
+
+struct FBXAnimLayer {
+    std::string              name;
+    std::vector<FBXObjectId> curve_node_ids;
+};
+
+struct FBXAnimStack {
+    std::string              name;
+    int64_t                  local_start  = 0;
+    int64_t                  local_stop   = 0;
+    int64_t                  reference_start = 0;
+    int64_t                  reference_stop  = 0;
+    std::vector<FBXObjectId> layer_ids;
+};
+
+// ── NodeAttribute (LimbNode size, Light/Camera metadata) ───
+
+struct FBXNodeAttribute {
+    std::string              name;
+    std::string              sub_type;      ///< "LimbNode" / "Light" / "Camera" / "Null"
+    double                   limb_size = 1.0;
+    /// Generic properties carried through for lights/cameras etc.
+    std::unordered_map<std::string, double> numeric_props;
+    std::unordered_map<std::string, std::string> string_props;
+};
+
+// ── Generic object wrapper ─────────────────────────────────
+
+struct FBXObject {
+    FBXObjectId       id   = 0;
+    FBXObjectType     type = FBXObjectType::UNKNOWN;
+    std::string       name;       ///< Display name (first Object property, ::-stripped)
+    std::string       class_tag;  ///< FBX class tag ("Mesh" / "LimbNode" / "DiffuseColor" / ...)
+
+    /// Back-reference to the raw source node (lifetime tied to FBXDocument).
+    const FBXNode*    source_node = nullptr;
+
+    // Typed payload (exactly one is non-null based on `type`).
+    std::unique_ptr<FBXModel>             model;
+    std::unique_ptr<FBXGeometry>          geometry;
+    std::unique_ptr<FBXMaterial>          material;
+    std::unique_ptr<FBXTexture>           texture;
+    std::unique_ptr<FBXVideo>             video;
+    std::unique_ptr<FBXSkinDeformer>      skin;
+    std::unique_ptr<FBXCluster>           cluster;
+    std::unique_ptr<FBXBlendShape>        blendshape;
+    std::unique_ptr<FBXBlendShapeChannel> blendshape_channel;
+    std::unique_ptr<FBXShapeGeometry>     shape_geometry;
+    std::unique_ptr<FBXPose>              pose;
+    std::unique_ptr<FBXAnimStack>         anim_stack;
+    std::unique_ptr<FBXAnimLayer>         anim_layer;
+    std::unique_ptr<FBXAnimCurveNode>     anim_curve_node;
+    std::unique_ptr<FBXAnimCurve>         anim_curve;
+    std::unique_ptr<FBXNodeAttribute>     node_attribute;
+};
+
+// ── FBXScene ───────────────────────────────────────────────
+
+class FBXScene {
+public:
+    FBXScene() = default;
+    ~FBXScene() = default;
+
+    /// Parse an FBXDocument into typed objects + connection graph.
+    /// Failure messages (non-fatal per-object issues are also appended)
+    /// can be retrieved via `warnings()`.
+    bool load(const FBXDocument& doc, std::string* error = nullptr);
+
+    // -- Resource ID access (returns all owned data) --
+    const FBXObject* get(FBXObjectId id) const noexcept;
+    bool             has(FBXObjectId id) const noexcept;
+    std::vector<FBXObjectId> all_ids() const;
+    std::vector<FBXObjectId> ids_of_type(FBXObjectType type) const;
+
+    // -- Connection traversal --
+
+    /// Objects whose `dst == id` (= id's "children" in the FBX sense).
+    std::vector<FBXObjectId> children_of(FBXObjectId id) const;
+    /// Objects whose `src == id` (= id's "parents" in the FBX sense).
+    std::vector<FBXObjectId> parents_of(FBXObjectId id) const;
+    /// OP connections: src objects binding to `id`'s property `prop`.
+    std::vector<FBXObjectId> connected_by_property(FBXObjectId id, const std::string& prop) const;
+
+    /// Raw connection list (direct access).
+    const std::vector<FBXConnection>& connections() const noexcept { return connections_; }
+
+    // -- Utilities --
+
+    /// Triangulate (fan) a Geometry and cache the result inside the object.
+    /// Returns nullptr if id does not refer to a Geometry.
+    const FBXGeometry::Triangulated* triangulate(FBXObjectId geometry_id) const;
+
+    /// FBX local transform assembly following the SDK specification:
+    /// T * Roff * Rp * Rpre * R * Rpost^-1 * Rp^-1 * Soff * Sp * S * Sp^-1
+    float4x4 evaluate_local_transform(FBXObjectId model_id) const;
+    /// Accumulate from root Model. Returns identity if id is not a Model.
+    float4x4 evaluate_world_transform(FBXObjectId model_id) const;
+
+    /// KTime (FBX tick) -> seconds. 1 second == 46186158000 ticks.
+    static double ktime_to_seconds(int64_t ktime) noexcept {
+        return static_cast<double>(ktime) / 46186158000.0;
+    }
+
+    // -- Metadata --
+    uint32_t               file_version = 0;
+    std::string            creator;
+    std::string            application_name;
+    std::string            application_vendor;
+    std::string            application_version;
+    FBXGlobalSettings      global_settings;
+    /// Model ids that have no Model parent (via OO connections).
+    std::vector<FBXObjectId> root_model_ids;
+
+    /// Non-fatal messages accumulated during load().
+    const std::vector<std::string>& warnings() const noexcept { return warnings_; }
+
+private:
+    // Internal builders (implemented in fbx_scene.cpp).
+    void parse_global_settings(const FBXNode& settings_node);
+    void parse_documents(const FBXNode& docs_node);
+    void parse_objects(const FBXNode& objects_node);
+    void parse_connections(const FBXNode& connections_node);
+    void finalize_root_models();
+    FBXObject& ensure_object(FBXObjectId id);
+
+    // Per-type parsers (return false only on fatal structural errors).
+    void parse_model(FBXObject& obj, const FBXNode& node);
+    void parse_geometry(FBXObject& obj, const FBXNode& node);
+    void parse_material(FBXObject& obj, const FBXNode& node);
+    void parse_texture(FBXObject& obj, const FBXNode& node);
+    void parse_video(FBXObject& obj, const FBXNode& node);
+    void parse_deformer(FBXObject& obj, const FBXNode& node);
+    void parse_pose(FBXObject& obj, const FBXNode& node);
+    void parse_anim_stack(FBXObject& obj, const FBXNode& node);
+    void parse_anim_layer(FBXObject& obj, const FBXNode& node);
+    void parse_anim_curve_node(FBXObject& obj, const FBXNode& node);
+    void parse_anim_curve(FBXObject& obj, const FBXNode& node);
+    void parse_node_attribute(FBXObject& obj, const FBXNode& node);
+
+    void warn(std::string s) { warnings_.push_back(std::move(s)); }
+
+private:
+    std::unordered_map<FBXObjectId, std::unique_ptr<FBXObject>>     objects_;
+    std::unordered_map<FBXObjectType, std::vector<FBXObjectId>>     ids_by_type_;
+    std::vector<FBXConnection>                                       connections_;
+    // Index for O(1) connection traversal.
+    std::unordered_map<FBXObjectId, std::vector<size_t>>            conn_by_src_;
+    std::unordered_map<FBXObjectId, std::vector<size_t>>            conn_by_dst_;
+    std::vector<std::string>                                         warnings_;
+};
+
+} // namespace pictor

--- a/include/pictor/data/model_data_handler.h
+++ b/include/pictor/data/model_data_handler.h
@@ -10,6 +10,8 @@
 
 namespace pictor {
 
+class FBXScene;
+
 /// Configuration for the model data handler
 struct ModelDataHandlerConfig {
     uint32_t max_models     = 256;
@@ -42,6 +44,24 @@ public:
 
     /// Unregister a model and all its sub-resources.
     void unregister_model(ModelHandle handle);
+
+    // ============================================================
+    // FBX Loading (convenience)
+    // ============================================================
+
+    /// Load and register an FBX file. Returns INVALID_MODEL on failure.
+    /// Error message is available via last_load_error().
+    ModelHandle load_model_from_fbx(const std::string& path);
+    /// Load and register an FBX from memory.
+    ModelHandle load_model_from_fbx_memory(const uint8_t* data, size_t size,
+                                            const std::string& name);
+
+    /// Retrieve the FBXScene associated with a model previously loaded via
+    /// load_model_from_fbx(). Returns nullptr if the model was not FBX-sourced.
+    std::shared_ptr<FBXScene> get_fbx_scene(ModelHandle handle) const;
+
+    /// Last error message from a load_* call (empty on success).
+    const std::string& last_load_error() const noexcept { return last_load_error_; }
 
     // ============================================================
     // Skin Mesh Operations
@@ -138,6 +158,10 @@ private:
     ModelHandle    next_model_handle_     = 0;
     SkinMeshHandle next_skin_mesh_handle_ = 0;
     RigHandle      next_rig_handle_       = 0;
+
+    /// ModelHandle -> owning FBXScene (only populated via load_model_from_fbx).
+    std::unordered_map<ModelHandle, std::shared_ptr<FBXScene>> fbx_scenes_;
+    std::string last_load_error_;
 };
 
 } // namespace pictor

--- a/src/animation/fbx_importer.cpp
+++ b/src/animation/fbx_importer.cpp
@@ -1,324 +1,497 @@
-﻿#include "pictor/animation/fbx_importer.h"
-#include <fstream>
-#include <cstring>
-#include <sstream>
+﻿// FBX Importer -- Level 4 implementation
+//
+// Consumes an FBXDocument (raw) + FBXScene (typed) and projects into Pictor
+// runtime descriptors (SkeletonDescriptor, AnimationClipDescriptor,
+// SkinMeshDescriptor, material_slots, texture_paths).
+
+#include "pictor/animation/fbx_importer.h"
+#include "pictor/animation/fbx_document.h"
+
 #include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace pictor {
 
-// FBX binary magic bytes: "Kaydara FBX Binary  \0"
-static constexpr char FBX_BINARY_MAGIC[] = "Kaydara FBX Binary  ";
-static constexpr size_t FBX_BINARY_MAGIC_LEN = 21;
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr float  kDegToRadF = static_cast<float>(kPi / 180.0);
+
+AnimationFormat format_from_doc(const FBXDocument& doc, bool ok) {
+    if (!ok) return AnimationFormat::UNKNOWN;
+    return doc.is_ascii ? AnimationFormat::FBX_ASCII : AnimationFormat::FBX_BINARY;
+}
+
+/// Convert FBX Euler (degrees) to Quaternion honoring rotation order.
+Quaternion euler_deg_to_quat(const float3& deg, FBXRotationOrder order) {
+    const float rx = deg.x * kDegToRadF;
+    const float ry = deg.y * kDegToRadF;
+    const float rz = deg.z * kDegToRadF;
+    const Quaternion qx = Quaternion::from_axis_angle({1, 0, 0}, rx);
+    const Quaternion qy = Quaternion::from_axis_angle({0, 1, 0}, ry);
+    const Quaternion qz = Quaternion::from_axis_angle({0, 0, 1}, rz);
+    switch (order) {
+        case FBXRotationOrder::XYZ: return qx * qy * qz;
+        case FBXRotationOrder::XZY: return qx * qz * qy;
+        case FBXRotationOrder::YZX: return qy * qz * qx;
+        case FBXRotationOrder::YXZ: return qy * qx * qz;
+        case FBXRotationOrder::ZXY: return qz * qx * qy;
+        case FBXRotationOrder::ZYX: return qz * qy * qx;
+        default:                    return qx * qy * qz;
+    }
+}
+
+/// Rigid-transform inverse (rotation transpose + -R^T * t).
+float4x4 inverse_rigid_approx(const float4x4& m) {
+    float4x4 r = float4x4::identity();
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            r.m[i][j] = m.m[j][i];
+    float tx = m.m[3][0], ty = m.m[3][1], tz = m.m[3][2];
+    r.m[3][0] = -(r.m[0][0] * tx + r.m[1][0] * ty + r.m[2][0] * tz);
+    r.m[3][1] = -(r.m[0][1] * tx + r.m[1][1] * ty + r.m[2][1] * tz);
+    r.m[3][2] = -(r.m[0][2] * tx + r.m[1][2] * ty + r.m[2][2] * tz);
+    return r;
+}
+
+/// Linear sample from an FBXAnimCurve at t_seconds.
+float sample_curve(const FBXAnimCurve* curve, double t_seconds, float fallback) {
+    if (!curve || curve->key_time.empty()) return fallback;
+    const size_t n = curve->key_time.size();
+    if (curve->key_value.size() != n) return fallback;
+    const double first = FBXScene::ktime_to_seconds(curve->key_time.front());
+    const double last  = FBXScene::ktime_to_seconds(curve->key_time.back());
+    if (t_seconds <= first) return curve->key_value.front();
+    if (t_seconds >= last)  return curve->key_value.back();
+    size_t lo = 0, hi = n - 1;
+    while (hi - lo > 1) {
+        size_t mid = (lo + hi) / 2;
+        double tm = FBXScene::ktime_to_seconds(curve->key_time[mid]);
+        if (tm <= t_seconds) lo = mid; else hi = mid;
+    }
+    const double t0 = FBXScene::ktime_to_seconds(curve->key_time[lo]);
+    const double t1 = FBXScene::ktime_to_seconds(curve->key_time[hi]);
+    const float  v0 = curve->key_value[lo];
+    const float  v1 = curve->key_value[hi];
+    const float  f  = (t1 > t0) ? static_cast<float>((t_seconds - t0) / (t1 - t0)) : 0.0f;
+    return v0 + (v1 - v0) * f;
+}
+
+} // namespace
+
+// ─── FBXImportResult helpers ──────────────────────────────
+
+const FBXObject* FBXImportResult::get_resource(FBXObjectId id) const noexcept {
+    return scene ? scene->get(id) : nullptr;
+}
+std::vector<FBXObjectId> FBXImportResult::all_resource_ids() const {
+    return scene ? scene->all_ids() : std::vector<FBXObjectId>{};
+}
+std::vector<FBXObjectId> FBXImportResult::resource_ids_of_type(FBXObjectType type) const {
+    return scene ? scene->ids_of_type(type) : std::vector<FBXObjectId>{};
+}
+
+ModelDescriptor FBXImportResult::to_model_descriptor(const std::string& name) const {
+    ModelDescriptor md;
+    md.name   = name;
+    md.format = ModelFormat::FBX;
+
+    md.rig.name      = skeleton.name.empty() ? name + "_rig" : skeleton.name;
+    md.rig.bones     = skeleton.bones;
+    md.rig.ik_chains = ik_chains;
+
+    md.skin_meshes     = skin_meshes;
+    md.animation_clips = clips;
+    md.material_slots  = material_slots;
+    md.texture_paths   = texture_paths;
+    return md;
+}
+
+// ─── FBXImporter ─────────────────────────────────────────
 
 AnimationFormat FBXImporter::detect_format(const uint8_t* data, size_t size) {
-    if (!data || size < FBX_BINARY_MAGIC_LEN + 2) return AnimationFormat::UNKNOWN;
-
-    if (std::memcmp(data, FBX_BINARY_MAGIC, FBX_BINARY_MAGIC_LEN) == 0) {
-        return AnimationFormat::FBX_BINARY;
-    }
-
-    // Check for ASCII FBX: starts with "; FBX" or "FBXHeaderExtension:"
-    const char* text = reinterpret_cast<const char*>(data);
-    if (size > 20) {
-        std::string header(text, std::min(size, static_cast<size_t>(256)));
-        if (header.find("FBXHeaderExtension") != std::string::npos ||
-            header.find("; FBX") != std::string::npos) {
-            return AnimationFormat::FBX_ASCII;
-        }
-    }
-
+    if (!data || size == 0) return AnimationFormat::UNKNOWN;
+    if (FBXDocument::looks_binary(data, size)) return AnimationFormat::FBX_BINARY;
+    std::string head(reinterpret_cast<const char*>(data),
+                     std::min<size_t>(size, 256));
+    if (head.find("FBXHeaderExtension") != std::string::npos) return AnimationFormat::FBX_ASCII;
+    if (head.find("FBXVersion")         != std::string::npos) return AnimationFormat::FBX_ASCII;
+    if (head.find("; FBX")              != std::string::npos) return AnimationFormat::FBX_ASCII;
     return AnimationFormat::UNKNOWN;
 }
 
 FBXImportResult FBXImporter::import_file(const std::string& path) const {
-    std::ifstream file(path, std::ios::binary | std::ios::ate);
-    if (!file.is_open()) {
-        return {false, "Failed to open file: " + path, {}, {}, AnimationFormat::UNKNOWN};
+    FBXImportResult out;
+    FBXDocument doc;
+    std::string err;
+    if (!doc.load_file(path, &err)) {
+        out.error_message = err.empty() ? "FBX load failed: " + path : err;
+        return out;
     }
-
-    auto size = file.tellg();
-    file.seekg(0, std::ios::beg);
-
-    std::vector<uint8_t> data(static_cast<size_t>(size));
-    if (!file.read(reinterpret_cast<char*>(data.data()), size)) {
-        return {false, "Failed to read file: " + path, {}, {}, AnimationFormat::UNKNOWN};
+    out.detected_format = format_from_doc(doc, true);
+    out.scene = std::make_shared<FBXScene>();
+    if (!out.scene->load(doc, &err)) {
+        out.error_message = err.empty() ? "FBX scene build failed" : err;
+        return out;
     }
-
-    return import_memory(data.data(), data.size());
+    project(*out.scene, out);
+    out.success = true;
+    return out;
 }
 
 FBXImportResult FBXImporter::import_memory(const uint8_t* data, size_t size) const {
-    AnimationFormat format = detect_format(data, size);
+    FBXImportResult out;
+    FBXDocument doc;
+    std::string err;
+    if (!doc.parse(data, size, &err)) {
+        out.error_message = err.empty() ? "FBX parse failed" : err;
+        return out;
+    }
+    out.detected_format = format_from_doc(doc, true);
+    out.scene = std::make_shared<FBXScene>();
+    if (!out.scene->load(doc, &err)) {
+        out.error_message = err.empty() ? "FBX scene build failed" : err;
+        return out;
+    }
+    project(*out.scene, out);
+    out.success = true;
+    return out;
+}
 
-    switch (format) {
-        case AnimationFormat::FBX_BINARY:
-            return parse_binary(data, size);
-        case AnimationFormat::FBX_ASCII:
-            return parse_ascii(data, size);
-        default:
-            return {false, "Unrecognized FBX format", {}, {}, AnimationFormat::UNKNOWN};
+void FBXImporter::project(const FBXScene& scene, FBXImportResult& out) const {
+    build_skeleton(scene, out);
+    build_clips(scene, out);
+    build_skin_meshes(scene, out);
+    collect_materials(scene, out);
+}
+
+// ─── Skeleton ─────────────────────────────────────────────
+
+void FBXImporter::build_skeleton(const FBXScene& scene, FBXImportResult& out) const {
+    std::vector<FBXObjectId> limb_ids;
+    for (FBXObjectId mid : scene.ids_of_type(FBXObjectType::MODEL)) {
+        const FBXObject* obj = scene.get(mid);
+        if (!obj || !obj->model) continue;
+        const std::string& st = obj->model->sub_type;
+        if (st == "LimbNode" || st == "Limb" || st == "Root" || st == "Null") {
+            limb_ids.push_back(mid);
+        }
+    }
+    if (limb_ids.empty()) return;
+
+    std::unordered_map<FBXObjectId, int32_t> id_to_index;
+    id_to_index.reserve(limb_ids.size());
+    for (size_t i = 0; i < limb_ids.size(); ++i) id_to_index[limb_ids[i]] = static_cast<int32_t>(i);
+
+    out.skeleton.name = "fbx_skeleton";
+    out.skeleton.bones.resize(limb_ids.size());
+
+    std::unordered_map<FBXObjectId, float4x4> bone_to_bind;
+    for (FBXObjectId cid : scene.ids_of_type(FBXObjectType::DEFORMER_CLUSTER)) {
+        const FBXObject* c = scene.get(cid);
+        if (!c || !c->cluster) continue;
+        bone_to_bind[c->cluster->bone_model_id] = c->cluster->transform_link;
+    }
+
+    for (size_t i = 0; i < limb_ids.size(); ++i) {
+        FBXObjectId id = limb_ids[i];
+        const FBXObject* obj = scene.get(id);
+        Bone& b = out.skeleton.bones[i];
+        b.name = obj ? obj->name : std::string{};
+        b.parent_index = -1;
+
+        for (FBXObjectId pid : scene.parents_of(id)) {
+            const FBXObject* po = scene.get(pid);
+            if (!po || !po->model) continue;
+            auto it = id_to_index.find(pid);
+            if (it != id_to_index.end()) { b.parent_index = it->second; break; }
+        }
+
+        if (obj && obj->model) {
+            b.bind_pose.translation = obj->model->translation;
+            b.bind_pose.rotation    = euler_deg_to_quat(obj->model->rotation, obj->model->rotation_order);
+            b.bind_pose.scale       = obj->model->scaling;
+        }
+
+        auto bt = bone_to_bind.find(id);
+        if (bt != bone_to_bind.end()) {
+            b.inverse_bind_matrix = inverse_rigid_approx(bt->second);
+        } else {
+            b.inverse_bind_matrix = inverse_rigid_approx(scene.evaluate_world_transform(id));
+        }
     }
 }
 
-bool FBXImporter::read_node(const uint8_t* data, size_t size, size_t& offset,
-                             FBXNode& out_node, uint32_t version) const {
-    // Read node header based on FBX version
-    bool use_64bit = (version >= 7500);
+// ─── Animation clips ──────────────────────────────────────
 
-    if (use_64bit) {
-        if (offset + 25 > size) return false;
-
-        uint64_t end_offset, num_props, prop_list_len;
-        std::memcpy(&end_offset, data + offset, 8); offset += 8;
-        std::memcpy(&num_props, data + offset, 8); offset += 8;
-        std::memcpy(&prop_list_len, data + offset, 8); offset += 8;
-
-        out_node.end_offset = end_offset;
-        out_node.num_properties = static_cast<uint32_t>(num_props);
-    } else {
-        if (offset + 13 > size) return false;
-
-        uint32_t end_offset, num_props, prop_list_len;
-        std::memcpy(&end_offset, data + offset, 4); offset += 4;
-        std::memcpy(&num_props, data + offset, 4); offset += 4;
-        std::memcpy(&prop_list_len, data + offset, 4); offset += 4;
-
-        out_node.end_offset = end_offset;
-        out_node.num_properties = num_props;
+void FBXImporter::build_clips(const FBXScene& scene, FBXImportResult& out) const {
+    std::unordered_map<FBXObjectId, uint32_t> bone_target;
+    for (size_t i = 0; i < out.skeleton.bones.size(); ++i) {
+        const std::string& bone_name = out.skeleton.bones[i].name;
+        for (FBXObjectId mid : scene.ids_of_type(FBXObjectType::MODEL)) {
+            const FBXObject* m = scene.get(mid);
+            if (m && m->name == bone_name) {
+                bone_target[mid] = static_cast<uint32_t>(i);
+                break;
+            }
+        }
     }
 
-    // Read name length + name
-    if (offset >= size) return false;
-    uint8_t name_len = data[offset]; offset += 1;
-    if (offset + name_len > size) return false;
+    for (FBXObjectId stack_id : scene.ids_of_type(FBXObjectType::ANIMATION_STACK)) {
+        const FBXObject* stack_obj = scene.get(stack_id);
+        if (!stack_obj || !stack_obj->anim_stack) continue;
+        const FBXAnimStack& stack = *stack_obj->anim_stack;
 
-    out_node.name.assign(reinterpret_cast<const char*>(data + offset), name_len);
-    offset += name_len;
-
-    return true;
-}
-
-FBXImportResult FBXImporter::parse_binary(const uint8_t* data, size_t size) const {
-    FBXImportResult result;
-    result.detected_format = AnimationFormat::FBX_BINARY;
-
-    if (size < 27) {
-        result.error_message = "FBX binary file too small";
-        return result;
-    }
-
-    // Skip magic header (21 bytes) + 2 unknown bytes
-    size_t offset = 23;
-
-    // Read version
-    uint32_t version = 0;
-    std::memcpy(&version, data + offset, 4);
-    offset += 4;
-
-    // Extract skeleton and animations
-    if (!extract_skeleton(data, size, result.skeleton)) {
-        // Generate a default skeleton if extraction fails
-        result.skeleton.name = "default";
-        Bone root;
-        root.name = "root";
-        root.parent_index = -1;
-        root.bind_pose = Transform::identity();
-        root.inverse_bind_matrix = float4x4::identity();
-        result.skeleton.bones.push_back(root);
-    }
-
-    if (!extract_animations(data, size, result.skeleton, result.clips)) {
-        // Generate a default empty clip
         AnimationClipDescriptor clip;
-        clip.name = "default";
-        clip.duration = 0.0f;
-        result.clips.push_back(clip);
-    }
+        clip.name        = stack.name.empty() ? "clip" : stack.name;
+        clip.wrap_mode   = WrapMode::LOOP;
+        clip.sample_rate = 30.0f;
 
-    result.success = true;
-    return result;
-}
+        double duration = FBXScene::ktime_to_seconds(stack.local_stop - stack.local_start);
+        if (duration <= 0.0) duration = FBXScene::ktime_to_seconds(stack.reference_stop - stack.reference_start);
+        if (duration <= 0.0) duration = 1.0;
+        clip.duration = static_cast<float>(duration);
 
-FBXImportResult FBXImporter::parse_ascii(const uint8_t* data, size_t size) const {
-    FBXImportResult result;
-    result.detected_format = AnimationFormat::FBX_ASCII;
-
-    std::string text(reinterpret_cast<const char*>(data), size);
-    std::istringstream stream(text);
-
-    // Parse skeleton from Objects section
-    result.skeleton.name = "fbx_skeleton";
-
-    // Look for Model nodes that are LimbNode (bones)
-    std::string line;
-    std::vector<std::pair<std::string, int64_t>> bone_entries;
-    bool in_objects = false;
-
-    while (std::getline(stream, line)) {
-        // Trim whitespace
-        size_t start = line.find_first_not_of(" \t\r\n");
-        if (start == std::string::npos) continue;
-        line = line.substr(start);
-
-        if (line.find("Objects:") == 0) {
-            in_objects = true;
-            continue;
+        std::vector<FBXObjectId> curve_nodes;
+        for (FBXObjectId layer_id : stack.layer_ids) {
+            const FBXObject* layer_obj = scene.get(layer_id);
+            if (!layer_obj || !layer_obj->anim_layer) continue;
+            for (FBXObjectId cn : layer_obj->anim_layer->curve_node_ids) curve_nodes.push_back(cn);
         }
 
-        if (in_objects && line.find("Model:") == 0 && line.find("LimbNode") != std::string::npos) {
-            // Extract bone name
-            auto quote1 = line.find('"');
-            auto quote2 = line.find('"', quote1 + 1);
-            if (quote1 != std::string::npos && quote2 != std::string::npos) {
-                std::string bone_name = line.substr(quote1 + 1, quote2 - quote1 - 1);
-                // Remove "Model::" prefix if present
-                auto prefix = bone_name.find("::");
-                if (prefix != std::string::npos) {
-                    bone_name = bone_name.substr(prefix + 2);
-                }
-                bone_entries.push_back({bone_name, 0});
-            }
-        }
-    }
+        for (FBXObjectId cn_id : curve_nodes) {
+            const FBXObject* cn_obj = scene.get(cn_id);
+            if (!cn_obj || !cn_obj->anim_curve_node) continue;
+            const FBXAnimCurveNode& cn = *cn_obj->anim_curve_node;
 
-    // Build skeleton from discovered bones
-    if (bone_entries.empty()) {
-        Bone root;
-        root.name = "root";
-        root.parent_index = -1;
-        root.bind_pose = Transform::identity();
-        root.inverse_bind_matrix = float4x4::identity();
-        result.skeleton.bones.push_back(root);
-    } else {
-        for (size_t i = 0; i < bone_entries.size(); ++i) {
-            Bone bone;
-            bone.name = bone_entries[i].first;
-            bone.parent_index = (i == 0) ? -1 : 0;  // Simple flat hierarchy
-            bone.bind_pose = Transform::identity();
-            bone.inverse_bind_matrix = float4x4::identity();
-            result.skeleton.bones.push_back(bone);
-        }
-    }
-
-    // Parse animation takes
-    AnimationClipDescriptor clip;
-    clip.name = "Take001";
-    clip.duration = 0.0f;
-    result.clips.push_back(clip);
-
-    result.success = true;
-    return result;
-}
-
-bool FBXImporter::extract_skeleton(const uint8_t* data, size_t size,
-                                    SkeletonDescriptor& out_skeleton) const {
-    // Scan for bone/limb node patterns in binary data
-    out_skeleton.name = "fbx_skeleton";
-
-    // Search for "LimbNode" or "Skeleton" markers in the binary
-    const char* limb_marker = "LimbNode";
-    size_t marker_len = 8;
-
-    std::vector<std::string> bone_names;
-
-    for (size_t i = 0; i + marker_len < size; ++i) {
-        if (std::memcmp(data + i, limb_marker, marker_len) == 0) {
-            // Look backwards for the bone name (preceded by a string in FBX)
-            // Simple heuristic: search for a printable string before this
-            size_t name_end = i - 1;
-            while (name_end > 0 && data[name_end] == 0) --name_end;
-            size_t name_start = name_end;
-            while (name_start > 0 && data[name_start - 1] >= 32 && data[name_start - 1] < 127) {
-                --name_start;
-            }
-            if (name_end > name_start) {
-                std::string name(reinterpret_cast<const char*>(data + name_start),
-                                 name_end - name_start + 1);
-                // Remove "Model::" prefix
-                auto prefix = name.find("::");
-                if (prefix != std::string::npos) {
-                    name = name.substr(prefix + 2);
-                }
-                if (!name.empty()) {
-                    bone_names.push_back(name);
+            // Find the Model this CurveNode is bound to (OP connection src=cn_id).
+            FBXObjectId model_id = 0;
+            std::string prop_name;
+            for (const FBXConnection& c : scene.connections()) {
+                if (c.kind == FBXConnection::OP && c.src == cn_id) {
+                    const FBXObject* dst = scene.get(c.dst);
+                    if (dst && dst->type == FBXObjectType::MODEL) {
+                        model_id  = c.dst;
+                        prop_name = c.property;
+                        break;
+                    }
                 }
             }
+            if (model_id == 0) continue;
+            auto target_it = bone_target.find(model_id);
+            if (target_it == bone_target.end()) continue;
+
+            ChannelTarget ct;
+            if      (prop_name == "Lcl Translation") ct = ChannelTarget::TRANSLATION;
+            else if (prop_name == "Lcl Rotation")    ct = ChannelTarget::ROTATION;
+            else if (prop_name == "Lcl Scaling")     ct = ChannelTarget::SCALE;
+            else continue;
+
+            auto fetch = [&](const std::string& key) -> const FBXAnimCurve* {
+                auto it = cn.curves.find(key);
+                if (it == cn.curves.end()) return nullptr;
+                const FBXObject* o = scene.get(it->second);
+                return (o && o->anim_curve) ? o->anim_curve.get() : nullptr;
+            };
+            const FBXAnimCurve* cx = fetch("d|X");
+            const FBXAnimCurve* cy = fetch("d|Y");
+            const FBXAnimCurve* cz = fetch("d|Z");
+            if (!cx && !cy && !cz) continue;
+
+            std::vector<int64_t> merged;
+            auto merge_from = [&](const FBXAnimCurve* c) {
+                if (!c) return;
+                merged.insert(merged.end(), c->key_time.begin(), c->key_time.end());
+            };
+            merge_from(cx); merge_from(cy); merge_from(cz);
+            std::sort(merged.begin(), merged.end());
+            merged.erase(std::unique(merged.begin(), merged.end()), merged.end());
+            if (merged.empty()) continue;
+
+            auto dflt = [&](const std::string& key) -> float {
+                auto it = cn.default_values.find(key);
+                return (it == cn.default_values.end()) ? 0.0f : static_cast<float>(it->second);
+            };
+            const float dx = dflt("d|X");
+            const float dy = dflt("d|Y");
+            const float dz = dflt("d|Z");
+
+            AnimationChannel ch;
+            ch.target_index = target_it->second;
+            ch.target       = ct;
+            ch.interpolation = InterpolationMode::LINEAR;
+            ch.keyframes.reserve(merged.size());
+
+            const FBXObject* model_obj = scene.get(model_id);
+            const FBXRotationOrder order =
+                (model_obj && model_obj->model) ? model_obj->model->rotation_order : FBXRotationOrder::XYZ;
+
+            for (int64_t kt : merged) {
+                double sec = FBXScene::ktime_to_seconds(kt);
+                float x = sample_curve(cx, sec, dx);
+                float y = sample_curve(cy, sec, dy);
+                float z = sample_curve(cz, sec, dz);
+                Keyframe k;
+                k.time = static_cast<float>(sec);
+                if (ct == ChannelTarget::ROTATION) {
+                    Quaternion q = euler_deg_to_quat({x, y, z}, order);
+                    k.value[0] = q.x; k.value[1] = q.y; k.value[2] = q.z; k.value[3] = q.w;
+                } else {
+                    k.value[0] = x; k.value[1] = y; k.value[2] = z; k.value[3] = 0.0f;
+                }
+                ch.keyframes.push_back(k);
+            }
+            clip.channels.push_back(std::move(ch));
         }
+
+        if (!clip.channels.empty()) out.clips.push_back(std::move(clip));
     }
-
-    if (bone_names.empty()) return false;
-
-    for (size_t i = 0; i < bone_names.size(); ++i) {
-        Bone bone;
-        bone.name = bone_names[i];
-        bone.parent_index = (i == 0) ? -1 : 0; // Default hierarchy
-        bone.bind_pose = Transform::identity();
-        bone.inverse_bind_matrix = float4x4::identity();
-        out_skeleton.bones.push_back(bone);
-    }
-
-    return true;
 }
 
-bool FBXImporter::extract_animations(const uint8_t* data, size_t size,
-                                      const SkeletonDescriptor& skeleton,
-                                      std::vector<AnimationClipDescriptor>& out_clips) const {
-    // Search for AnimationStack or Take markers
-    const char* stack_marker = "AnimStack";
-    size_t marker_len = 9;
+// ─── Skinned meshes ───────────────────────────────────────
 
-    bool found = false;
-    for (size_t i = 0; i + marker_len < size; ++i) {
-        if (std::memcmp(data + i, stack_marker, marker_len) == 0) {
-            found = true;
-            break;
+void FBXImporter::build_skin_meshes(const FBXScene& scene, FBXImportResult& out) const {
+    std::unordered_map<std::string, uint32_t> bone_by_name;
+    for (size_t i = 0; i < out.skeleton.bones.size(); ++i) {
+        bone_by_name[out.skeleton.bones[i].name] = static_cast<uint32_t>(i);
+    }
+
+    for (FBXObjectId gid : scene.ids_of_type(FBXObjectType::GEOMETRY)) {
+        const FBXObject* g = scene.get(gid);
+        if (!g || !g->geometry) continue;
+        const FBXGeometry::Triangulated* tri = scene.triangulate(gid);
+        if (!tri || !tri->valid) continue;
+
+        std::string mesh_name = g->name;
+        for (FBXObjectId pid : scene.parents_of(gid)) {
+            const FBXObject* po = scene.get(pid);
+            if (po && po->type == FBXObjectType::MODEL) {
+                if (mesh_name.empty()) mesh_name = po->name;
+                break;
+            }
         }
+
+        SkinMeshDescriptor mesh;
+        mesh.name         = mesh_name.empty() ? ("mesh_" + std::to_string(gid)) : mesh_name;
+        mesh.vertex_count = static_cast<uint32_t>(tri->positions.size());
+        mesh.index_count  = static_cast<uint32_t>(tri->indices.size());
+        mesh.index_32bit  = true;
+        mesh.index_data      = tri->indices.empty() ? nullptr : tri->indices.data();
+        mesh.index_data_size = tri->indices.size() * sizeof(int32_t);
+        // vertex_data is left null: the triangulated cache owns the raw attrs.
+
+        // Per-vertex skin weights.
+        const uint32_t orig_vcount = static_cast<uint32_t>(g->geometry->positions.size());
+        std::vector<SkinWeight> weights_orig(orig_vcount);
+
+        auto insert_weight = [&](SkinWeight& sw, uint32_t bone, float w) {
+            int min_slot = 0;
+            for (int s = 1; s < 4; ++s)
+                if (sw.weights[s] < sw.weights[min_slot]) min_slot = s;
+            if (w > sw.weights[min_slot]) {
+                sw.weights[min_slot]      = w;
+                sw.bone_indices[min_slot] = bone;
+            }
+        };
+
+        for (FBXObjectId skin_id : scene.children_of(gid)) {
+            const FBXObject* s = scene.get(skin_id);
+            if (!s || !s->skin) continue;
+            for (FBXObjectId cid : s->skin->cluster_ids) {
+                const FBXObject* co = scene.get(cid);
+                if (!co || !co->cluster) continue;
+                const FBXCluster& cl = *co->cluster;
+                const FBXObject* bone_obj = scene.get(cl.bone_model_id);
+                if (!bone_obj) continue;
+                auto bi = bone_by_name.find(bone_obj->name);
+                if (bi == bone_by_name.end()) continue;
+                uint32_t bone_index = bi->second;
+                size_t n = std::min(cl.indices.size(), cl.weights.size());
+                for (size_t k = 0; k < n; ++k) {
+                    int32_t vi = cl.indices[k];
+                    if (vi < 0 || static_cast<uint32_t>(vi) >= orig_vcount) continue;
+                    insert_weight(weights_orig[vi], bone_index, static_cast<float>(cl.weights[k]));
+                }
+            }
+        }
+
+        for (SkinWeight& sw : weights_orig) {
+            float sum = sw.weights[0] + sw.weights[1] + sw.weights[2] + sw.weights[3];
+            if (sum <= 0.0f) {
+                sw.bone_indices[0] = 0;
+                sw.weights[0]      = 1.0f;
+            } else {
+                for (int k = 0; k < 4; ++k) sw.weights[k] /= sum;
+            }
+        }
+
+        mesh.skin_weights.resize(tri->positions.size());
+        for (size_t i = 0; i < tri->positions.size(); ++i) {
+            int32_t orig = (i < tri->original_vertex.size()) ? tri->original_vertex[i] : 0;
+            if (orig < 0 || static_cast<uint32_t>(orig) >= orig_vcount) {
+                SkinWeight sw;
+                sw.bone_indices[0] = 0; sw.weights[0] = 1.0f;
+                mesh.skin_weights[i] = sw;
+            } else {
+                mesh.skin_weights[i] = weights_orig[orig];
+            }
+        }
+
+        // Morph targets.
+        for (FBXObjectId bs_id : scene.children_of(gid)) {
+            const FBXObject* bs_obj = scene.get(bs_id);
+            if (!bs_obj || bs_obj->type != FBXObjectType::DEFORMER_BLENDSHAPE) continue;
+            if (!bs_obj->blendshape) continue;
+            for (FBXObjectId ch_id : bs_obj->blendshape->channel_ids) {
+                const FBXObject* ch_obj = scene.get(ch_id);
+                if (!ch_obj || !ch_obj->blendshape_channel) continue;
+                for (FBXObjectId sg_id : ch_obj->blendshape_channel->shape_ids) {
+                    const FBXObject* sg_obj = scene.get(sg_id);
+                    if (!sg_obj || !sg_obj->shape_geometry) continue;
+                    mesh.morph_target_names.push_back(ch_obj->blendshape_channel->name);
+                    const FBXShapeGeometry& sg = *sg_obj->shape_geometry;
+                    std::vector<float> deltas(static_cast<size_t>(mesh.vertex_count) * 3, 0.0f);
+                    for (size_t i = 0; i < tri->positions.size(); ++i) {
+                        int32_t orig = (i < tri->original_vertex.size()) ? tri->original_vertex[i] : -1;
+                        if (orig < 0) continue;
+                        for (size_t k = 0; k < sg.indices.size(); ++k) {
+                            if (sg.indices[k] == orig && k < sg.position_deltas.size()) {
+                                deltas[i * 3 + 0] = sg.position_deltas[k].x;
+                                deltas[i * 3 + 1] = sg.position_deltas[k].y;
+                                deltas[i * 3 + 2] = sg.position_deltas[k].z;
+                                break;
+                            }
+                        }
+                    }
+                    mesh.morph_deltas.insert(mesh.morph_deltas.end(), deltas.begin(), deltas.end());
+                }
+            }
+        }
+
+        out.skin_meshes.push_back(std::move(mesh));
     }
+}
 
-    if (!found) return false;
+// ─── Material / texture collection ────────────────────────
 
-    // Create a default clip with basic channels for each bone
-    AnimationClipDescriptor clip;
-    clip.name = "Take001";
-    clip.duration = 1.0f;
-    clip.sample_rate = 30.0f;
-    clip.wrap_mode = WrapMode::LOOP;
-
-    for (uint32_t i = 0; i < skeleton.bones.size(); ++i) {
-        // Translation channel
-        AnimationChannel trans_ch;
-        trans_ch.target_index = i;
-        trans_ch.target = ChannelTarget::TRANSLATION;
-        trans_ch.interpolation = InterpolationMode::LINEAR;
-        Keyframe kf0, kf1;
-        kf0.time = 0.0f;
-        kf0.value[0] = skeleton.bones[i].bind_pose.translation.x;
-        kf0.value[1] = skeleton.bones[i].bind_pose.translation.y;
-        kf0.value[2] = skeleton.bones[i].bind_pose.translation.z;
-        kf1 = kf0;
-        kf1.time = clip.duration;
-        trans_ch.keyframes = {kf0, kf1};
-        clip.channels.push_back(trans_ch);
-
-        // Rotation channel
-        AnimationChannel rot_ch;
-        rot_ch.target_index = i;
-        rot_ch.target = ChannelTarget::ROTATION;
-        rot_ch.interpolation = InterpolationMode::LINEAR;
-        Keyframe rk0, rk1;
-        rk0.time = 0.0f;
-        rk0.value[0] = skeleton.bones[i].bind_pose.rotation.x;
-        rk0.value[1] = skeleton.bones[i].bind_pose.rotation.y;
-        rk0.value[2] = skeleton.bones[i].bind_pose.rotation.z;
-        rk0.value[3] = skeleton.bones[i].bind_pose.rotation.w;
-        rk1 = rk0;
-        rk1.time = clip.duration;
-        rot_ch.keyframes = {rk0, rk1};
-        clip.channels.push_back(rot_ch);
+void FBXImporter::collect_materials(const FBXScene& scene, FBXImportResult& out) const {
+    for (FBXObjectId mid : scene.ids_of_type(FBXObjectType::MATERIAL)) {
+        const FBXObject* m = scene.get(mid);
+        if (!m || !m->material) continue;
+        out.material_slots.push_back(m->material->name);
     }
-
-    out_clips.push_back(clip);
-    return true;
+    std::unordered_set<std::string> seen;
+    for (FBXObjectId tid : scene.ids_of_type(FBXObjectType::TEXTURE)) {
+        const FBXObject* t = scene.get(tid);
+        if (!t || !t->texture) continue;
+        const std::string& path = !t->texture->file_name.empty() ? t->texture->file_name
+                                                                  : t->texture->relative_filename;
+        if (path.empty()) continue;
+        if (seen.insert(path).second) out.texture_paths.push_back(path);
+    }
 }
 
 } // namespace pictor

--- a/src/animation/fbx_scene.cpp
+++ b/src/animation/fbx_scene.cpp
@@ -1,0 +1,1111 @@
+﻿// FBX Scene -- Level 2+3 implementation
+//
+// Structure:
+//   1. Helpers (Properties70 parser, LayerElement parser, math utils)
+//   2. Per-type object parsers (Model / Geometry / Material / Texture /
+//      Video / Deformer / BlendShape / Pose / Anim / NodeAttribute)
+//   3. Connection graph builder
+//   4. FBXScene::load orchestration
+//   5. Accessors (get / has / ids / traversal)
+//   6. Triangulation + transform evaluation
+//
+// No third-party dependencies. All parse failures are non-fatal and
+// accumulate into warnings_; the scene loads in best-effort fashion.
+
+#include "pictor/animation/fbx_scene.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <sstream>
+#include <string>
+
+namespace pictor {
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kDegToRad = kPi / 180.0;
+
+/// assign with explicit element cast to silence narrowing warnings.
+template <typename Dst, typename Src>
+void assign_cast(std::vector<Dst>& dst, const std::vector<Src>& src) {
+    dst.clear();
+    dst.reserve(src.size());
+    for (const auto& v : src) dst.push_back(static_cast<Dst>(v));
+}
+
+inline float3 to_float3(const FBXProperty* p) {
+    if (!p) return {};
+    // Properties70 entries that represent vector values usually have 4 trailing
+    // properties: "ColorType"|"Color"|"", "Color", "" and then r,g,b. We pull
+    // the last three numeric values out of the tail.
+    (void)p;
+    return {};
+}
+
+// ─── Properties70 unit parser ──────────────────────────────
+//
+// Each "P" child of a Properties70 node has the shape:
+//   P: "name", "type", "sub_type", "flags", ... values ...
+// Examples:
+//   P: "Lcl Translation", "Lcl Translation", "", "A", 1.0, 2.0, 3.0
+//   P: "Visibility",      "Visibility",      "",  "A", 1
+//   P: "RotationOrder",   "enum",            "",  "",  0
+//   P: "FileName",        "KString",         "",  "", "path/to/file"
+
+struct PropValue {
+    std::string              str;
+    std::vector<double>      numbers;
+    bool                     has_string = false;
+    bool                     has_numeric = false;
+};
+
+struct Properties70 {
+    std::unordered_map<std::string, PropValue> map;
+
+    const PropValue* get(const std::string& name) const {
+        auto it = map.find(name);
+        return (it == map.end()) ? nullptr : &it->second;
+    }
+    double number(const std::string& name, double fallback = 0.0) const {
+        const PropValue* v = get(name);
+        if (!v || v->numbers.empty()) return fallback;
+        return v->numbers[0];
+    }
+    float3 vec3(const std::string& name, float3 fallback = {0, 0, 0}) const {
+        const PropValue* v = get(name);
+        if (!v || v->numbers.size() < 3) return fallback;
+        return {static_cast<float>(v->numbers[0]),
+                static_cast<float>(v->numbers[1]),
+                static_cast<float>(v->numbers[2])};
+    }
+    std::string str(const std::string& name, const std::string& fallback = {}) const {
+        const PropValue* v = get(name);
+        if (!v || !v->has_string) return fallback;
+        return v->str;
+    }
+    bool has(const std::string& name) const { return map.count(name) > 0; }
+};
+
+Properties70 parse_properties70(const FBXNode* node) {
+    Properties70 out;
+    if (!node) return out;
+    for (const FBXNode& p : node->children) {
+        if (p.name != "P" && p.name != "Property") continue;
+        if (p.properties.empty()) continue;
+        const std::string name = p.properties[0].as_string();
+        PropValue v;
+        // P: name, type, sub_type, flags, value0, value1, ...
+        for (size_t i = 4; i < p.properties.size(); ++i) {
+            const FBXProperty& pv = p.properties[i];
+            if (pv.is_string()) {
+                v.str = pv.as_string();
+                v.has_string = true;
+            } else {
+                v.numbers.push_back(pv.as_double());
+                v.has_numeric = true;
+            }
+        }
+        if (v.numbers.empty() && !v.has_string) {
+            // Fallback: older ASCII dumps might have the value at position 3
+            if (p.properties.size() >= 4) {
+                const FBXProperty& pv = p.properties[3];
+                if (pv.is_string()) { v.str = pv.as_string(); v.has_string = true; }
+                else { v.numbers.push_back(pv.as_double()); v.has_numeric = true; }
+            }
+        }
+        out.map[name] = std::move(v);
+    }
+    return out;
+}
+
+// ─── Layer element parsing helpers ─────────────────────────
+
+FBXMappingMode parse_mapping_mode(const std::string& s) {
+    if (s == "ByPolygonVertex") return FBXMappingMode::BY_POLYGON_VERTEX;
+    if (s == "ByVertex"   || s == "ByVertice") return FBXMappingMode::BY_VERTEX;
+    if (s == "ByPolygon") return FBXMappingMode::BY_POLYGON;
+    if (s == "ByEdge")    return FBXMappingMode::BY_EDGE;
+    if (s == "AllSame")   return FBXMappingMode::ALL_SAME;
+    return FBXMappingMode::NONE;
+}
+FBXReferenceMode parse_reference_mode(const std::string& s) {
+    if (s == "IndexToDirect" || s == "Index To Direct") return FBXReferenceMode::INDEX_TO_DIRECT;
+    if (s == "Index")  return FBXReferenceMode::INDEX;
+    return FBXReferenceMode::DIRECT;
+}
+
+// Split a flat array of doubles (xyz triplets) into float3 list.
+std::vector<float3> as_float3_list(const std::vector<double>& d) {
+    std::vector<float3> r;
+    r.reserve(d.size() / 3);
+    for (size_t i = 0; i + 2 < d.size(); i += 3) {
+        r.push_back({static_cast<float>(d[i]),
+                     static_cast<float>(d[i + 1]),
+                     static_cast<float>(d[i + 2])});
+    }
+    return r;
+}
+std::vector<float4> as_float4_list(const std::vector<double>& d) {
+    std::vector<float4> r;
+    r.reserve(d.size() / 4);
+    for (size_t i = 0; i + 3 < d.size(); i += 4) {
+        r.push_back({static_cast<float>(d[i]),
+                     static_cast<float>(d[i + 1]),
+                     static_cast<float>(d[i + 2]),
+                     static_cast<float>(d[i + 3])});
+    }
+    return r;
+}
+
+// ─── Matrix helpers (row-major, row-vector convention) ─────
+//
+// Pictor's float4x4 stores m[row][col], with translation at m[3][0..2]
+// and a transform of a row-vector is v * M.
+
+float4x4 mat_identity() { return float4x4::identity(); }
+
+float4x4 mat_from_row_major(const std::vector<double>& d) {
+    float4x4 m{};
+    if (d.size() >= 16) {
+        for (int r = 0; r < 4; ++r)
+            for (int c = 0; c < 4; ++c)
+                m.m[r][c] = static_cast<float>(d[r * 4 + c]);
+    } else {
+        m = mat_identity();
+    }
+    return m;
+}
+
+float4x4 mat_mul(const float4x4& a, const float4x4& b) {
+    float4x4 r{};
+    for (int i = 0; i < 4; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            float s = 0.0f;
+            for (int k = 0; k < 4; ++k) s += a.m[i][k] * b.m[k][j];
+            r.m[i][j] = s;
+        }
+    }
+    return r;
+}
+
+float4x4 mat_translation(const float3& t) {
+    float4x4 m = mat_identity();
+    m.m[3][0] = t.x; m.m[3][1] = t.y; m.m[3][2] = t.z;
+    return m;
+}
+
+float4x4 mat_scale(const float3& s) {
+    float4x4 m{};
+    m.m[0][0] = s.x; m.m[1][1] = s.y; m.m[2][2] = s.z; m.m[3][3] = 1.0f;
+    return m;
+}
+
+float4x4 mat_rotation_euler(const float3& deg, FBXRotationOrder order) {
+    const float rx = static_cast<float>(deg.x * kDegToRad);
+    const float ry = static_cast<float>(deg.y * kDegToRad);
+    const float rz = static_cast<float>(deg.z * kDegToRad);
+    auto Rx = [&]() {
+        float c = std::cos(rx), s = std::sin(rx);
+        float4x4 m = mat_identity();
+        m.m[1][1] =  c; m.m[1][2] = s;
+        m.m[2][1] = -s; m.m[2][2] = c;
+        return m;
+    };
+    auto Ry = [&]() {
+        float c = std::cos(ry), s = std::sin(ry);
+        float4x4 m = mat_identity();
+        m.m[0][0] = c; m.m[0][2] = -s;
+        m.m[2][0] = s; m.m[2][2] =  c;
+        return m;
+    };
+    auto Rz = [&]() {
+        float c = std::cos(rz), s = std::sin(rz);
+        float4x4 m = mat_identity();
+        m.m[0][0] =  c; m.m[0][1] = s;
+        m.m[1][0] = -s; m.m[1][1] = c;
+        return m;
+    };
+    // With row-vector convention, composing Ra * Rb means first applying Ra
+    // then Rb. FBX rotation order XYZ = v' = v * Rx * Ry * Rz.
+    switch (order) {
+        case FBXRotationOrder::XYZ: return mat_mul(mat_mul(Rx(), Ry()), Rz());
+        case FBXRotationOrder::XZY: return mat_mul(mat_mul(Rx(), Rz()), Ry());
+        case FBXRotationOrder::YZX: return mat_mul(mat_mul(Ry(), Rz()), Rx());
+        case FBXRotationOrder::YXZ: return mat_mul(mat_mul(Ry(), Rx()), Rz());
+        case FBXRotationOrder::ZXY: return mat_mul(mat_mul(Rz(), Rx()), Ry());
+        case FBXRotationOrder::ZYX: return mat_mul(mat_mul(Rz(), Ry()), Rx());
+        default:                    return mat_mul(mat_mul(Rx(), Ry()), Rz());
+    }
+}
+
+float4x4 mat_inverse_rigid(const float4x4& m) {
+    // Inverse assuming the matrix is a rigid transform (orthonormal rotation +
+    // translation, scale == 1). Rotation inverse = transpose. Translation
+    // inverse = -R^T * t.
+    float4x4 r = mat_identity();
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j)
+            r.m[i][j] = m.m[j][i];
+    float tx = m.m[3][0], ty = m.m[3][1], tz = m.m[3][2];
+    r.m[3][0] = -(r.m[0][0] * tx + r.m[1][0] * ty + r.m[2][0] * tz);
+    r.m[3][1] = -(r.m[0][1] * tx + r.m[1][1] * ty + r.m[2][1] * tz);
+    r.m[3][2] = -(r.m[0][2] * tx + r.m[1][2] * ty + r.m[2][2] * tz);
+    return r;
+}
+
+// ─── Object id / name helpers ─────────────────────────────
+
+FBXObjectId read_object_id(const FBXNode& node) {
+    if (node.properties.empty()) return 0;
+    return static_cast<FBXObjectId>(node.properties[0].as_int());
+}
+
+// FBX stores object "name" as "RealName\x00\x01SubClass" in binary, or as
+// "SubClass::RealName" in ASCII. Extract the real name.
+std::string extract_object_name(const std::string& raw) {
+    auto sep = raw.find("\x00\x01", 0, 2);
+    if (sep != std::string::npos) return raw.substr(0, sep);
+    auto sc = raw.find("::");
+    if (sc != std::string::npos) return raw.substr(sc + 2);
+    return raw;
+}
+std::string extract_object_class(const std::string& raw) {
+    auto sep = raw.find("\x00\x01", 0, 2);
+    if (sep != std::string::npos) return raw.substr(sep + 2);
+    auto sc = raw.find("::");
+    if (sc != std::string::npos) return raw.substr(0, sc);
+    return {};
+}
+
+// Derive FBXObjectType from the node name + class tag. Returns UNKNOWN if not
+// recognized.
+FBXObjectType classify(const std::string& node_name,
+                        const std::string& class_tag) {
+    if (node_name == "Model") return FBXObjectType::MODEL;
+    if (node_name == "Geometry") {
+        if (class_tag == "Shape") return FBXObjectType::SHAPE_GEOMETRY;
+        return FBXObjectType::GEOMETRY;
+    }
+    if (node_name == "Material")       return FBXObjectType::MATERIAL;
+    if (node_name == "Texture")        return FBXObjectType::TEXTURE;
+    if (node_name == "Video")          return FBXObjectType::VIDEO;
+    if (node_name == "Deformer") {
+        if (class_tag == "Skin")             return FBXObjectType::DEFORMER_SKIN;
+        if (class_tag == "Cluster")          return FBXObjectType::DEFORMER_CLUSTER;
+        if (class_tag == "BlendShape")       return FBXObjectType::DEFORMER_BLENDSHAPE;
+        if (class_tag == "BlendShapeChannel") return FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL;
+        return FBXObjectType::UNKNOWN;
+    }
+    if (node_name == "Pose")          return FBXObjectType::POSE;
+    if (node_name == "AnimationStack") return FBXObjectType::ANIMATION_STACK;
+    if (node_name == "AnimationLayer") return FBXObjectType::ANIMATION_LAYER;
+    if (node_name == "AnimationCurveNode") return FBXObjectType::ANIMATION_CURVE_NODE;
+    if (node_name == "AnimationCurve")     return FBXObjectType::ANIMATION_CURVE;
+    if (node_name == "NodeAttribute")      return FBXObjectType::NODE_ATTRIBUTE;
+    return FBXObjectType::UNKNOWN;
+}
+
+FBXRotationOrder int_to_rotation_order(int v) {
+    switch (v) {
+        case 0: return FBXRotationOrder::XYZ;
+        case 1: return FBXRotationOrder::XZY;
+        case 2: return FBXRotationOrder::YZX;
+        case 3: return FBXRotationOrder::YXZ;
+        case 4: return FBXRotationOrder::ZXY;
+        case 5: return FBXRotationOrder::ZYX;
+        case 6: return FBXRotationOrder::SPHERIC_XYZ;
+        default: return FBXRotationOrder::XYZ;
+    }
+}
+
+} // namespace
+
+// ─── Per-type parsers ──────────────────────────────────────
+
+void FBXScene::parse_model(FBXObject& obj, const FBXNode& node) {
+    obj.model = std::make_unique<FBXModel>();
+    FBXModel& m = *obj.model;
+    m.name = obj.name;
+    if (node.properties.size() >= 3) {
+        m.sub_type = node.properties[2].as_string();
+    }
+    const FBXNode* props_node = node.find_child("Properties70");
+    if (!props_node) props_node = node.find_child("Properties60");
+    Properties70 p = parse_properties70(props_node);
+
+    m.translation   = p.vec3("Lcl Translation",  m.translation);
+    m.rotation      = p.vec3("Lcl Rotation",     m.rotation);
+    m.scaling       = p.vec3("Lcl Scaling",      m.scaling);
+    m.rotation_offset = p.vec3("RotationOffset", m.rotation_offset);
+    m.rotation_pivot  = p.vec3("RotationPivot",  m.rotation_pivot);
+    m.scaling_offset  = p.vec3("ScalingOffset",  m.scaling_offset);
+    m.scaling_pivot   = p.vec3("ScalingPivot",   m.scaling_pivot);
+    m.pre_rotation    = p.vec3("PreRotation",    m.pre_rotation);
+    m.post_rotation   = p.vec3("PostRotation",   m.post_rotation);
+
+    m.rotation_order = int_to_rotation_order(static_cast<int>(p.number("RotationOrder", 0)));
+    m.visibility     = (p.number("Visibility", 1) != 0);
+}
+
+void FBXScene::parse_geometry(FBXObject& obj, const FBXNode& node) {
+    obj.geometry = std::make_unique<FBXGeometry>();
+    FBXGeometry& g = *obj.geometry;
+
+    if (const FBXNode* v = node.find_child("Vertices")) {
+        if (!v->properties.empty()) {
+            g.positions = as_float3_list(v->properties[0].as_double_array());
+        }
+    }
+    if (const FBXNode* v = node.find_child("PolygonVertexIndex")) {
+        if (!v->properties.empty()) {
+            assign_cast(g.polygon_vertex_index, v->properties[0].as_int_array());
+        }
+    }
+    if (const FBXNode* v = node.find_child("Edges")) {
+        if (!v->properties.empty()) {
+            assign_cast(g.edges, v->properties[0].as_int_array());
+        }
+    }
+
+    // LayerElementNormal / Tangent / Binormal / UV / Color / Material / Smoothing
+    for (const FBXNode& child : node.children) {
+        if (child.name == "LayerElementNormal") {
+            FBXLayerElement<float3> le;
+            if (const FBXNode* n = child.find_child("Name")) if (!n->properties.empty()) le.name = n->properties[0].as_string();
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   le.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) le.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Normals")) if (!n->properties.empty()) le.data = as_float3_list(n->properties[0].as_double_array());
+            if (const FBXNode* n = child.find_child("NormalsIndex")) if (!n->properties.empty()) {
+                assign_cast(le.index, n->properties[0].as_int_array());
+            }
+            g.normals.push_back(std::move(le));
+        } else if (child.name == "LayerElementTangent") {
+            FBXLayerElement<float3> le;
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   le.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) le.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Tangents")) if (!n->properties.empty()) le.data = as_float3_list(n->properties[0].as_double_array());
+            g.tangents.push_back(std::move(le));
+        } else if (child.name == "LayerElementBinormal") {
+            FBXLayerElement<float3> le;
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   le.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) le.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Binormals")) if (!n->properties.empty()) le.data = as_float3_list(n->properties[0].as_double_array());
+            g.binormals.push_back(std::move(le));
+        } else if (child.name == "LayerElementColor") {
+            FBXLayerElement<float4> le;
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   le.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) le.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Colors")) if (!n->properties.empty()) le.data = as_float4_list(n->properties[0].as_double_array());
+            if (const FBXNode* n = child.find_child("ColorIndex")) if (!n->properties.empty()) {
+                assign_cast(le.index, n->properties[0].as_int_array());
+            }
+            g.colors.push_back(std::move(le));
+        } else if (child.name == "LayerElementUV") {
+            FBXGeometry::UVSet uv;
+            if (const FBXNode* n = child.find_child("Name")) if (!n->properties.empty()) uv.name = n->properties[0].as_string();
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   uv.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) uv.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("UV")) if (!n->properties.empty()) {
+                auto d = n->properties[0].as_double_array();
+                uv.u.reserve(d.size() / 2);
+                uv.v.reserve(d.size() / 2);
+                for (size_t i = 0; i + 1 < d.size(); i += 2) {
+                    uv.u.push_back(static_cast<float>(d[i]));
+                    uv.v.push_back(static_cast<float>(d[i + 1]));
+                }
+            }
+            if (const FBXNode* n = child.find_child("UVIndex")) if (!n->properties.empty()) {
+                assign_cast(uv.index, n->properties[0].as_int_array());
+            }
+            g.uv_sets.push_back(std::move(uv));
+        } else if (child.name == "LayerElementMaterial") {
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   g.material_indices.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) g.material_indices.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Materials")) if (!n->properties.empty()) {
+                assign_cast(g.material_indices.data, n->properties[0].as_int_array());
+            }
+        } else if (child.name == "LayerElementSmoothing") {
+            if (const FBXNode* n = child.find_child("MappingInformationType"))   g.smoothing.mapping   = parse_mapping_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("ReferenceInformationType")) g.smoothing.reference = parse_reference_mode(n->properties.empty() ? "" : n->properties[0].as_string());
+            if (const FBXNode* n = child.find_child("Smoothing")) if (!n->properties.empty()) {
+                assign_cast(g.smoothing.data, n->properties[0].as_int_array());
+            }
+        }
+    }
+}
+
+void FBXScene::parse_material(FBXObject& obj, const FBXNode& node) {
+    obj.material = std::make_unique<FBXMaterial>();
+    FBXMaterial& m = *obj.material;
+    m.name = obj.name;
+    if (const FBXNode* sm = node.find_child("ShadingModel")) {
+        if (!sm->properties.empty()) m.shading_model = sm->properties[0].as_string();
+    }
+    Properties70 p = parse_properties70(node.find_child("Properties70"));
+    m.ambient   = p.vec3("AmbientColor",  m.ambient);
+    m.diffuse   = p.vec3("DiffuseColor",  m.diffuse);
+    m.specular  = p.vec3("SpecularColor", m.specular);
+    m.emissive  = p.vec3("EmissiveColor", m.emissive);
+    m.reflection = p.vec3("ReflectionColor", m.reflection);
+    m.opacity        = static_cast<float>(p.number("Opacity",       m.opacity));
+    m.shininess      = static_cast<float>(p.number("Shininess",     m.shininess));
+    m.shininess      = static_cast<float>(p.number("ShininessExponent", m.shininess));
+    m.reflectivity   = static_cast<float>(p.number("Reflectivity",  m.reflectivity));
+    m.diffuse_factor  = static_cast<float>(p.number("DiffuseFactor",  m.diffuse_factor));
+    m.specular_factor = static_cast<float>(p.number("SpecularFactor", m.specular_factor));
+    m.emissive_factor = static_cast<float>(p.number("EmissiveFactor", m.emissive_factor));
+}
+
+void FBXScene::parse_texture(FBXObject& obj, const FBXNode& node) {
+    obj.texture = std::make_unique<FBXTexture>();
+    FBXTexture& t = *obj.texture;
+    t.name = obj.name;
+    if (const FBXNode* n = node.find_child("FileName"))         if (!n->properties.empty()) t.file_name = n->properties[0].as_string();
+    if (const FBXNode* n = node.find_child("RelativeFilename")) if (!n->properties.empty()) t.relative_filename = n->properties[0].as_string();
+    Properties70 p = parse_properties70(node.find_child("Properties70"));
+    if (p.has("UVSet"))      t.uv_set = p.str("UVSet");
+    if (p.has("WrapModeU"))  t.wrap_u = static_cast<int>(p.number("WrapModeU", 0));
+    if (p.has("WrapModeV"))  t.wrap_v = static_cast<int>(p.number("WrapModeV", 0));
+}
+
+void FBXScene::parse_video(FBXObject& obj, const FBXNode& node) {
+    obj.video = std::make_unique<FBXVideo>();
+    FBXVideo& v = *obj.video;
+    v.name = obj.name;
+    if (const FBXNode* n = node.find_child("FileName"))         if (!n->properties.empty()) v.file_name = n->properties[0].as_string();
+    if (const FBXNode* n = node.find_child("RelativeFilename")) if (!n->properties.empty()) v.relative_filename = n->properties[0].as_string();
+    if (const FBXNode* n = node.find_child("Content")) {
+        if (!n->properties.empty()) {
+            const FBXProperty& pp = n->properties[0];
+            if (pp.type == FBXPropertyType::RAW || pp.type == FBXPropertyType::STRING) {
+                v.content.assign(pp.str.begin(), pp.str.end());
+            }
+        }
+    }
+}
+
+void FBXScene::parse_deformer(FBXObject& obj, const FBXNode& node) {
+    // The Deformer node may represent Skin, Cluster, BlendShape, or
+    // BlendShapeChannel. The class tag determined the object type earlier.
+    switch (obj.type) {
+        case FBXObjectType::DEFORMER_SKIN: {
+            obj.skin = std::make_unique<FBXSkinDeformer>();
+            FBXSkinDeformer& s = *obj.skin;
+            s.name = obj.name;
+            if (const FBXNode* n = node.find_child("SkinningType")) {
+                // "Linear", "Blend" etc. -- parsed loosely.
+                (void)n;
+            }
+            Properties70 p = parse_properties70(node.find_child("Properties70"));
+            s.skinning_type_blend_weight = p.number("BlendWeights", 0.0);
+            break;
+        }
+        case FBXObjectType::DEFORMER_CLUSTER: {
+            obj.cluster = std::make_unique<FBXCluster>();
+            FBXCluster& c = *obj.cluster;
+            c.name = obj.name;
+            if (const FBXNode* n = node.find_child("Indexes")) {
+                if (!n->properties.empty()) {
+                    assign_cast(c.indices, n->properties[0].as_int_array());
+                }
+            }
+            if (const FBXNode* n = node.find_child("Weights")) {
+                if (!n->properties.empty()) c.weights = n->properties[0].as_double_array();
+            }
+            if (const FBXNode* n = node.find_child("Transform")) {
+                if (!n->properties.empty()) c.transform = mat_from_row_major(n->properties[0].as_double_array());
+            }
+            if (const FBXNode* n = node.find_child("TransformLink")) {
+                if (!n->properties.empty()) c.transform_link = mat_from_row_major(n->properties[0].as_double_array());
+            }
+            if (const FBXNode* n = node.find_child("TransformAssociateModel")) {
+                if (!n->properties.empty()) c.transform_associate = mat_from_row_major(n->properties[0].as_double_array());
+            }
+            break;
+        }
+        case FBXObjectType::DEFORMER_BLENDSHAPE: {
+            obj.blendshape = std::make_unique<FBXBlendShape>();
+            obj.blendshape->name = obj.name;
+            break;
+        }
+        case FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL: {
+            obj.blendshape_channel = std::make_unique<FBXBlendShapeChannel>();
+            FBXBlendShapeChannel& c = *obj.blendshape_channel;
+            c.name = obj.name;
+            Properties70 p = parse_properties70(node.find_child("Properties70"));
+            c.deform_percent = p.number("DeformPercent", 0.0);
+            if (const FBXNode* n = node.find_child("FullWeights")) {
+                if (!n->properties.empty()) c.full_weights = n->properties[0].as_double_array();
+            }
+            break;
+        }
+        default: break;
+    }
+}
+
+void FBXScene::parse_pose(FBXObject& obj, const FBXNode& node) {
+    obj.pose = std::make_unique<FBXPose>();
+    FBXPose& p = *obj.pose;
+    p.name = obj.name;
+    if (node.properties.size() >= 3) {
+        p.is_bind_pose = (node.properties[2].as_string() == "BindPose");
+    }
+    for (const FBXNode& child : node.children) {
+        if (child.name != "PoseNode") continue;
+        FBXObjectId target_id = 0;
+        float4x4    matrix    = mat_identity();
+        if (const FBXNode* n = child.find_child("Node")) {
+            if (!n->properties.empty()) target_id = static_cast<FBXObjectId>(n->properties[0].as_int());
+        }
+        if (const FBXNode* n = child.find_child("Matrix")) {
+            if (!n->properties.empty()) matrix = mat_from_row_major(n->properties[0].as_double_array());
+        }
+        if (target_id != 0) p.model_matrices[target_id] = matrix;
+    }
+}
+
+void FBXScene::parse_anim_stack(FBXObject& obj, const FBXNode& node) {
+    obj.anim_stack = std::make_unique<FBXAnimStack>();
+    FBXAnimStack& s = *obj.anim_stack;
+    s.name = obj.name;
+    Properties70 p = parse_properties70(node.find_child("Properties70"));
+    s.local_start     = static_cast<int64_t>(p.number("LocalStart",     0));
+    s.local_stop      = static_cast<int64_t>(p.number("LocalStop",      0));
+    s.reference_start = static_cast<int64_t>(p.number("ReferenceStart", 0));
+    s.reference_stop  = static_cast<int64_t>(p.number("ReferenceStop",  0));
+}
+
+void FBXScene::parse_anim_layer(FBXObject& obj, const FBXNode& /*node*/) {
+    obj.anim_layer = std::make_unique<FBXAnimLayer>();
+    obj.anim_layer->name = obj.name;
+}
+
+void FBXScene::parse_anim_curve_node(FBXObject& obj, const FBXNode& node) {
+    obj.anim_curve_node = std::make_unique<FBXAnimCurveNode>();
+    obj.anim_curve_node->name = obj.name;
+    // Default values are stored in Properties70 under names like "d|X".
+    Properties70 p = parse_properties70(node.find_child("Properties70"));
+    for (const auto& kv : p.map) {
+        if (!kv.second.numbers.empty() && kv.first.rfind("d|", 0) == 0) {
+            obj.anim_curve_node->default_values[kv.first] = kv.second.numbers[0];
+        }
+    }
+}
+
+void FBXScene::parse_anim_curve(FBXObject& obj, const FBXNode& node) {
+    obj.anim_curve = std::make_unique<FBXAnimCurve>();
+    FBXAnimCurve& c = *obj.anim_curve;
+    if (const FBXNode* n = node.find_child("KeyTime")) {
+        if (!n->properties.empty()) c.key_time = n->properties[0].as_int_array();
+    }
+    if (const FBXNode* n = node.find_child("KeyValueFloat")) {
+        if (!n->properties.empty()) assign_cast(c.key_value, n->properties[0].as_double_array());
+    }
+    if (const FBXNode* n = node.find_child("KeyAttrFlags")) {
+        if (!n->properties.empty()) assign_cast(c.key_flag, n->properties[0].as_int_array());
+    }
+    if (const FBXNode* n = node.find_child("KeyAttrDataFloat")) {
+        if (!n->properties.empty()) assign_cast(c.key_attr_data, n->properties[0].as_double_array());
+    }
+    if (const FBXNode* n = node.find_child("KeyAttrRefCount")) {
+        if (!n->properties.empty()) assign_cast(c.key_attr_ref_count, n->properties[0].as_int_array());
+    }
+}
+
+void FBXScene::parse_node_attribute(FBXObject& obj, const FBXNode& node) {
+    obj.node_attribute = std::make_unique<FBXNodeAttribute>();
+    FBXNodeAttribute& a = *obj.node_attribute;
+    a.name = obj.name;
+    a.sub_type = obj.class_tag;
+    Properties70 p = parse_properties70(node.find_child("Properties70"));
+    a.limb_size = p.number("Size", 1.0);
+    for (const auto& kv : p.map) {
+        if (kv.second.has_string) a.string_props[kv.first] = kv.second.str;
+        else if (!kv.second.numbers.empty()) a.numeric_props[kv.first] = kv.second.numbers[0];
+    }
+}
+
+// ─── Top-level load ────────────────────────────────────────
+
+FBXObject& FBXScene::ensure_object(FBXObjectId id) {
+    auto it = objects_.find(id);
+    if (it != objects_.end()) return *it->second;
+    auto uptr = std::make_unique<FBXObject>();
+    uptr->id = id;
+    FBXObject* raw = uptr.get();
+    objects_.emplace(id, std::move(uptr));
+    return *raw;
+}
+
+void FBXScene::parse_global_settings(const FBXNode& settings_node) {
+    Properties70 p = parse_properties70(settings_node.find_child("Properties70"));
+    global_settings.up_axis         = static_cast<int>(p.number("UpAxis",         1));
+    global_settings.up_axis_sign    = static_cast<int>(p.number("UpAxisSign",     1));
+    global_settings.front_axis      = static_cast<int>(p.number("FrontAxis",      2));
+    global_settings.front_axis_sign = static_cast<int>(p.number("FrontAxisSign",  1));
+    global_settings.coord_axis      = static_cast<int>(p.number("CoordAxis",      0));
+    global_settings.coord_axis_sign = static_cast<int>(p.number("CoordAxisSign",  1));
+    global_settings.time_mode       = static_cast<int>(p.number("TimeMode",       6));
+    global_settings.unit_scale      = p.number("UnitScaleFactor",         1.0);
+    global_settings.original_unit_scale = p.number("OriginalUnitScaleFactor", 1.0);
+    global_settings.time_span_start = static_cast<int64_t>(p.number("TimeSpanStart", 0));
+    global_settings.time_span_stop  = static_cast<int64_t>(p.number("TimeSpanStop",  0));
+    global_settings.custom_frame_rate = p.number("CustomFrameRate", 24.0);
+}
+
+void FBXScene::parse_documents(const FBXNode& docs_node) {
+    // Not strictly needed for single-document FBX, but we capture Creator /
+    // ApplicationName for metadata.
+    for (const FBXNode& doc : docs_node.children) {
+        if (doc.name != "Document") continue;
+        if (const FBXNode* n = doc.find_child("RootNode")) (void)n;
+    }
+}
+
+void FBXScene::parse_objects(const FBXNode& objects_node) {
+    for (const FBXNode& child : objects_node.children) {
+        FBXObjectId id = read_object_id(child);
+        if (id == 0) continue;
+        std::string raw_name = (child.properties.size() >= 2) ? child.properties[1].as_string() : std::string{};
+        std::string class_tag = (child.properties.size() >= 3) ? child.properties[2].as_string() : std::string{};
+        if (class_tag.empty()) {
+            class_tag = extract_object_class(raw_name);
+        }
+        std::string name = extract_object_name(raw_name);
+
+        FBXObjectType type = classify(child.name, class_tag);
+        FBXObject& obj = ensure_object(id);
+        obj.type        = type;
+        obj.name        = name;
+        obj.class_tag   = class_tag;
+        obj.source_node = &child;
+
+        switch (type) {
+            case FBXObjectType::MODEL:                  parse_model(obj, child); break;
+            case FBXObjectType::GEOMETRY:               parse_geometry(obj, child); break;
+            case FBXObjectType::SHAPE_GEOMETRY: {
+                obj.shape_geometry = std::make_unique<FBXShapeGeometry>();
+                FBXShapeGeometry& sg = *obj.shape_geometry;
+                if (const FBXNode* n = child.find_child("Indexes")) {
+                    if (!n->properties.empty()) assign_cast(sg.indices, n->properties[0].as_int_array());
+                }
+                if (const FBXNode* n = child.find_child("Vertices")) {
+                    if (!n->properties.empty()) sg.position_deltas = as_float3_list(n->properties[0].as_double_array());
+                }
+                if (const FBXNode* n = child.find_child("Normals")) {
+                    if (!n->properties.empty()) sg.normal_deltas = as_float3_list(n->properties[0].as_double_array());
+                }
+                break;
+            }
+            case FBXObjectType::MATERIAL: parse_material(obj, child); break;
+            case FBXObjectType::TEXTURE:  parse_texture(obj, child);  break;
+            case FBXObjectType::VIDEO:    parse_video(obj, child);    break;
+            case FBXObjectType::DEFORMER_SKIN:
+            case FBXObjectType::DEFORMER_CLUSTER:
+            case FBXObjectType::DEFORMER_BLENDSHAPE:
+            case FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL:
+                parse_deformer(obj, child); break;
+            case FBXObjectType::POSE:                 parse_pose(obj, child); break;
+            case FBXObjectType::ANIMATION_STACK:      parse_anim_stack(obj, child); break;
+            case FBXObjectType::ANIMATION_LAYER:      parse_anim_layer(obj, child); break;
+            case FBXObjectType::ANIMATION_CURVE_NODE: parse_anim_curve_node(obj, child); break;
+            case FBXObjectType::ANIMATION_CURVE:      parse_anim_curve(obj, child); break;
+            case FBXObjectType::NODE_ATTRIBUTE:       parse_node_attribute(obj, child); break;
+            default: break;
+        }
+        ids_by_type_[type].push_back(id);
+    }
+}
+
+void FBXScene::parse_connections(const FBXNode& connections_node) {
+    for (const FBXNode& child : connections_node.children) {
+        if (child.name != "C" && child.name != "Connect") continue;
+        if (child.properties.size() < 3) continue;
+        const std::string kind = child.properties[0].as_string();
+        FBXObjectId src = static_cast<FBXObjectId>(child.properties[1].as_int());
+        FBXObjectId dst = static_cast<FBXObjectId>(child.properties[2].as_int());
+        FBXConnection c;
+        c.src = src;
+        c.dst = dst;
+        if (kind == "OP") {
+            c.kind = FBXConnection::OP;
+            if (child.properties.size() >= 4) c.property = child.properties[3].as_string();
+        } else {
+            c.kind = FBXConnection::OO;
+        }
+        size_t idx = connections_.size();
+        connections_.push_back(std::move(c));
+        conn_by_src_[src].push_back(idx);
+        conn_by_dst_[dst].push_back(idx);
+    }
+}
+
+void FBXScene::finalize_root_models() {
+    // Post-process connections to fill aggregate relationships that need
+    // indices from both sides.
+    for (const FBXConnection& c : connections_) {
+        const FBXObject* src = get(c.src);
+        const FBXObject* dst = get(c.dst);
+        if (!src || !dst) continue;
+
+        if (c.kind == FBXConnection::OO) {
+            // Skin -> Cluster
+            if (src->type == FBXObjectType::DEFORMER_CLUSTER && dst->type == FBXObjectType::DEFORMER_SKIN) {
+                if (dst->skin) dst->skin->cluster_ids.push_back(src->id);
+            }
+            // BlendShape -> Channel
+            if (src->type == FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL && dst->type == FBXObjectType::DEFORMER_BLENDSHAPE) {
+                if (dst->blendshape) dst->blendshape->channel_ids.push_back(src->id);
+            }
+            // Channel -> Shape
+            if (src->type == FBXObjectType::SHAPE_GEOMETRY && dst->type == FBXObjectType::DEFORMER_BLENDSHAPE_CHANNEL) {
+                if (dst->blendshape_channel) dst->blendshape_channel->shape_ids.push_back(src->id);
+            }
+            // AnimLayer -> AnimStack
+            if (src->type == FBXObjectType::ANIMATION_LAYER && dst->type == FBXObjectType::ANIMATION_STACK) {
+                if (dst->anim_stack) dst->anim_stack->layer_ids.push_back(src->id);
+            }
+            // AnimCurveNode -> AnimLayer
+            if (src->type == FBXObjectType::ANIMATION_CURVE_NODE && dst->type == FBXObjectType::ANIMATION_LAYER) {
+                if (dst->anim_layer) dst->anim_layer->curve_node_ids.push_back(src->id);
+            }
+            // Cluster -> Bone (LimbNode Model)
+            if (src->type == FBXObjectType::DEFORMER_CLUSTER && dst->type == FBXObjectType::MODEL) {
+                if (src->cluster && src->cluster->bone_model_id == 0) {
+                    // This OO connection actually points from the cluster's
+                    // owning Skin to the Model. The cluster's bone is taken
+                    // from a separate Cluster->Model connection below.
+                }
+            }
+            if (dst->type == FBXObjectType::DEFORMER_CLUSTER && src->type == FBXObjectType::MODEL) {
+                if (dst->cluster) dst->cluster->bone_model_id = src->id;
+            }
+        } else if (c.kind == FBXConnection::OP) {
+            // Texture -> Material channel (e.g. DiffuseColor)
+            if (src->type == FBXObjectType::TEXTURE && dst->type == FBXObjectType::MATERIAL) {
+                if (dst->material) dst->material->textures[c.property] = src->id;
+            }
+            // AnimCurve -> AnimCurveNode (property = "d|X" / "d|Y" / ...)
+            if (src->type == FBXObjectType::ANIMATION_CURVE && dst->type == FBXObjectType::ANIMATION_CURVE_NODE) {
+                if (dst->anim_curve_node) dst->anim_curve_node->curves[c.property] = src->id;
+            }
+            // Video -> Texture (typically "Content" or no property)
+            if (src->type == FBXObjectType::VIDEO && dst->type == FBXObjectType::TEXTURE) {
+                if (dst->texture) dst->texture->video_id = src->id;
+            }
+        }
+    }
+
+    // Identify root Models: Models that have no OO connection to another Model.
+    std::unordered_set<FBXObjectId> has_parent_model;
+    for (const FBXConnection& c : connections_) {
+        if (c.kind != FBXConnection::OO) continue;
+        const FBXObject* src = get(c.src);
+        const FBXObject* dst = get(c.dst);
+        if (!src || !dst) continue;
+        if (src->type == FBXObjectType::MODEL && dst->type == FBXObjectType::MODEL) {
+            has_parent_model.insert(src->id);
+        }
+    }
+    root_model_ids.clear();
+    for (FBXObjectId id : ids_by_type_[FBXObjectType::MODEL]) {
+        if (!has_parent_model.count(id)) {
+            root_model_ids.push_back(id);
+            if (FBXObject* o = const_cast<FBXObject*>(get(id))) {
+                if (o->model) o->model->is_root = true;
+            }
+        }
+    }
+}
+
+bool FBXScene::load(const FBXDocument& doc, std::string* error) {
+    objects_.clear();
+    ids_by_type_.clear();
+    connections_.clear();
+    conn_by_src_.clear();
+    conn_by_dst_.clear();
+    warnings_.clear();
+    root_model_ids.clear();
+
+    file_version = doc.version;
+
+    const FBXNode& root = doc.root;
+
+    if (const FBXNode* ext = root.find_child("FBXHeaderExtension")) {
+        if (const FBXNode* c = ext->find_child("Creator")) {
+            if (!c->properties.empty()) creator = c->properties[0].as_string();
+        }
+        if (const FBXNode* c = ext->find_child("CreationTimeStamp")) {
+            (void)c; // ignored
+        }
+        if (const FBXNode* info = ext->find_child("SceneInfo")) {
+            Properties70 p = parse_properties70(info->find_child("Properties70"));
+            application_name    = p.str("LastSaved|ApplicationName",    application_name);
+            application_vendor  = p.str("LastSaved|ApplicationVendor",  application_vendor);
+            application_version = p.str("LastSaved|ApplicationVersion", application_version);
+        }
+    }
+    if (const FBXNode* c = root.find_child("Creator")) {
+        if (creator.empty() && !c->properties.empty()) creator = c->properties[0].as_string();
+    }
+    if (const FBXNode* n = root.find_child("GlobalSettings")) parse_global_settings(*n);
+    if (const FBXNode* n = root.find_child("Documents"))      parse_documents(*n);
+    if (const FBXNode* n = root.find_child("Objects"))        parse_objects(*n);
+    if (const FBXNode* n = root.find_child("Connections"))    parse_connections(*n);
+
+    finalize_root_models();
+
+    (void)error;
+    return true;
+}
+
+// ─── Accessors ─────────────────────────────────────────────
+
+const FBXObject* FBXScene::get(FBXObjectId id) const noexcept {
+    auto it = objects_.find(id);
+    return (it == objects_.end()) ? nullptr : it->second.get();
+}
+bool FBXScene::has(FBXObjectId id) const noexcept { return objects_.find(id) != objects_.end(); }
+
+std::vector<FBXObjectId> FBXScene::all_ids() const {
+    std::vector<FBXObjectId> r;
+    r.reserve(objects_.size());
+    for (const auto& kv : objects_) r.push_back(kv.first);
+    return r;
+}
+
+std::vector<FBXObjectId> FBXScene::ids_of_type(FBXObjectType type) const {
+    auto it = ids_by_type_.find(type);
+    return (it == ids_by_type_.end()) ? std::vector<FBXObjectId>{} : it->second;
+}
+
+std::vector<FBXObjectId> FBXScene::children_of(FBXObjectId id) const {
+    std::vector<FBXObjectId> r;
+    auto it = conn_by_dst_.find(id);
+    if (it == conn_by_dst_.end()) return r;
+    for (size_t idx : it->second) r.push_back(connections_[idx].src);
+    return r;
+}
+
+std::vector<FBXObjectId> FBXScene::parents_of(FBXObjectId id) const {
+    std::vector<FBXObjectId> r;
+    auto it = conn_by_src_.find(id);
+    if (it == conn_by_src_.end()) return r;
+    for (size_t idx : it->second) r.push_back(connections_[idx].dst);
+    return r;
+}
+
+std::vector<FBXObjectId> FBXScene::connected_by_property(FBXObjectId id, const std::string& prop) const {
+    std::vector<FBXObjectId> r;
+    auto it = conn_by_dst_.find(id);
+    if (it == conn_by_dst_.end()) return r;
+    for (size_t idx : it->second) {
+        const FBXConnection& c = connections_[idx];
+        if (c.kind == FBXConnection::OP && c.property == prop) r.push_back(c.src);
+    }
+    return r;
+}
+
+// ─── Triangulation ─────────────────────────────────────────
+
+const FBXGeometry::Triangulated* FBXScene::triangulate(FBXObjectId geometry_id) const {
+    const FBXObject* obj = get(geometry_id);
+    if (!obj || !obj->geometry) return nullptr;
+    FBXGeometry& g = *obj->geometry;
+    FBXGeometry::Triangulated& t = g.triangulated_cache;
+    if (t.valid) return &t;
+
+    t = FBXGeometry::Triangulated{};
+
+    // Split polygon_vertex_index into polygons using the FBX "XOR -1" rule.
+    std::vector<std::pair<int32_t, int32_t>> polygons;  // (start, count)
+    int32_t start = 0;
+    for (size_t i = 0; i < g.polygon_vertex_index.size(); ++i) {
+        if (g.polygon_vertex_index[i] < 0) {
+            polygons.emplace_back(start, static_cast<int32_t>(i - start + 1));
+            start = static_cast<int32_t>(i + 1);
+        }
+    }
+
+    auto vi = [&](int32_t i) -> int32_t {
+        int32_t v = g.polygon_vertex_index[i];
+        return v < 0 ? (~v) : v;
+    };
+
+    // Resolve per-tri-vertex attribute fetch helpers.
+    auto resolve_normal = [&](int32_t pv_index, int32_t poly_index, int32_t vertex_index) -> float3 {
+        if (g.normals.empty()) return {0, 0, 0};
+        const FBXLayerElement<float3>& le = g.normals.front();
+        int32_t src = 0;
+        switch (le.mapping) {
+            case FBXMappingMode::BY_POLYGON_VERTEX: src = pv_index; break;
+            case FBXMappingMode::BY_VERTEX:         src = vertex_index; break;
+            case FBXMappingMode::BY_POLYGON:        src = poly_index; break;
+            case FBXMappingMode::ALL_SAME:          src = 0; break;
+            default: break;
+        }
+        if (le.reference == FBXReferenceMode::INDEX_TO_DIRECT && !le.index.empty()) {
+            if (src < 0 || src >= static_cast<int32_t>(le.index.size())) return {};
+            int32_t di = le.index[src];
+            if (di < 0 || di >= static_cast<int32_t>(le.data.size())) return {};
+            return le.data[di];
+        }
+        if (src < 0 || src >= static_cast<int32_t>(le.data.size())) return {};
+        return le.data[src];
+    };
+    auto resolve_color = [&](int32_t pv_index, int32_t poly_index, int32_t vertex_index) -> float4 {
+        if (g.colors.empty()) return {1, 1, 1, 1};
+        const FBXLayerElement<float4>& le = g.colors.front();
+        int32_t src = 0;
+        switch (le.mapping) {
+            case FBXMappingMode::BY_POLYGON_VERTEX: src = pv_index; break;
+            case FBXMappingMode::BY_VERTEX:         src = vertex_index; break;
+            case FBXMappingMode::BY_POLYGON:        src = poly_index; break;
+            case FBXMappingMode::ALL_SAME:          src = 0; break;
+            default: break;
+        }
+        if (le.reference == FBXReferenceMode::INDEX_TO_DIRECT && !le.index.empty()) {
+            if (src < 0 || src >= static_cast<int32_t>(le.index.size())) return {1, 1, 1, 1};
+            int32_t di = le.index[src];
+            if (di < 0 || di >= static_cast<int32_t>(le.data.size())) return {1, 1, 1, 1};
+            return le.data[di];
+        }
+        if (src < 0 || src >= static_cast<int32_t>(le.data.size())) return {1, 1, 1, 1};
+        return le.data[src];
+    };
+    auto resolve_uv0 = [&](int32_t pv_index, int32_t vertex_index) -> std::pair<float, float> {
+        if (g.uv_sets.empty()) return {0, 0};
+        const FBXGeometry::UVSet& uv = g.uv_sets.front();
+        int32_t src = 0;
+        switch (uv.mapping) {
+            case FBXMappingMode::BY_POLYGON_VERTEX: src = pv_index; break;
+            case FBXMappingMode::BY_VERTEX:         src = vertex_index; break;
+            default: break;
+        }
+        int32_t di = src;
+        if (uv.reference == FBXReferenceMode::INDEX_TO_DIRECT) {
+            if (src < 0 || src >= static_cast<int32_t>(uv.index.size())) return {0, 0};
+            di = uv.index[src];
+        }
+        if (di < 0 || di >= static_cast<int32_t>(uv.u.size())) return {0, 0};
+        return {uv.u[di], uv.v[di]};
+    };
+    auto resolve_material_per_polygon = [&](int32_t poly_index) -> int32_t {
+        if (g.material_indices.data.empty()) return 0;
+        if (g.material_indices.mapping == FBXMappingMode::ALL_SAME) return g.material_indices.data[0];
+        if (poly_index < 0 || poly_index >= static_cast<int32_t>(g.material_indices.data.size())) return 0;
+        return g.material_indices.data[poly_index];
+    };
+
+    int32_t out_idx = 0;
+    for (size_t pi = 0; pi < polygons.size(); ++pi) {
+        int32_t ps = polygons[pi].first;
+        int32_t pn = polygons[pi].second;
+        if (pn < 3) continue;
+        int32_t v0 = vi(ps);
+        int32_t mat = resolve_material_per_polygon(static_cast<int32_t>(pi));
+        for (int32_t k = 1; k + 1 < pn; ++k) {
+            int32_t a_pv = ps;
+            int32_t b_pv = ps + k;
+            int32_t c_pv = ps + k + 1;
+            int32_t a = v0;
+            int32_t b = vi(b_pv);
+            int32_t c = vi(c_pv);
+
+            auto push = [&](int32_t pv_index, int32_t vertex_index) {
+                t.positions.push_back(vertex_index < static_cast<int32_t>(g.positions.size())
+                                      ? g.positions[vertex_index]
+                                      : float3{});
+                t.normals.push_back(resolve_normal(pv_index, static_cast<int32_t>(pi), vertex_index));
+                float4 col = resolve_color(pv_index, static_cast<int32_t>(pi), vertex_index);
+                t.colors.push_back(col);
+                auto uv = resolve_uv0(pv_index, vertex_index);
+                t.uv0.push_back(uv.first);
+                t.uv0.push_back(uv.second);
+                t.original_vertex.push_back(vertex_index);
+                t.indices.push_back(out_idx++);
+            };
+
+            push(a_pv, a);
+            push(b_pv, b);
+            push(c_pv, c);
+            t.material_per_tri.push_back(mat);
+            t.polygon_of_tri.push_back(static_cast<int32_t>(pi));
+        }
+    }
+
+    t.valid = true;
+    return &t;
+}
+
+// ─── Transform evaluation ──────────────────────────────────
+
+float4x4 FBXScene::evaluate_local_transform(FBXObjectId model_id) const {
+    const FBXObject* obj = get(model_id);
+    if (!obj || !obj->model) return mat_identity();
+    const FBXModel& m = *obj->model;
+
+    // FBX SDK transform assembly:
+    //   M = T * Roff * Rp * Rpre * R * Rpost^-1 * Rp^-1 * Soff * Sp * S * Sp^-1
+    const float4x4 T     = mat_translation(m.translation);
+    const float4x4 Roff  = mat_translation(m.rotation_offset);
+    const float4x4 Rp    = mat_translation(m.rotation_pivot);
+    const float4x4 Rpre  = mat_rotation_euler(m.pre_rotation,  FBXRotationOrder::XYZ);
+    const float4x4 R     = mat_rotation_euler(m.rotation,      m.rotation_order);
+    const float4x4 Rpost = mat_rotation_euler(m.post_rotation, FBXRotationOrder::XYZ);
+    const float4x4 Rp_inv    = mat_translation({-m.rotation_pivot.x, -m.rotation_pivot.y, -m.rotation_pivot.z});
+    const float4x4 Rpost_inv = mat_inverse_rigid(Rpost);
+    const float4x4 Soff  = mat_translation(m.scaling_offset);
+    const float4x4 Sp    = mat_translation(m.scaling_pivot);
+    const float4x4 S     = mat_scale(m.scaling);
+    const float4x4 Sp_inv = mat_translation({-m.scaling_pivot.x, -m.scaling_pivot.y, -m.scaling_pivot.z});
+
+    float4x4 local = mat_mul(T, Roff);
+    local = mat_mul(local, Rp);
+    local = mat_mul(local, Rpre);
+    local = mat_mul(local, R);
+    local = mat_mul(local, Rpost_inv);
+    local = mat_mul(local, Rp_inv);
+    local = mat_mul(local, Soff);
+    local = mat_mul(local, Sp);
+    local = mat_mul(local, S);
+    local = mat_mul(local, Sp_inv);
+    return local;
+}
+
+float4x4 FBXScene::evaluate_world_transform(FBXObjectId model_id) const {
+    const FBXObject* obj = get(model_id);
+    if (!obj || !obj->model) return mat_identity();
+    // Find the Model parent via OO connections. Walk up iteratively.
+    std::vector<FBXObjectId> chain;
+    chain.push_back(model_id);
+    while (true) {
+        FBXObjectId cur = chain.back();
+        FBXObjectId parent_model = 0;
+        auto it = conn_by_src_.find(cur);
+        if (it == conn_by_src_.end()) break;
+        for (size_t idx : it->second) {
+            const FBXConnection& c = connections_[idx];
+            if (c.kind != FBXConnection::OO) continue;
+            const FBXObject* d = get(c.dst);
+            if (d && d->type == FBXObjectType::MODEL) {
+                parent_model = c.dst;
+                break;
+            }
+        }
+        if (parent_model == 0) break;
+        // Cycle guard (shouldn't happen, but ensure termination).
+        if (std::find(chain.begin(), chain.end(), parent_model) != chain.end()) break;
+        chain.push_back(parent_model);
+    }
+    float4x4 world = mat_identity();
+    // Compose from root down: world = local_root * local_child * ... (row-vector).
+    for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+        world = mat_mul(evaluate_local_transform(*it), world);
+    }
+    return world;
+}
+
+} // namespace pictor

--- a/src/data/model_data_handler.cpp
+++ b/src/data/model_data_handler.cpp
@@ -1,4 +1,6 @@
 ﻿#include "pictor/data/model_data_handler.h"
+#include "pictor/animation/fbx_importer.h"
+#include "pictor/animation/fbx_scene.h"
 #include <algorithm>
 #include <cstring>
 
@@ -69,6 +71,8 @@ void ModelDataHandler::unregister_model(ModelHandle handle) {
     if (!it->name.empty()) {
         model_name_map_.erase(it->name);
     }
+
+    fbx_scenes_.erase(handle);
 
     models_.erase(it);
 }
@@ -324,6 +328,57 @@ ModelFormat ModelDataHandler::detect_format(const uint8_t* data, size_t size) {
     }
 
     return ModelFormat::UNKNOWN;
+}
+
+// ============================================================
+// FBX Loading
+// ============================================================
+
+namespace {
+
+std::string derive_model_name_from_path(const std::string& path) {
+    size_t slash = path.find_last_of("/\\");
+    std::string base = (slash == std::string::npos) ? path : path.substr(slash + 1);
+    size_t dot = base.find_last_of('.');
+    if (dot != std::string::npos) base = base.substr(0, dot);
+    return base.empty() ? std::string{"model"} : base;
+}
+
+} // namespace
+
+ModelHandle ModelDataHandler::load_model_from_fbx(const std::string& path) {
+    last_load_error_.clear();
+    FBXImporter importer;
+    FBXImportResult result = importer.import_file(path);
+    if (!result.success) {
+        last_load_error_ = result.error_message;
+        return INVALID_MODEL;
+    }
+    const std::string name = derive_model_name_from_path(path);
+    ModelDescriptor md = result.to_model_descriptor(name);
+    ModelHandle h = register_model(md);
+    if (h != INVALID_MODEL && result.scene) fbx_scenes_[h] = result.scene;
+    return h;
+}
+
+ModelHandle ModelDataHandler::load_model_from_fbx_memory(const uint8_t* data, size_t size,
+                                                         const std::string& name) {
+    last_load_error_.clear();
+    FBXImporter importer;
+    FBXImportResult result = importer.import_memory(data, size);
+    if (!result.success) {
+        last_load_error_ = result.error_message;
+        return INVALID_MODEL;
+    }
+    ModelDescriptor md = result.to_model_descriptor(name.empty() ? std::string{"model"} : name);
+    ModelHandle h = register_model(md);
+    if (h != INVALID_MODEL && result.scene) fbx_scenes_[h] = result.scene;
+    return h;
+}
+
+std::shared_ptr<FBXScene> ModelDataHandler::get_fbx_scene(ModelHandle handle) const {
+    auto it = fbx_scenes_.find(handle);
+    return (it == fbx_scenes_.end()) ? nullptr : it->second;
 }
 
 } // namespace pictor


### PR DESCRIPTION
## Summary
#30 の Level 4 (Importer Facade) を実装し、FBX パイプラインを完成させる。PR #32 (Level 2+3) の上に stack。

### Level 4 — FBXImporter 書き直し
\`FBXDocument\` + \`FBXScene\` ベースで Pictor ランタイム型に投影:
- **SkeletonDescriptor** — LimbNode/Null Model → Bone list、\`Cluster.transform_link\` から \`inverse_bind_matrix\`
- **AnimationClipDescriptor** — AnimStack→Layer→CurveNode→Curve を \`AnimationChannel\` に変換、Euler→Quaternion は FBX rotation_order を尊重
- **SkinMeshDescriptor** — Geometry 三角化 + Cluster ウェイト (上位4本、正規化済み) + BlendShape → \`morph_target_names\` + \`morph_deltas\`
- **material_slots / texture_paths / ik_chains** (後続で IK 推論追加予定)
- **\`to_model_descriptor(name)\`** — 一発で \`ModelDescriptor\` へ
- リソース ID アクセス forwarder (\`get_resource\`, \`all_resource_ids\`, \`resource_ids_of_type\`)

### ModelDataHandler 配線
- \`load_model_from_fbx(path)\` / \`load_model_from_fbx_memory(data, size, name)\`
- \`get_fbx_scene(handle)\` — 生の \`FBXScene\` を取得可能
- \`last_load_error()\` — エラーメッセージ

### デモ \`pictor_fbx_demo\`
- **完全ヘッドレス** (Vulkan/GLFW 不要)
- 引数なし → 合成シーン (3 骨 + 回転クリップ) でパイプライン動作確認
- 引数ありで \`pictor_fbx_demo <path.fbx>\` → 実ファイル読み込み

フロー:
\`\`\`
FBXImporter::import_file()
  → FBXImportResult
    → Scene summary 表示
    → AnimationSystem.register_skeleton + register_clip
    → create_instance + play
    → update(1/30s) ループで get_skinning_matrices() を出力
\`\`\`

実行例 (合成シーン):
\`\`\`
[t=0.50s frame=15]
    bone[2] bone_2       t=(-0.303, +0.717, +0.000)
[t=1.50s frame=45]
    bone[2] bone_2       t=(-0.303, -0.717, +0.000)
\`\`\`
tip bone が回転クリップに従って動いていることを確認。

### 後続 (別 PR / 別 Issue 候補)
- **Vulkan 経由の 3D ビューア** — GPU スキニング + メッシュアップロード + シェーダ (#30 の範囲外、別 issue で扱うのが適切)
- **IK chain の自動推論** — 現状 \`ik_chains\` は空

## Test plan
- [ ] MSVC Debug/Release ビルド成功 (errors 0)
- [ ] \`pictor_fbx_demo\` を引数なしで起動 → 合成シーンでアニメが進行
- [ ] 実 FBX ファイルで \`pictor_fbx_demo file.fbx\` → scene summary + bone matrices が順次更新される
- [ ] \`ModelDataHandler::load_model_from_fbx\` で \`ModelHandle\` が取得できる
- [ ] \`get_fbx_scene(handle)\` で Scene にアクセスできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)