### PR TITLE
feat(pipeline): mobile rendering pipeline demo + external builder API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(pictor STATIC
 
     # Pipeline
     src/pipeline/pipeline_profile.cpp
+    src/pipeline/pipeline_builder.cpp
     src/pipeline/render_pass_scheduler.cpp
     src/pipeline/command_encoder.cpp
 
@@ -179,6 +180,23 @@ if(PICTOR_BUILD_DEMO)
     # FBX loading + animation demo (headless, console output)
     add_executable(pictor_fbx_demo demo/fbx/main.cpp)
     target_link_libraries(pictor_fbx_demo PRIVATE pictor)
+
+    # Mobile rendering pipeline demo (headless — no Vulkan/GLFW required).
+    # Showcases MobileLow / MobileHigh profiles and the external
+    # PipelineProfileBuilder API, so it builds on CI and on mobile toolchains
+    # where a Vulkan SDK isn't available.
+    add_executable(pictor_mobile_demo demo/mobile/main.cpp)
+    target_link_libraries(pictor_mobile_demo PRIVATE pictor)
+
+    # Copy sample kv-config file next to the binary so --config= works out of
+    # the box from the build tree.
+    add_custom_command(TARGET pictor_mobile_demo POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/profiles
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_SOURCE_DIR}/demo/mobile/profiles/mobile_custom.ini
+            ${CMAKE_BINARY_DIR}/profiles/mobile_custom.ini
+        COMMENT "Staging mobile demo profile config"
+    )
 
     # FBX viewer demo (Vulkan + skinning, general-purpose lit shader)
     if(Vulkan_FOUND AND glfw3_FOUND)

--- a/demo/mobile/main.cpp
+++ b/demo/mobile/main.cpp
@@ -1,0 +1,316 @@
+/// Pictor Mobile Rendering Pipeline Demo
+///
+/// Demonstrates:
+///  1. Two built-in mobile pipeline profiles (MobileLow / MobileHigh) tuned
+///     for tile-based GPUs (Adreno, Mali, Apple A-series).
+///  2. External / data-driven pipeline construction via PipelineProfileBuilder,
+///     including JSON-style key/value configuration the host app would load
+///     from disk at runtime.
+///  3. Live profile switching at runtime — the scheduler and memory subsystem
+///     reconfigure without destroying the scene graph.
+///
+/// Runs headless (no Vulkan / GLFW dependency) so it builds and executes on
+/// CI, docker images, and mobile emulators. If a Vulkan SDK is present the
+/// demo still only drives the data pipeline — the heavy GPU submission path
+/// lives in pictor_demo / pictor_benchmark.
+///
+/// Command-line flags:
+///   --profile=<name>   Start profile (default: MobileLow)
+///   --frames=<N>       Number of frames to simulate per profile (default: 120)
+///   --objects=<N>      Scene object count (default: 2000 for low / 20000 for high)
+///   --switch           Cycle through all mobile profiles, N frames each
+///   --config=<path>    Load a key=value profile config (see kv_profile.ini format)
+
+#include "pictor/pictor.h"
+#include "pictor/pipeline/pipeline_builder.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace pictor;
+
+namespace {
+
+// ---- Utility: scene populator (lissajous-moving cubes) ---------------------
+
+class MobileUpdateCallback : public IUpdateCallback {
+public:
+    float total_time = 0.0f;
+
+    void update(float4x4* transforms, AABB* bounds,
+                uint32_t start, uint32_t count, float delta_time) override {
+        total_time += delta_time;
+        for (uint32_t i = 0; i < count; ++i) {
+            uint32_t idx = start + i;
+            float phase = static_cast<float>(idx) * 0.17f;
+            float x = std::sin(total_time * 0.8f + phase) * 6.0f;
+            float y = std::cos(total_time * 1.3f + phase) * 3.0f;
+            float z = std::sin(total_time * 0.5f + phase * 2.1f) * 6.0f;
+
+            transforms[idx] = float4x4::identity();
+            transforms[idx].set_translation(x, y, z);
+            bounds[idx].min = {x - 0.5f, y - 0.5f, z - 0.5f};
+            bounds[idx].max = {x + 0.5f, y + 0.5f, z + 0.5f};
+        }
+    }
+};
+
+void register_scene(PictorRenderer& renderer, uint32_t count) {
+    for (uint32_t i = 0; i < count; ++i) {
+        ObjectDescriptor desc;
+        desc.mesh        = 0;
+        desc.material    = 0;
+        desc.transform   = float4x4::identity();
+        desc.bounds.min  = {-0.5f, -0.5f, -0.5f};
+        desc.bounds.max  = { 0.5f,  0.5f,  0.5f};
+        desc.shaderKey   = i & 0x3; // four shader-key buckets
+        desc.materialKey = 0;
+        desc.flags       = ObjectFlags::DYNAMIC | ObjectFlags::INSTANCED |
+                           ObjectFlags::CAST_SHADOW | ObjectFlags::RECEIVE_SHADOW;
+        renderer.register_object(desc);
+    }
+}
+
+Camera make_camera() {
+    Camera cam;
+    cam.position = {0.0f, 2.0f, 15.0f};
+    for (int i = 0; i < 6; ++i) {
+        cam.frustum.planes[i].normal   = {0, 0, 0};
+        cam.frustum.planes[i].distance = 1000.0f;
+    }
+    cam.frustum.planes[0] = {{ 1, 0, 0}, 50.0f};
+    cam.frustum.planes[1] = {{-1, 0, 0}, 50.0f};
+    cam.frustum.planes[2] = {{ 0, 1, 0}, 50.0f};
+    cam.frustum.planes[3] = {{ 0,-1, 0}, 50.0f};
+    cam.frustum.planes[4] = {{ 0, 0, 1}, 0.1f};
+    cam.frustum.planes[5] = {{ 0, 0,-1}, 200.0f};
+    return cam;
+}
+
+// ---- Pretty-printing a profile definition ---------------------------------
+
+const char* rp_name(RenderingPath p) {
+    switch (p) {
+        case RenderingPath::FORWARD:      return "FORWARD";
+        case RenderingPath::FORWARD_PLUS: return "FORWARD_PLUS";
+        case RenderingPath::DEFERRED:     return "DEFERRED";
+        case RenderingPath::HYBRID:       return "HYBRID";
+    }
+    return "?";
+}
+
+const char* shadow_name(ShadowFilterMode m) {
+    switch (m) {
+        case ShadowFilterMode::NONE: return "NONE";
+        case ShadowFilterMode::PCF:  return "PCF";
+        case ShadowFilterMode::PCSS: return "PCSS";
+    }
+    return "?";
+}
+
+void print_profile(const PipelineProfileDef& p) {
+    constexpr size_t MB = 1024 * 1024;
+    printf("  Profile '%s'\n", p.profile_name.c_str());
+    printf("    rendering_path  : %s\n", rp_name(p.rendering_path));
+    printf("    max_lights      : %u\n", p.max_lights);
+    printf("    msaa_samples    : %u\n", static_cast<unsigned>(p.msaa_samples));
+    printf("    gpu_driven      : %s\n", p.gpu_driven_enabled ? "on" : "off");
+    printf("    compute_update  : %s\n", p.compute_update_enabled ? "on" : "off");
+    printf("    shadows         : %u cascade(s), %ux, filter=%s\n",
+           p.shadow_config.cascade_count,
+           p.shadow_config.resolution,
+           shadow_name(p.shadow_config.filter_mode));
+    printf("    frame_alloc     : %zu MB (x%u flights)\n",
+           p.memory_config.frame_allocator_size / MB,
+           p.memory_config.flight_count);
+    printf("    mesh_pool       : %zu MB\n",
+           p.memory_config.gpu_config.mesh_pool_size / MB);
+    printf("    ssbo_pool       : %zu MB\n",
+           p.memory_config.gpu_config.ssbo_pool_size / MB);
+    printf("    passes (%zu)    :", p.render_passes.size());
+    for (const auto& rp : p.render_passes) printf(" %s", rp.pass_name.c_str());
+    printf("\n    post_process    :");
+    if (p.post_process_stack.empty()) printf(" (none)");
+    for (const auto& pp : p.post_process_stack) {
+        printf(" %s%s", pp.name.c_str(), pp.enabled ? "" : "(disabled)");
+    }
+    printf("\n");
+}
+
+// ---- Key/value config loader (INI-lite: one "key=value" per line) ---------
+
+std::unordered_map<std::string, std::string> load_kv_config(const std::string& path) {
+    std::unordered_map<std::string, std::string> kv;
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        fprintf(stderr, "warning: could not open config '%s'\n", path.c_str());
+        return kv;
+    }
+    std::string line;
+    while (std::getline(f, line)) {
+        auto hash = line.find('#');
+        if (hash != std::string::npos) line.erase(hash);
+        auto eq = line.find('=');
+        if (eq == std::string::npos) continue;
+        auto key = line.substr(0, eq);
+        auto val = line.substr(eq + 1);
+        auto trim = [](std::string& s) {
+            auto b = s.find_first_not_of(" \t\r\n");
+            auto e = s.find_last_not_of(" \t\r\n");
+            if (b == std::string::npos) { s.clear(); return; }
+            s = s.substr(b, e - b + 1);
+        };
+        trim(key); trim(val);
+        if (!key.empty()) kv[key] = val;
+    }
+    return kv;
+}
+
+// ---- Frame simulation -----------------------------------------------------
+
+void run_frames(PictorRenderer& renderer, uint32_t frame_count) {
+    const Camera cam = make_camera();
+    constexpr float DT = 1.0f / 60.0f;
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (uint32_t f = 0; f < frame_count; ++f) {
+        renderer.begin_frame(DT);
+        renderer.render(cam);
+        renderer.end_frame();
+    }
+    auto t1 = std::chrono::high_resolution_clock::now();
+
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    const auto& s = renderer.get_frame_stats();
+    printf("    ran %u frames in %.1f ms (%.2f ms/frame)\n", frame_count, ms, ms / frame_count);
+    printf("    last-frame: fps=%.1f update=%.2fms cull=%.2fms batch=%.2fms\n",
+           s.fps, s.data_update_ms, s.culling_ms, s.batch_build_ms);
+}
+
+} // namespace
+
+// ---- Entry point ----------------------------------------------------------
+
+int main(int argc, char* argv[]) {
+    printf("=== Pictor Mobile Rendering Pipeline Demo ===\n\n");
+
+    std::string start_profile = "MobileLow";
+    std::string config_path;
+    uint32_t    frames  = 120;
+    int32_t     objects = -1; // -1 = pick per-profile default
+    bool        cycle   = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg.rfind("--profile=", 0) == 0)      start_profile = arg.substr(10);
+        else if (arg.rfind("--frames=", 0) == 0)  frames  = static_cast<uint32_t>(std::atoi(arg.c_str() + 9));
+        else if (arg.rfind("--objects=", 0) == 0) objects = std::atoi(arg.c_str() + 10);
+        else if (arg.rfind("--config=", 0) == 0)  config_path = arg.substr(9);
+        else if (arg == "--switch")               cycle = true;
+        else if (arg == "--help" || arg == "-h") {
+            printf("usage: pictor_mobile_demo [--profile=<name>] [--frames=N] [--objects=N] [--switch] [--config=<path>]\n");
+            return 0;
+        }
+    }
+
+    // ---- Build the profile set ---------------------------------------------
+
+    PipelineProfileDef low  = PipelineProfileManager::create_mobile_low_profile();
+    PipelineProfileDef high = PipelineProfileManager::create_mobile_high_profile();
+
+    // Demonstrate external construction: start from MobileHigh and tweak a
+    // handful of knobs via the fluent builder.
+    PipelineProfileDef custom = PipelineProfileBuilder::from_preset(high)
+        .with_msaa(0)
+        .with_max_lights(24)
+        .with_shadow(1, 512, ShadowFilterMode::PCF)
+        .with_memory_budget_mb(2, 96, 24)
+        .clear_post_process()
+        .add_post_process("Tonemapping")
+        .add_post_process("FXAA")
+        .take();
+    custom.profile_name = "MobileCustom";
+
+    // Optional data-driven profile loaded from a flat kv file.
+    PipelineProfileDef from_file;
+    bool has_from_file = false;
+    if (!config_path.empty()) {
+        auto kv = load_kv_config(config_path);
+        if (!kv.empty()) {
+            from_file = PipelineProfileBuilder::from_key_value(low, kv);
+            has_from_file = true;
+        }
+    }
+
+    printf("-- Registered mobile profiles ------------------------------------------\n");
+    print_profile(low);
+    print_profile(high);
+    print_profile(custom);
+    if (has_from_file) {
+        printf("\n  (loaded from %s)\n", config_path.c_str());
+        print_profile(from_file);
+    }
+    printf("\n");
+
+    // ---- Wire up renderer --------------------------------------------------
+
+    RendererConfig rc;
+    rc.initial_profile = low.profile_name; // begin with the smallest memory footprint
+    rc.memory_config   = low.memory_config;
+    rc.update_config   = low.update_config;
+    rc.screen_width    = 1280;
+    rc.screen_height   = 720;
+    rc.profiler_enabled = true;
+    rc.overlay_mode     = OverlayMode::MINIMAL;
+
+    PictorRenderer renderer;
+    renderer.initialize(rc);
+
+    // Register custom profiles with the manager — this is the external hand-off.
+    renderer.register_custom_profile(low);
+    renderer.register_custom_profile(high);
+    renderer.register_custom_profile(custom);
+    if (has_from_file) renderer.register_custom_profile(from_file);
+
+    MobileUpdateCallback cb;
+    renderer.set_update_callback(&cb);
+
+    // ---- Scene -------------------------------------------------------------
+
+    uint32_t obj_count = (objects >= 0)
+        ? static_cast<uint32_t>(objects)
+        : (start_profile == "MobileLow" ? 2000u : 20000u);
+    printf("Registering %u scene objects...\n", obj_count);
+    register_scene(renderer, obj_count);
+    printf("\n");
+
+    // ---- Run ---------------------------------------------------------------
+
+    std::vector<std::string> run_list;
+    if (cycle) {
+        run_list = {"MobileLow", "MobileHigh", "MobileCustom"};
+        if (has_from_file) run_list.push_back(from_file.profile_name);
+    } else {
+        run_list = {start_profile};
+    }
+
+    for (const auto& name : run_list) {
+        if (!renderer.set_profile(name)) {
+            fprintf(stderr, "warning: profile '%s' not registered — skipping\n", name.c_str());
+            continue;
+        }
+        printf("-- Active profile: %s ------------------------------------------\n", name.c_str());
+        run_frames(renderer, frames);
+        printf("\n");
+    }
+
+    renderer.shutdown();
+    printf("Mobile demo complete.\n");
+    return 0;
+}

--- a/demo/mobile/profiles/mobile_custom.ini
+++ b/demo/mobile/profiles/mobile_custom.ini
@@ -1,0 +1,27 @@
+# Pictor mobile pipeline — external key=value profile
+#
+# Loaded by pictor_mobile_demo --config=... and parsed via
+# PipelineProfileBuilder::from_key_value(). See pipeline_builder.h for the
+# full key reference.
+
+name                  = MobileCustomINI
+rendering_path        = FORWARD
+max_lights            = 16
+msaa_samples          = 2
+gpu_driven            = false
+compute_update        = false
+
+shadow.cascade_count  = 1
+shadow.resolution     = 1024
+shadow.filter_mode    = PCF
+
+memory.frame_alloc_mb = 2
+memory.mesh_pool_mb   = 64
+memory.ssbo_pool_mb   = 16
+memory.flight_count   = 2
+
+post_process          = Bloom,Tonemapping,FXAA
+passes                = ShadowPass,OpaquePass,TransparentPass,PostProcess
+
+profiler.enabled      = true
+profiler.overlay      = MINIMAL

--- a/include/pictor/pictor.h
+++ b/include/pictor/pictor.h
@@ -36,6 +36,7 @@
 
 // Pipeline
 #include "pictor/pipeline/pipeline_profile.h"
+#include "pictor/pipeline/pipeline_builder.h"
 #include "pictor/pipeline/render_pass_scheduler.h"
 #include "pictor/pipeline/command_encoder.h"
 

--- a/include/pictor/pipeline/pipeline_builder.h
+++ b/include/pictor/pipeline/pipeline_builder.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "pictor/pipeline/pipeline_profile.h"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace pictor {
+
+/// Fluent builder for constructing PipelineProfileDef from external code
+/// without needing to touch PipelineProfileManager internals.
+///
+/// Usage (programmatic):
+///
+///     auto def = PipelineProfileBuilder("MyMobile")
+///                    .with_rendering_path(RenderingPath::FORWARD)
+///                    .with_max_lights(16)
+///                    .with_shadow(1, 1024, ShadowFilterMode::PCF)
+///                    .with_msaa(2)
+///                    .with_memory_budget_mb(2, 64, 16)
+///                    .add_pass({"OpaquePass", PassType::OPAQUE})
+///                    .add_pass({"TransparentPass", PassType::TRANSPARENT,
+///                               INVALID_MESH, {}, {}, SortMode::BACK_TO_FRONT})
+///                    .add_post_process("Tonemapping")
+///                    .build();
+///     renderer.register_custom_profile(def);
+///
+/// Usage (data-driven, e.g. loaded from JSON/TOML by the host application):
+///
+///     std::unordered_map<std::string, std::string> cfg = { ... };
+///     auto def = PipelineProfileBuilder::from_key_value(cfg);
+///
+/// The builder performs no I/O and has no external dependencies — the host
+/// application owns parsing (JSON, YAML, INI, etc.) and passes the resulting
+/// key/value pairs in.
+class PipelineProfileBuilder {
+public:
+    explicit PipelineProfileBuilder(std::string profile_name);
+
+    /// Seed the builder from an existing preset (e.g. one of the MobileLow /
+    /// MobileHigh factories) and then customize further.
+    static PipelineProfileBuilder from_preset(const PipelineProfileDef& preset);
+
+    // ---- Scalar / enum settings --------------------------------------------
+
+    PipelineProfileBuilder& with_rendering_path(RenderingPath path);
+    PipelineProfileBuilder& with_max_lights(uint32_t count);
+    PipelineProfileBuilder& with_msaa(uint8_t samples);
+    PipelineProfileBuilder& with_gpu_driven(bool enabled);
+    PipelineProfileBuilder& with_compute_update(bool enabled);
+
+    // ---- Shadows -----------------------------------------------------------
+
+    /// Configure CSM shadows. Pass cascade_count=0 to disable.
+    PipelineProfileBuilder& with_shadow(uint32_t cascade_count,
+                                        uint32_t resolution,
+                                        ShadowFilterMode filter_mode);
+
+    // ---- Memory budget -----------------------------------------------------
+
+    /// Quick helper: set the three dominant budgets in MB.
+    /// frame_alloc_mb covers per-frame scratch, mesh_pool_mb is the vertex/
+    /// index arena, ssbo_pool_mb covers draw/instance SSBOs.
+    PipelineProfileBuilder& with_memory_budget_mb(size_t frame_alloc_mb,
+                                                   size_t mesh_pool_mb,
+                                                   size_t ssbo_pool_mb);
+
+    PipelineProfileBuilder& with_flight_count(uint32_t count);
+
+    // ---- Render passes -----------------------------------------------------
+
+    /// Replace the entire pass list.
+    PipelineProfileBuilder& with_passes(std::vector<RenderPassDef> passes);
+
+    /// Append a single pass.
+    PipelineProfileBuilder& add_pass(RenderPassDef pass);
+
+    /// Remove a pass by name. No-op if not found.
+    PipelineProfileBuilder& remove_pass(std::string_view pass_name);
+
+    // ---- Post-process stack ------------------------------------------------
+
+    PipelineProfileBuilder& with_post_process(std::vector<PostProcessDef> stack);
+    PipelineProfileBuilder& add_post_process(std::string name, bool enabled = true);
+    PipelineProfileBuilder& clear_post_process();
+
+    // ---- Profiler ----------------------------------------------------------
+
+    PipelineProfileBuilder& with_profiler(bool enabled, OverlayMode mode);
+
+    // ---- GI ----------------------------------------------------------------
+
+    PipelineProfileBuilder& with_gi_config(const GIConfig& cfg);
+
+    // ---- Build -------------------------------------------------------------
+
+    /// Returns the assembled definition. The builder remains usable afterward.
+    const PipelineProfileDef& build() const { return def_; }
+    PipelineProfileDef take() { return std::move(def_); }
+
+    // ---- Data-driven construction -----------------------------------------
+
+    /// Construct a profile from a flat key/value string map.
+    ///
+    /// Recognized keys (all optional except name):
+    ///   name                     (string, required)
+    ///   rendering_path           ("FORWARD" | "FORWARD_PLUS" | "DEFERRED" | "HYBRID")
+    ///   max_lights               (uint)
+    ///   msaa_samples             (uint, 0/2/4/8)
+    ///   gpu_driven               ("true" | "false")
+    ///   compute_update           ("true" | "false")
+    ///   shadow.cascade_count     (uint; 0 disables shadows)
+    ///   shadow.resolution        (uint)
+    ///   shadow.filter_mode       ("NONE" | "PCF" | "PCSS")
+    ///   memory.frame_alloc_mb    (uint)
+    ///   memory.mesh_pool_mb      (uint)
+    ///   memory.ssbo_pool_mb      (uint)
+    ///   memory.flight_count      (uint)
+    ///   post_process             (comma-separated list, e.g. "Bloom,Tonemapping,FXAA")
+    ///   passes                   (comma-separated pass names; pass types default to OPAQUE)
+    ///   profiler.enabled         ("true" | "false")
+    ///   profiler.overlay         ("OFF" | "MINIMAL" | "STANDARD" | "DETAILED" | "TIMELINE")
+    ///
+    /// Unknown keys are ignored (forward compatibility). Invalid values fall
+    /// back to the preset defaults so the output is always a usable profile.
+    static PipelineProfileDef from_key_value(
+        const std::unordered_map<std::string, std::string>& kv);
+
+    /// Same as from_key_value() but seeded from an existing preset, so the
+    /// caller only needs to specify overrides.
+    static PipelineProfileDef from_key_value(
+        const PipelineProfileDef& preset,
+        const std::unordered_map<std::string, std::string>& kv);
+
+private:
+    PipelineProfileDef def_{};
+};
+
+} // namespace pictor

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -93,6 +93,12 @@ public:
     static PipelineProfileDef create_standard_profile();
     static PipelineProfileDef create_ultra_profile();
 
+    /// Mobile presets (§8.1 extension).
+    /// MobileLow targets bandwidth-bound tile-based GPUs (no shadows, FORWARD, no MSAA).
+    /// MobileHigh targets modern mobile SoCs (FORWARD, 1-cascade PCF shadows, light post-process).
+    static PipelineProfileDef create_mobile_low_profile();
+    static PipelineProfileDef create_mobile_high_profile();
+
 private:
     std::vector<PipelineProfileDef> profiles_;
     const PipelineProfileDef*       current_ = nullptr;

--- a/src/pipeline/pipeline_builder.cpp
+++ b/src/pipeline/pipeline_builder.cpp
@@ -1,0 +1,301 @@
+#include "pictor/pipeline/pipeline_builder.h"
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+
+namespace pictor {
+
+namespace {
+
+// ---- small parsing helpers -------------------------------------------------
+
+std::string to_upper(std::string_view s) {
+    std::string out(s);
+    for (char& c : out) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    return out;
+}
+
+bool parse_bool(const std::string& v, bool fallback) {
+    std::string u = to_upper(v);
+    if (u == "TRUE" || u == "1" || u == "ON" || u == "YES")  return true;
+    if (u == "FALSE" || u == "0" || u == "OFF" || u == "NO") return false;
+    return fallback;
+}
+
+uint32_t parse_uint(const std::string& v, uint32_t fallback) {
+    if (v.empty()) return fallback;
+    char* end = nullptr;
+    unsigned long n = std::strtoul(v.c_str(), &end, 10);
+    if (end == v.c_str()) return fallback;
+    return static_cast<uint32_t>(n);
+}
+
+RenderingPath parse_rendering_path(const std::string& v, RenderingPath fallback) {
+    std::string u = to_upper(v);
+    if (u == "FORWARD")      return RenderingPath::FORWARD;
+    if (u == "FORWARD_PLUS") return RenderingPath::FORWARD_PLUS;
+    if (u == "DEFERRED")     return RenderingPath::DEFERRED;
+    if (u == "HYBRID")       return RenderingPath::HYBRID;
+    return fallback;
+}
+
+ShadowFilterMode parse_shadow_filter(const std::string& v, ShadowFilterMode fallback) {
+    std::string u = to_upper(v);
+    if (u == "NONE") return ShadowFilterMode::NONE;
+    if (u == "PCF")  return ShadowFilterMode::PCF;
+    if (u == "PCSS") return ShadowFilterMode::PCSS;
+    return fallback;
+}
+
+OverlayMode parse_overlay(const std::string& v, OverlayMode fallback) {
+    std::string u = to_upper(v);
+    if (u == "OFF")      return OverlayMode::OFF;
+    if (u == "MINIMAL")  return OverlayMode::MINIMAL;
+    if (u == "STANDARD") return OverlayMode::STANDARD;
+    if (u == "DETAILED") return OverlayMode::DETAILED;
+    if (u == "TIMELINE") return OverlayMode::TIMELINE;
+    return fallback;
+}
+
+std::vector<std::string> split_csv(const std::string& v) {
+    std::vector<std::string> out;
+    std::stringstream ss(v);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        auto b = token.find_first_not_of(" \t");
+        auto e = token.find_last_not_of(" \t");
+        if (b == std::string::npos) continue;
+        out.emplace_back(token.substr(b, e - b + 1));
+    }
+    return out;
+}
+
+const std::string* find(const std::unordered_map<std::string, std::string>& kv,
+                        const char* key) {
+    auto it = kv.find(key);
+    return (it != kv.end()) ? &it->second : nullptr;
+}
+
+} // namespace
+
+// ---- ctors -----------------------------------------------------------------
+
+PipelineProfileBuilder::PipelineProfileBuilder(std::string profile_name) {
+    def_.profile_name = std::move(profile_name);
+}
+
+PipelineProfileBuilder PipelineProfileBuilder::from_preset(const PipelineProfileDef& preset) {
+    PipelineProfileBuilder b(preset.profile_name);
+    b.def_ = preset;
+    return b;
+}
+
+// ---- scalar setters --------------------------------------------------------
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_rendering_path(RenderingPath path) {
+    def_.rendering_path = path;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_max_lights(uint32_t count) {
+    def_.max_lights = count;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_msaa(uint8_t samples) {
+    def_.msaa_samples = samples;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_gpu_driven(bool enabled) {
+    def_.gpu_driven_enabled = enabled;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_compute_update(bool enabled) {
+    def_.compute_update_enabled = enabled;
+    def_.gpu_driven_config.compute_update = enabled;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_shadow(uint32_t cascade_count,
+                                                             uint32_t resolution,
+                                                             ShadowFilterMode filter_mode) {
+    def_.shadow_config.cascade_count = cascade_count;
+    def_.shadow_config.resolution    = resolution;
+    def_.shadow_config.filter_mode   = filter_mode;
+
+    def_.gi_config.shadow_enabled        = (cascade_count > 0);
+    def_.gi_config.shadow.cascade_count  = cascade_count;
+    def_.gi_config.shadow.resolution     = resolution;
+    def_.gi_config.shadow.filter_mode    = filter_mode;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_memory_budget_mb(size_t frame_alloc_mb,
+                                                                       size_t mesh_pool_mb,
+                                                                       size_t ssbo_pool_mb) {
+    constexpr size_t MB = 1024 * 1024;
+    def_.memory_config.frame_allocator_size         = frame_alloc_mb * MB;
+    def_.memory_config.gpu_config.mesh_pool_size    = mesh_pool_mb   * MB;
+    def_.memory_config.gpu_config.ssbo_pool_size    = ssbo_pool_mb   * MB;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_flight_count(uint32_t count) {
+    def_.memory_config.flight_count = count;
+    return *this;
+}
+
+// ---- passes ---------------------------------------------------------------
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_passes(std::vector<RenderPassDef> passes) {
+    def_.render_passes = std::move(passes);
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::add_pass(RenderPassDef pass) {
+    def_.render_passes.push_back(std::move(pass));
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::remove_pass(std::string_view pass_name) {
+    auto& v = def_.render_passes;
+    v.erase(std::remove_if(v.begin(), v.end(),
+                           [&](const RenderPassDef& p) { return p.pass_name == pass_name; }),
+            v.end());
+    return *this;
+}
+
+// ---- post-process ---------------------------------------------------------
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_post_process(std::vector<PostProcessDef> stack) {
+    def_.post_process_stack = std::move(stack);
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::add_post_process(std::string name, bool enabled) {
+    def_.post_process_stack.push_back({std::move(name), enabled});
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::clear_post_process() {
+    def_.post_process_stack.clear();
+    return *this;
+}
+
+// ---- profiler / GI --------------------------------------------------------
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_profiler(bool enabled, OverlayMode mode) {
+    def_.profiler_config.enabled      = enabled;
+    def_.profiler_config.overlay_mode = mode;
+    return *this;
+}
+
+PipelineProfileBuilder& PipelineProfileBuilder::with_gi_config(const GIConfig& cfg) {
+    def_.gi_config = cfg;
+    return *this;
+}
+
+// ---- data-driven construction ---------------------------------------------
+
+PipelineProfileDef PipelineProfileBuilder::from_key_value(
+    const std::unordered_map<std::string, std::string>& kv) {
+
+    const std::string* name_v = find(kv, "name");
+    PipelineProfileBuilder b(name_v ? *name_v : std::string("Custom"));
+    // Seed with a sensible default (Lite) so minimal configs still produce a
+    // runnable profile.
+    auto seed = PipelineProfileManager::create_lite_profile();
+    seed.profile_name = b.def_.profile_name;
+    b.def_ = seed;
+
+    return from_key_value(b.def_, kv);
+}
+
+PipelineProfileDef PipelineProfileBuilder::from_key_value(
+    const PipelineProfileDef& preset,
+    const std::unordered_map<std::string, std::string>& kv) {
+
+    PipelineProfileBuilder b = PipelineProfileBuilder::from_preset(preset);
+
+    if (auto* v = find(kv, "name"))              b.def_.profile_name = *v;
+    if (auto* v = find(kv, "rendering_path"))    b.with_rendering_path(parse_rendering_path(*v, preset.rendering_path));
+    if (auto* v = find(kv, "max_lights"))        b.with_max_lights(parse_uint(*v, preset.max_lights));
+    if (auto* v = find(kv, "msaa_samples"))      b.with_msaa(static_cast<uint8_t>(parse_uint(*v, preset.msaa_samples)));
+    if (auto* v = find(kv, "gpu_driven"))        b.with_gpu_driven(parse_bool(*v, preset.gpu_driven_enabled));
+    if (auto* v = find(kv, "compute_update"))    b.with_compute_update(parse_bool(*v, preset.compute_update_enabled));
+
+    // Shadows — only re-apply if any shadow.* key is present so that presets
+    // with shadow configs remain intact when caller doesn't override.
+    const bool has_shadow_key =
+        find(kv, "shadow.cascade_count") || find(kv, "shadow.resolution") ||
+        find(kv, "shadow.filter_mode");
+    if (has_shadow_key) {
+        uint32_t cc   = parse_uint(find(kv, "shadow.cascade_count") ? *find(kv, "shadow.cascade_count") : "",
+                                   preset.shadow_config.cascade_count);
+        uint32_t res  = parse_uint(find(kv, "shadow.resolution") ? *find(kv, "shadow.resolution") : "",
+                                   preset.shadow_config.resolution);
+        ShadowFilterMode fm = parse_shadow_filter(
+            find(kv, "shadow.filter_mode") ? *find(kv, "shadow.filter_mode") : "",
+            preset.shadow_config.filter_mode);
+        b.with_shadow(cc, res, fm);
+    }
+
+    // Memory
+    const bool has_mem_key =
+        find(kv, "memory.frame_alloc_mb") ||
+        find(kv, "memory.mesh_pool_mb") ||
+        find(kv, "memory.ssbo_pool_mb");
+    if (has_mem_key) {
+        constexpr size_t MB = 1024 * 1024;
+        size_t fa   = parse_uint(find(kv, "memory.frame_alloc_mb") ? *find(kv, "memory.frame_alloc_mb") : "",
+                                 static_cast<uint32_t>(preset.memory_config.frame_allocator_size / MB));
+        size_t mesh = parse_uint(find(kv, "memory.mesh_pool_mb") ? *find(kv, "memory.mesh_pool_mb") : "",
+                                 static_cast<uint32_t>(preset.memory_config.gpu_config.mesh_pool_size / MB));
+        size_t ssbo = parse_uint(find(kv, "memory.ssbo_pool_mb") ? *find(kv, "memory.ssbo_pool_mb") : "",
+                                 static_cast<uint32_t>(preset.memory_config.gpu_config.ssbo_pool_size / MB));
+        b.with_memory_budget_mb(fa, mesh, ssbo);
+    }
+    if (auto* v = find(kv, "memory.flight_count")) {
+        b.with_flight_count(parse_uint(*v, preset.memory_config.flight_count));
+    }
+
+    // Post-process: replace the whole stack if specified.
+    if (auto* v = find(kv, "post_process")) {
+        b.clear_post_process();
+        for (auto& name : split_csv(*v)) {
+            b.add_post_process(std::move(name), true);
+        }
+    }
+
+    // Passes: replace pass list with simple default-OPAQUE entries. Host apps
+    // needing finer-grained control should use the programmatic API.
+    if (auto* v = find(kv, "passes")) {
+        std::vector<RenderPassDef> passes;
+        for (auto& pname : split_csv(*v)) {
+            RenderPassDef p;
+            p.pass_name = pname;
+            p.pass_type = PassType::OPAQUE;
+            p.sort_mode = SortMode::FRONT_TO_BACK;
+            passes.push_back(std::move(p));
+        }
+        b.with_passes(std::move(passes));
+    }
+
+    // Profiler
+    if (auto* v = find(kv, "profiler.enabled")) {
+        OverlayMode m = preset.profiler_config.overlay_mode;
+        if (auto* ov = find(kv, "profiler.overlay")) {
+            m = parse_overlay(*ov, m);
+        }
+        b.with_profiler(parse_bool(*v, preset.profiler_config.enabled), m);
+    } else if (auto* v = find(kv, "profiler.overlay")) {
+        b.with_profiler(preset.profiler_config.enabled, parse_overlay(*v, preset.profiler_config.overlay_mode));
+    }
+
+    return b.take();
+}
+
+} // namespace pictor

--- a/src/pipeline/pipeline_profile.cpp
+++ b/src/pipeline/pipeline_profile.cpp
@@ -271,4 +271,121 @@ PipelineProfileDef PipelineProfileManager::create_ultra_profile() {
     return def;
 }
 
+// ============================================================
+// Mobile Profile Definitions (§8.1 extension)
+//
+// These presets are tuned for mobile tile-based GPUs (Adreno, Mali, Apple
+// A-series). Compared to Lite, they disable bandwidth-heavy features
+// (MSAA resolve, multi-cascade shadows) that hurt tile-based deferred
+// hardware, and shrink memory footprints to fit mobile DRAM budgets.
+// ============================================================
+
+PipelineProfileDef PipelineProfileManager::create_mobile_low_profile() {
+    PipelineProfileDef def;
+    def.profile_name = "MobileLow";
+    def.rendering_path = RenderingPath::FORWARD;
+    def.gpu_driven_enabled = false;
+    def.compute_update_enabled = false;
+    def.max_lights = 8;
+    def.msaa_samples = 0; // MSAA resolve is expensive on tile-based GPUs
+
+    // Shadows disabled entirely for low-end mobile
+    def.shadow_config.cascade_count = 0;
+    def.shadow_config.resolution    = 0;
+    def.shadow_config.filter_mode   = ShadowFilterMode::NONE;
+
+    // Memory config: sized for ~1-2GB mobile RAM
+    def.memory_config.frame_allocator_size = 1 * 1024 * 1024; // 1MB
+    def.memory_config.flight_count = 2;
+    def.memory_config.gpu_config.mesh_pool_size     = 32 * 1024 * 1024;  // 32MB
+    def.memory_config.gpu_config.ssbo_pool_size     = 16 * 1024 * 1024;  // 16MB
+    def.memory_config.gpu_config.instance_buffer_size = 4 * 1024 * 1024; // 4MB
+    def.memory_config.gpu_config.staging_buffer_size  = 4 * 1024 * 1024; // 4MB
+
+    def.gpu_driven_config = {};
+    def.gpu_driven_config.compute_update = false;
+
+    def.update_config.chunk_size = 4096;
+    def.update_config.nt_store_enabled = false;
+
+    def.profiler_config.enabled      = true;
+    def.profiler_config.overlay_mode = OverlayMode::MINIMAL;
+    def.profiler_config.max_queries  = 16;
+
+    // GI: everything off — no shadows, no SSAO, no probes
+    def.gi_config.shadow_enabled    = false;
+    def.gi_config.ssao_enabled      = false;
+    def.gi_config.gi_probes_enabled = false;
+
+    // Minimal render passes — single forward pass + tonemap
+    def.render_passes = {
+        {"OpaquePass",      PassType::OPAQUE,       INVALID_MESH, {}, {}, SortMode::FRONT_TO_BACK, 0xFFFF, false, {"transforms", "shaderKeys"}},
+        {"TransparentPass", PassType::TRANSPARENT,  INVALID_MESH, {}, {}, SortMode::BACK_TO_FRONT, 0xFFFF, false, {"transforms", "sortKeys"}},
+        {"PostProcess",     PassType::POST_PROCESS, INVALID_MESH, {}, {}, SortMode::NONE,          0xFFFF, false, {}},
+    };
+
+    def.post_process_stack = {
+        {"Tonemapping", true},
+    };
+
+    return def;
+}
+
+PipelineProfileDef PipelineProfileManager::create_mobile_high_profile() {
+    PipelineProfileDef def;
+    def.profile_name = "MobileHigh";
+    def.rendering_path = RenderingPath::FORWARD; // stay on Forward — Forward+ light lists cost bandwidth
+    def.gpu_driven_enabled = false;
+    def.compute_update_enabled = false;
+    def.max_lights = 32;
+    def.msaa_samples = 2; // 2x MSAA is the mobile sweet spot
+
+    // 1 shadow cascade, modest resolution, PCF soft shadows
+    def.shadow_config.cascade_count = 1;
+    def.shadow_config.resolution    = 1024;
+    def.shadow_config.filter_mode   = ShadowFilterMode::PCF;
+
+    // Memory config: sized for mid/high-tier mobile (~4GB RAM devices)
+    def.memory_config.frame_allocator_size = 4 * 1024 * 1024;  // 4MB
+    def.memory_config.flight_count = 2;
+    def.memory_config.gpu_config.mesh_pool_size     = 128 * 1024 * 1024; // 128MB
+    def.memory_config.gpu_config.ssbo_pool_size     = 32 * 1024 * 1024;  // 32MB
+    def.memory_config.gpu_config.instance_buffer_size = 16 * 1024 * 1024;
+    def.memory_config.gpu_config.staging_buffer_size  = 16 * 1024 * 1024;
+
+    def.gpu_driven_config = {};
+    def.gpu_driven_config.compute_update = false;
+
+    def.update_config.chunk_size = 8192;
+    def.update_config.nt_store_enabled = false;
+
+    def.profiler_config.enabled      = true;
+    def.profiler_config.overlay_mode = OverlayMode::STANDARD;
+    def.profiler_config.max_queries  = 32;
+
+    def.gi_config.shadow_enabled    = true;
+    def.gi_config.ssao_enabled      = false; // SSAO is heavy on tile-based GPUs
+    def.gi_config.gi_probes_enabled = false;
+    def.gi_config.shadow.cascade_count = 1;
+    def.gi_config.shadow.resolution    = 1024;
+    def.gi_config.shadow.filter_mode   = ShadowFilterMode::PCF;
+    def.gi_config.shadow.depth_bias    = 0.005f;
+
+    def.render_passes = {
+        {"ShadowPass",      PassType::SHADOW,       INVALID_MESH, {}, {}, SortMode::NONE,          0xFFFF, false, {"bounds", "transforms"}},
+        {"DepthPrePass",    PassType::DEPTH_ONLY,   INVALID_MESH, {}, {}, SortMode::FRONT_TO_BACK, 0xFFFF, false, {"bounds", "transforms"}},
+        {"OpaquePass",      PassType::OPAQUE,       INVALID_MESH, {}, {}, SortMode::FRONT_TO_BACK, 0xFFFF, false, {"transforms", "shaderKeys"}},
+        {"TransparentPass", PassType::TRANSPARENT,  INVALID_MESH, {}, {}, SortMode::BACK_TO_FRONT, 0xFFFF, false, {"transforms", "sortKeys"}},
+        {"PostProcess",     PassType::POST_PROCESS, INVALID_MESH, {}, {}, SortMode::NONE,          0xFFFF, false, {}},
+    };
+
+    def.post_process_stack = {
+        {"Bloom",       true},
+        {"Tonemapping", true},
+        {"FXAA",        true},
+    };
+
+    return def;
+}
+
 } // namespace pictor


### PR DESCRIPTION
Adds MobileLow / MobileHigh profile presets tuned for tile-based GPUs,
plus a PipelineProfileBuilder that lets host applications construct
pipelines from outside the library — either via a fluent API or from a
flat key/value map loaded from disk (JSON/INI/TOML parsing stays with
the host). A new headless pictor_mobile_demo showcases both tiers and
cycles profiles at runtime to validate live reconfiguration.