### PR TITLE
feat(vector): Rive Renderer integration + demo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ option(PICTOR_BUILD_DEMO          "Build all demo applications"      ON)
 option(PICTOR_ENABLE_PROFILER     "Enable built-in profiler"        ON)
 option(PICTOR_USE_LARGE_PAGES     "Enable large page support"       OFF)
 option(PICTOR_BUILD_WEBGL         "Build WebGL2 backend (Emscripten)" OFF)
+option(PICTOR_ENABLE_RIVE         "Enable Rive Renderer integration (requires prebuilt rive-runtime; see cmake/FindRive.cmake)" OFF)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # --- Vulkan (requires Vulkan SDK to be installed) ---
 find_package(Vulkan QUIET)
@@ -128,6 +131,9 @@ add_library(pictor STATIC
     src/animation/vector_animation.cpp
     src/animation/animation_system.cpp
 
+    # Vector (Rive Renderer integration)
+    src/vector/rive_renderer.cpp
+
     # UI Overlay
     src/ui/screen_overlay_group.cpp
     src/ui/ui_overlay_pipeline.cpp
@@ -159,6 +165,19 @@ endif()
 
 if(PICTOR_USE_LARGE_PAGES)
     target_compile_definitions(pictor PRIVATE PICTOR_LARGE_PAGES=1)
+endif()
+
+# ─── Rive Renderer (optional) ────────────────────────────────
+# Rive's own build is premake5-based; we consume it as a prebuilt static
+# library. User workflow:
+#   git clone https://github.com/rive-app/rive-runtime
+#   cd rive-runtime && ./build.sh release
+#   cmake -DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=/path/to/rive-runtime ...
+if(PICTOR_ENABLE_RIVE)
+    find_package(Rive REQUIRED)
+    target_link_libraries(pictor PUBLIC Rive::Rive)
+    target_compile_definitions(pictor PUBLIC PICTOR_HAS_RIVE=1)
+    message(STATUS "Pictor: Rive Renderer enabled (dir=${PICTOR_RIVE_DIR}, config=${PICTOR_RIVE_CONFIG})")
 endif()
 
 # Platform-specific flags
@@ -228,6 +247,13 @@ if(PICTOR_BUILD_DEMO)
         # Post-process demo
         add_executable(pictor_postprocess_demo demo/postprocess/main.cpp)
         target_link_libraries(pictor_postprocess_demo PRIVATE pictor)
+
+        # Rive Renderer demo (plays an official .riv file through pictor::RiveRenderer).
+        # Always builds so Pictor's CI catches compile-time regressions in the
+        # demo — when PICTOR_ENABLE_RIVE is OFF, `rive.initialize()` returns
+        # false and the demo exits cleanly at startup.
+        add_executable(pictor_rive_demo demo/rive/main.cpp)
+        target_link_libraries(pictor_rive_demo PRIVATE pictor)
 
         # 2D Texture rendering demo
         add_executable(pictor_texture2d_demo

--- a/cmake/FindRive.cmake
+++ b/cmake/FindRive.cmake
@@ -1,0 +1,153 @@
+# FindRive.cmake
+#
+# Locates a pre-built rive-runtime distribution (https://github.com/rive-app/rive-runtime)
+# produced by its native premake5 build (`./build.sh release`).
+#
+# Rive itself does not ship a CMake build, so Pictor treats it as an external
+# prebuilt dependency. The user is expected to clone rive-runtime, run its
+# build once, and point this module at the result via PICTOR_RIVE_DIR.
+#
+# Inputs (set by the caller or on the cmake command line):
+#   PICTOR_RIVE_DIR    — root of the rive-runtime checkout (must contain
+#                        include/ and the compiled static libs under out/).
+#   PICTOR_RIVE_CONFIG — build config to consume ("debug" or "release",
+#                        default: "release").
+#
+# Outputs:
+#   Rive_FOUND              — TRUE if all required libraries were located.
+#   Rive_INCLUDE_DIRS       — list of include directories.
+#   Rive_LIBRARIES          — list of static libraries to link.
+#   Rive::Rive              — imported INTERFACE target wrapping the above.
+#
+# Expected on-disk layout (matches rive-runtime's premake defaults):
+#   ${PICTOR_RIVE_DIR}/include/
+#   ${PICTOR_RIVE_DIR}/renderer/include/
+#   ${PICTOR_RIVE_DIR}/out/${PICTOR_RIVE_CONFIG}/rive.lib
+#   ${PICTOR_RIVE_DIR}/out/${PICTOR_RIVE_CONFIG}/rive_pls_renderer.lib   (or rive_renderer)
+#   ${PICTOR_RIVE_DIR}/out/${PICTOR_RIVE_CONFIG}/rive_vk_bootstrap.lib
+#   ${PICTOR_RIVE_DIR}/out/${PICTOR_RIVE_CONFIG}/rive_decoders.lib        (optional)
+#
+# On non-Windows platforms the extension is .a instead of .lib.
+
+if(NOT PICTOR_RIVE_DIR)
+    set(Rive_FOUND FALSE)
+    return()
+endif()
+
+if(NOT PICTOR_RIVE_CONFIG)
+    set(PICTOR_RIVE_CONFIG "release")
+endif()
+
+# rive-runtime's premake places build artifacts under the subproject
+# directory whose premake5.lua was invoked. For the renderer (the library
+# we care about here) that is `renderer/out/<config>/`. A handful of
+# users drive the monorepo-level build instead, which places artifacts
+# at `out/<config>/` — check both so either workflow is supported.
+set(_rive_lib_candidates
+    "${PICTOR_RIVE_DIR}/renderer/out/${PICTOR_RIVE_CONFIG}"
+    "${PICTOR_RIVE_DIR}/out/${PICTOR_RIVE_CONFIG}"
+)
+set(_rive_lib_dir "")
+foreach(_dir IN LISTS _rive_lib_candidates)
+    if(EXISTS "${_dir}")
+        set(_rive_lib_dir "${_dir}")
+        break()
+    endif()
+endforeach()
+
+# Include directories — Rive's public headers live in two trees:
+#   include/               -> rive/core/*, rive/animation/*, scene graph
+#   renderer/include/      -> rive/renderer/* (the GPU renderer public API)
+set(Rive_INCLUDE_DIRS
+    "${PICTOR_RIVE_DIR}/include"
+    "${PICTOR_RIVE_DIR}/renderer/include"
+)
+
+# Primary libraries. rive-runtime's premake output names vary slightly
+# between branches (rive_pls_renderer was renamed to rive_renderer in the
+# public-domain release); probe both.
+find_library(Rive_CORE_LIB
+    NAMES rive
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+find_library(Rive_RENDERER_LIB
+    NAMES rive_renderer rive_pls_renderer
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+find_library(Rive_DECODERS_LIB
+    NAMES rive_decoders
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+find_library(Rive_HARFBUZZ_LIB
+    NAMES rive_harfbuzz harfbuzz
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+find_library(Rive_SHEENBIDI_LIB
+    NAMES rive_sheenbidi sheenbidi
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+find_library(Rive_YOGA_LIB
+    NAMES rive_yoga yoga
+    PATHS "${_rive_lib_dir}"
+    NO_DEFAULT_PATH
+)
+
+# Image decoder transitive deps — rive_decoders.lib pulls unresolved symbols
+# from libjpeg, libpng, libwebp, and zlib, all built alongside Rive under the
+# same output directory.
+find_library(Rive_LIBJPEG_LIB NAMES libjpeg jpeg PATHS "${_rive_lib_dir}" NO_DEFAULT_PATH)
+find_library(Rive_LIBPNG_LIB  NAMES libpng png   PATHS "${_rive_lib_dir}" NO_DEFAULT_PATH)
+find_library(Rive_LIBWEBP_LIB NAMES libwebp webp PATHS "${_rive_lib_dir}" NO_DEFAULT_PATH)
+find_library(Rive_ZLIB_LIB    NAMES zlib z       PATHS "${_rive_lib_dir}" NO_DEFAULT_PATH)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Rive
+    REQUIRED_VARS
+        Rive_CORE_LIB
+        Rive_RENDERER_LIB
+    FAIL_MESSAGE
+        "Rive runtime not found. Set PICTOR_RIVE_DIR to the root of a checked-out and built rive-runtime (run `./build.sh release` inside rive-runtime first)."
+)
+
+if(Rive_FOUND)
+    set(Rive_LIBRARIES
+        ${Rive_RENDERER_LIB}
+        ${Rive_CORE_LIB}
+    )
+    # Optional auxiliaries — include only if present. Order matters for
+    # static-link resolution: decoders first (they reference the image libs),
+    # harfbuzz/sheenbidi/yoga provide text/layout symbols called from rive.lib,
+    # image libs last since nothing depends on them.
+    foreach(_lib IN ITEMS
+            Rive_DECODERS_LIB
+            Rive_HARFBUZZ_LIB
+            Rive_SHEENBIDI_LIB
+            Rive_YOGA_LIB
+            Rive_LIBJPEG_LIB
+            Rive_LIBPNG_LIB
+            Rive_LIBWEBP_LIB
+            Rive_ZLIB_LIB)
+        if(${_lib})
+            list(APPEND Rive_LIBRARIES ${${_lib}})
+        endif()
+    endforeach()
+
+    if(NOT TARGET Rive::Rive)
+        add_library(Rive::Rive INTERFACE IMPORTED)
+        set_target_properties(Rive::Rive PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES   "${Rive_INCLUDE_DIRS}"
+            INTERFACE_LINK_LIBRARIES        "${Rive_LIBRARIES}"
+            # Must mirror the defines Rive itself is compiled with so the
+            # Vulkan class declarations (gated on RIVE_VULKAN) and the
+            # rive-render-factory (gated on WITH_RIVE_*) are visible to
+            # consumers. Missing these yields spurious "incomplete type"
+            # errors on RenderContextVulkanImpl.
+            INTERFACE_COMPILE_DEFINITIONS   "RIVE_VULKAN;WITH_RIVE_TEXT;WITH_RIVE_LAYOUT"
+        )
+    endif()
+endif()

--- a/demo/rive/main.cpp
+++ b/demo/rive/main.cpp
@@ -1,0 +1,246 @@
+/// Pictor Rive Renderer Demo
+///
+/// Plays an official .riv file through pictor::RiveRenderer (which wraps
+/// Rive's own GPU renderer). Useful to verify that the Rive runtime
+/// integration — including file import, artboard selection, state machine
+/// advancement, and Vulkan frame plumbing — works end-to-end inside Pictor.
+///
+/// Usage:
+///   pictor_rive_demo <path/to/file.riv> [state_machine_index]
+///
+/// Official sample .riv files live in rive-runtime/gold/ and
+/// rive-runtime/renderer/path_fiddle/rivs/. Point the demo at any of them.
+///
+/// Controls:
+///   Space      — toggle between state machine 0 and animation 0
+///   Left/Right — cycle artboards
+///   Esc        — quit
+
+#include "pictor/surface/vulkan_context.h"
+#include "pictor/surface/glfw_surface_provider.h"
+#include "pictor/vector/rive_renderer.h"
+
+#include <GLFW/glfw3.h>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+using namespace pictor;
+
+namespace {
+
+struct Keys {
+    bool toggle_scene = false;
+    int  cycle_artboard = 0; // -1, 0, +1
+};
+static Keys g_keys;
+
+void key_callback(GLFWwindow* w, int key, int /*scan*/, int action, int /*mods*/) {
+    if (action != GLFW_PRESS) return;
+    switch (key) {
+    case GLFW_KEY_ESCAPE: glfwSetWindowShouldClose(w, GLFW_TRUE); break;
+    case GLFW_KEY_SPACE:  g_keys.toggle_scene = true;             break;
+    case GLFW_KEY_LEFT:   g_keys.cycle_artboard = -1;             break;
+    case GLFW_KEY_RIGHT:  g_keys.cycle_artboard = +1;             break;
+    default: break;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr,
+                "usage: %s <path/to/file.riv> [state_machine_index]\n\n"
+                "Tip: official sample .riv files ship with rive-runtime under\n"
+                "  rive-runtime/gold/ and rive-runtime/renderer/path_fiddle/rivs/\n",
+                argv[0]);
+        return 1;
+    }
+    const char* riv_path = argv[1];
+    int requested_sm    = (argc >= 3) ? std::atoi(argv[2]) : 0;
+
+    printf("=== Pictor Rive Renderer Demo ===\n");
+    printf("file: %s\n", riv_path);
+    printf("state machine: %d\n\n", requested_sm);
+
+    // ─── 1. GLFW + Vulkan ───────────────────────────────────
+    GlfwSurfaceProvider surface;
+    GlfwWindowConfig win_cfg;
+    win_cfg.width  = 1024;
+    win_cfg.height = 1024;
+    win_cfg.title  = "Pictor — Rive Renderer Demo";
+    win_cfg.vsync  = true;
+    if (!surface.create(win_cfg)) {
+        fprintf(stderr, "GLFW window creation failed\n");
+        return 1;
+    }
+    glfwSetKeyCallback(surface.glfw_window(), key_callback);
+
+    VulkanContext vk;
+    VulkanContextConfig vk_cfg;
+    vk_cfg.app_name   = "Pictor Rive Demo";
+    vk_cfg.validation = true;
+    if (!vk.initialize(&surface, vk_cfg)) {
+        fprintf(stderr, "Vulkan init failed\n");
+        surface.destroy();
+        return 1;
+    }
+
+    // ─── 2. Rive renderer ──────────────────────────────────
+    RiveRenderer rive;
+    RiveRenderer::Options opts;
+    // Atomic mode is the portable path. Flip to false once Pictor's device
+    // creation is verified to enable Rive's preferred rasterizer-ordering
+    // extensions (VK_EXT_rasterization_order_attachment_access etc.).
+    opts.force_atomic_mode = true;
+    opts.clear_color       = 0xff202020; // dark grey background
+
+    if (!rive.initialize(vk, opts)) {
+        fprintf(stderr,
+                "RiveRenderer init failed. Common causes:\n"
+                "  * Pictor was built without PICTOR_ENABLE_RIVE=ON\n"
+                "  * rive-runtime was not built in release mode\n"
+                "  * Required Vulkan device extensions are missing\n");
+        vk.shutdown();
+        surface.destroy();
+        return 1;
+    }
+
+    if (!rive.load_riv_file(riv_path)) {
+        fprintf(stderr, "failed to load .riv\n");
+        rive.shutdown();
+        vk.shutdown();
+        surface.destroy();
+        return 1;
+    }
+
+    // Prefer the requested state machine; fall back to animation 0.
+    bool using_sm = rive.set_state_machine(requested_sm);
+    if (!using_sm) {
+        using_sm = rive.set_animation(0);
+        printf("(no state machine %d — falling back to animation 0)\n",
+               requested_sm);
+    }
+
+    printf("Controls: Space=toggle scene, Left/Right=cycle artboard, Esc=quit\n\n");
+
+    // ─── 3. Main loop ──────────────────────────────────────
+    auto     t_prev         = std::chrono::high_resolution_clock::now();
+    uint64_t frame_number   = 0;
+    uint64_t safe_frame     = 0;
+    uint64_t frame_count    = 0;
+    int      artboard_index = 0;
+
+    while (!surface.should_close()) {
+        surface.poll_events();
+
+        auto t_now = std::chrono::high_resolution_clock::now();
+        float dt   = std::chrono::duration<float>(t_now - t_prev).count();
+        t_prev     = t_now;
+        if (dt > 0.1f) dt = 0.1f; // clamp huge hitches
+
+        // Handle input since last frame
+        if (g_keys.toggle_scene) {
+            g_keys.toggle_scene = false;
+            using_sm = !using_sm;
+            if (using_sm) rive.set_state_machine(0);
+            else          rive.set_animation(0);
+            printf("scene: %s\n", using_sm ? "state machine 0" : "animation 0");
+        }
+        if (g_keys.cycle_artboard != 0) {
+            artboard_index += g_keys.cycle_artboard;
+            if (artboard_index < 0) artboard_index = 0;
+            g_keys.cycle_artboard = 0;
+            if (rive.set_artboard(artboard_index)) {
+                if (using_sm) rive.set_state_machine(0);
+                else          rive.set_animation(0);
+                printf("artboard: %d\n", artboard_index);
+            } else {
+                --artboard_index; // revert
+            }
+        }
+
+        rive.advance(dt);
+
+        uint32_t image_idx = vk.acquire_next_image();
+        if (image_idx == UINT32_MAX) continue;
+
+        VkCommandBuffer cmd = vk.command_buffers()[image_idx];
+        vkResetCommandBuffer(cmd, 0);
+
+        VkCommandBufferBeginInfo bi{};
+        bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        vkBeginCommandBuffer(cmd, &bi);
+
+        VkImage     image = nullptr; // VulkanContext only exposes views; we
+                                     // look up the image via swapchain below.
+        // The current Pictor VulkanContext doesn't expose swapchain_images()
+        // directly — use vkGetSwapchainImagesKHR on the fly.
+        {
+            uint32_t count = 0;
+            vkGetSwapchainImagesKHR(vk.device(), vk.swapchain(), &count, nullptr);
+            std::vector<VkImage> images(count);
+            vkGetSwapchainImagesKHR(vk.device(), vk.swapchain(), &count, images.data());
+            image = images[image_idx];
+        }
+        VkImageView view = vk.swapchain_image_views()[image_idx];
+
+        // Rive renders and finishes with a layout that depends on the
+        // rendering path; the wrapper tracks that internally and emits the
+        // correct PRESENT_SRC_KHR transition on our behalf.
+        rive.render(cmd,
+                    image,
+                    view,
+                    vk.swapchain_extent(),
+                    vk.swapchain_format(),
+                    static_cast<uint32_t>(frame_number),
+                    static_cast<uint32_t>(safe_frame),
+                    VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
+
+        vkEndCommandBuffer(cmd);
+
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSemaphore wait_sem = vk.image_available_semaphore();
+        VkSemaphore sig_sem  = vk.render_finished_semaphore();
+
+        VkSubmitInfo si{};
+        si.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        si.waitSemaphoreCount   = 1;
+        si.pWaitSemaphores      = &wait_sem;
+        si.pWaitDstStageMask    = &wait_stage;
+        si.commandBufferCount   = 1;
+        si.pCommandBuffers      = &cmd;
+        si.signalSemaphoreCount = 1;
+        si.pSignalSemaphores    = &sig_sem;
+        vkQueueSubmit(vk.graphics_queue(), 1, &si, vk.in_flight_fence());
+
+        vk.present(image_idx);
+
+        // Rive uses currentFrameNumber as a monotonically increasing id and
+        // safeFrameNumber as "last frame whose resources have been retired by
+        // the GPU". With a single-fence-per-frame model we wait on the fence
+        // at the top of the next iteration's acquire; that means by the time
+        // we advance frame_number, (frame_number - 1) is safe.
+        if (frame_number > 0) safe_frame = frame_number - 1;
+        ++frame_number;
+        ++frame_count;
+
+        if (frame_count % 120 == 0) {
+            printf("[frame %llu] %.1f fps\n",
+                   static_cast<unsigned long long>(frame_count),
+                   1.0f / dt);
+        }
+    }
+
+    // ─── 4. Cleanup ─────────────────────────────────────────
+    vk.device_wait_idle();
+    rive.shutdown();
+    vk.shutdown();
+    surface.destroy();
+    printf("\nDemo finished. %llu frames.\n",
+           static_cast<unsigned long long>(frame_count));
+    return 0;
+}

--- a/include/pictor/vector/rive_renderer.h
+++ b/include/pictor/vector/rive_renderer.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#ifdef PICTOR_HAS_VULKAN
+#include <vulkan/vulkan.h>
+#endif
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace pictor {
+
+class VulkanContext;
+
+/// Pictor wrapper around the Rive Renderer
+/// (https://github.com/rive-app/rive-runtime, MIT-licensed).
+///
+/// Owns a single `rive::gpu::RenderContextVulkanImpl` configured against
+/// Pictor's shared `VulkanContext`. A loaded `.riv` file yields an artboard
+/// and an optional state machine / animation that is advanced and drawn each
+/// frame into a caller-supplied VkImage.
+///
+/// The wrapper exposes no Rive types in its public header — the Rive include
+/// tree only needs to be visible while compiling `rive_renderer.cpp`. This
+/// keeps Pictor's public headers free of Rive's Vulkan include chain.
+///
+/// Compilation model:
+///   - When PICTOR_HAS_RIVE is defined (set by CMake when `PICTOR_ENABLE_RIVE=ON`
+///     and a prebuilt rive-runtime is located via `cmake/FindRive.cmake`), the
+///     implementation forwards to Rive.
+///   - When it is not defined, every public method is a safe no-op that
+///     reports failure on `initialize()`. This lets downstream code depend on
+///     Pictor unconditionally.
+class RiveRenderer {
+public:
+    struct Options {
+        /// Force atomic-based fill mode. Required on drivers without rasterizer
+        /// ordering support (`VK_EXT_rasterization_order_attachment_access` or
+        /// the Rive-preferred pixel-local-storage equivalents). Slightly slower
+        /// on compliant drivers but portable.
+        bool     force_atomic_mode = false;
+
+        /// MSAA sample count for the Rive output. 0 = no MSAA (default).
+        uint32_t msaa_sample_count = 0;
+
+        /// Packed 0xAABBGGRR clear color applied each frame.
+        uint32_t clear_color = 0x00000000;
+    };
+
+    RiveRenderer();
+    ~RiveRenderer();
+
+    RiveRenderer(const RiveRenderer&)            = delete;
+    RiveRenderer& operator=(const RiveRenderer&) = delete;
+
+    // ─── Lifecycle ───────────────────────────────────────────
+
+    /// Create the Rive RenderContext bound to the given Vulkan context.
+    /// Returns false if Rive is not compiled in (PICTOR_HAS_RIVE undefined)
+    /// or if Rive initialisation fails.
+    bool initialize(VulkanContext& vk_ctx, const Options& opts = {});
+
+    void shutdown();
+
+    bool is_initialized() const;
+
+    // ─── Asset loading ───────────────────────────────────────
+
+    /// Load a .riv file from disk. Replaces any previously-loaded file.
+    bool load_riv_file(const std::string& path);
+
+    /// Load a .riv file from an in-memory buffer. `data` is copied; the
+    /// caller may free the buffer immediately after the call returns.
+    bool load_riv_memory(const uint8_t* data, size_t size);
+
+    void unload();
+
+    bool has_file() const;
+
+    // ─── Scene selection ─────────────────────────────────────
+
+    /// Pick an artboard by index. -1 selects the default artboard.
+    bool set_artboard(int index = -1);
+
+    /// Pick a state machine. Use `set_state_machine(-1)` to disable and
+    /// fall back to an animation.
+    bool set_state_machine(int index);
+
+    /// Pick an animation (ignored if a state machine is active).
+    bool set_animation(int index);
+
+    bool has_scene() const;
+
+    // ─── Per-frame ───────────────────────────────────────────
+
+    /// Advance the currently selected scene by `delta_time` seconds.
+    void advance(float delta_time);
+
+#ifdef PICTOR_HAS_VULKAN
+    /// Draw the current scene into the supplied Vulkan image.
+    ///
+    /// Layout tracking is handled internally: the wrapper remembers the
+    /// last access state per VkImage it has seen, so the caller never
+    /// needs to tell Rive "what layout is this image in". First-time images
+    /// are assumed to be in VK_IMAGE_LAYOUT_UNDEFINED (the content is
+    /// discarded — fine for swapchain images immediately after acquire).
+    ///
+    /// `final_layout` optionally requests a final layout transition after
+    /// Rive's flush. Passing `VK_IMAGE_LAYOUT_PRESENT_SRC_KHR` handles the
+    /// common swapchain case — the wrapper queries the layout Rive actually
+    /// ended in (which depends on atomic vs raster-ordered mode, MSAA, and
+    /// the Rive version) and emits a single barrier from that to
+    /// `final_layout`. Passing VK_IMAGE_LAYOUT_UNDEFINED (the default)
+    /// skips the transition.
+    ///
+    /// `current_frame_number` / `safe_frame_number` feed Rive's internal
+    /// ring-buffered GPU resource recycling — the caller typically passes
+    /// the active swapchain frame and the last frame known to be retired.
+    bool render(VkCommandBuffer  cmd,
+                VkImage          target_image,
+                VkImageView      target_view,
+                VkExtent2D       extent,
+                VkFormat         format,
+                uint32_t         current_frame_number,
+                uint32_t         safe_frame_number,
+                VkImageLayout    final_layout = VK_IMAGE_LAYOUT_UNDEFINED);
+#endif
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace pictor

--- a/src/vector/rive_renderer.cpp
+++ b/src/vector/rive_renderer.cpp
@@ -1,0 +1,396 @@
+#include "pictor/vector/rive_renderer.h"
+
+#include <cstdio>
+#include <fstream>
+#include <unordered_map>
+#include <vector>
+
+#ifdef PICTOR_HAS_RIVE
+
+// Rive public headers. These only need to be visible in this translation unit.
+// Pictor consumers never include them.
+#include "rive/artboard.hpp"
+#include "rive/file.hpp"
+#include "rive/renderer.hpp"
+#include "rive/scene.hpp"
+#include "rive/animation/state_machine_instance.hpp"
+#include "rive/renderer/render_context.hpp"
+#include "rive/renderer/rive_renderer.hpp"
+#include "rive/renderer/vulkan/render_context_vulkan_impl.hpp"
+#include "rive/renderer/vulkan/render_target_vulkan.hpp"
+
+#endif // PICTOR_HAS_RIVE
+
+#ifdef PICTOR_HAS_VULKAN
+#include "pictor/surface/vulkan_context.h"
+#endif
+
+namespace pictor {
+
+// ═══════════════════════════════════════════════════════════════
+// Impl — real when PICTOR_HAS_RIVE is defined, otherwise a minimal
+// stub that only tracks initialization state so calls fail cleanly.
+// ═══════════════════════════════════════════════════════════════
+
+#ifdef PICTOR_HAS_RIVE
+
+struct RiveRenderer::Impl {
+    RiveRenderer::Options                                    options;
+
+    std::unique_ptr<rive::gpu::RenderContext>                render_context;
+    rive::rcp<rive::gpu::RenderTargetVulkanImpl>             render_target;
+
+    std::vector<uint8_t>                                     file_bytes;
+    rive::rcp<rive::File>                                    file;
+    std::unique_ptr<rive::ArtboardInstance>                  artboard;
+    std::unique_ptr<rive::Scene>                             scene;
+
+    std::unique_ptr<rive::RiveRenderer>                      renderer;
+    uint32_t                                                 cached_w = 0;
+    uint32_t                                                 cached_h = 0;
+
+    bool                                                     initialized = false;
+
+    // Cached Vulkan handles — needed when creating/resizing render targets.
+#ifdef PICTOR_HAS_VULKAN
+    VkInstance                                               vk_instance = VK_NULL_HANDLE;
+    VkPhysicalDevice                                         vk_physical = VK_NULL_HANDLE;
+    VkDevice                                                 vk_device   = VK_NULL_HANDLE;
+
+    // Per-image layout tracking. Rive's setTargetImageView() wants the
+    // image's current access state, and after flush() we need to know what
+    // layout to barrier from. We cache both here, keyed by VkImage.
+    // Swapchain images are a small finite set so the map stays tiny.
+    std::unordered_map<VkImage, rive::gpu::vkutil::ImageAccess> image_access;
+#endif
+
+    rive::gpu::RenderContextVulkanImpl* vulkan_impl() const {
+        return render_context
+            ? render_context->static_impl_cast<rive::gpu::RenderContextVulkanImpl>()
+            : nullptr;
+    }
+
+    void reset_scene() {
+        scene.reset();
+        artboard.reset();
+    }
+
+    void reset_file() {
+        reset_scene();
+        file.reset();
+        file_bytes.clear();
+    }
+};
+
+#else  // !PICTOR_HAS_RIVE — stub impl
+
+struct RiveRenderer::Impl {
+    bool initialized = false;
+};
+
+#endif
+
+// ═══════════════════════════════════════════════════════════════
+// Public API
+// ═══════════════════════════════════════════════════════════════
+
+RiveRenderer::RiveRenderer() : impl_(std::make_unique<Impl>()) {}
+
+RiveRenderer::~RiveRenderer() {
+    if (impl_ && impl_->initialized) shutdown();
+}
+
+bool RiveRenderer::is_initialized() const {
+    return impl_ && impl_->initialized;
+}
+
+// ─── initialize / shutdown ───────────────────────────────────
+
+bool RiveRenderer::initialize(VulkanContext& vk_ctx, const Options& opts) {
+    (void)vk_ctx; (void)opts;
+#if !defined(PICTOR_HAS_RIVE)
+    fprintf(stderr, "[Rive] PICTOR_HAS_RIVE is not defined — rebuild Pictor "
+                    "with -DPICTOR_ENABLE_RIVE=ON and PICTOR_RIVE_DIR pointing "
+                    "at a prebuilt rive-runtime.\n");
+    return false;
+#elif !defined(PICTOR_HAS_VULKAN)
+    fprintf(stderr, "[Rive] Vulkan is not available in this Pictor build.\n");
+    return false;
+#else
+    impl_->options       = opts;
+    impl_->vk_instance   = vk_ctx.instance();
+    impl_->vk_physical   = vk_ctx.physical_device();
+    impl_->vk_device     = vk_ctx.device();
+
+    rive::gpu::RenderContextVulkanImpl::ContextOptions ctx_opts;
+    ctx_opts.forceAtomicMode = opts.force_atomic_mode;
+
+    impl_->render_context = rive::gpu::RenderContextVulkanImpl::MakeContext(
+        impl_->vk_instance,
+        impl_->vk_physical,
+        impl_->vk_device,
+        rive::gpu::VulkanFeatures{},                  // auto-detect
+        /*vkGetInstanceProcAddr=*/nullptr,            // static linkage with loader
+        ctx_opts);
+
+    if (!impl_->render_context) {
+        fprintf(stderr, "[Rive] RenderContextVulkanImpl::MakeContext failed\n");
+        return false;
+    }
+
+    impl_->initialized = true;
+    printf("[Rive] Initialized (atomic=%d, msaa=%u)\n",
+           opts.force_atomic_mode ? 1 : 0, opts.msaa_sample_count);
+    return true;
+#endif
+}
+
+void RiveRenderer::shutdown() {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->initialized) return;
+    // Order: scene & renderer refer to the context, tear them down first.
+    impl_->renderer.reset();
+    impl_->reset_file();
+    impl_->render_target.reset();
+    impl_->render_context.reset();
+    impl_->initialized = false;
+#endif
+}
+
+// ─── Asset loading ───────────────────────────────────────────
+
+bool RiveRenderer::load_riv_file(const std::string& path) {
+#ifdef PICTOR_HAS_RIVE
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    if (!f.is_open()) {
+        fprintf(stderr, "[Rive] Cannot open .riv: %s\n", path.c_str());
+        return false;
+    }
+    size_t size = static_cast<size_t>(f.tellg());
+    std::vector<uint8_t> bytes(size);
+    f.seekg(0);
+    f.read(reinterpret_cast<char*>(bytes.data()),
+           static_cast<std::streamsize>(size));
+    return load_riv_memory(bytes.data(), bytes.size());
+#else
+    (void)path;
+    return false;
+#endif
+}
+
+bool RiveRenderer::load_riv_memory(const uint8_t* data, size_t size) {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->initialized) return false;
+    if (!data || size == 0)   return false;
+
+    impl_->reset_file();
+    impl_->file_bytes.assign(data, data + size);
+
+    // Rive's File::import requires a Factory — the RenderContext provides one.
+    impl_->file = rive::File::import(
+        rive::Span<const uint8_t>(impl_->file_bytes.data(),
+                                  impl_->file_bytes.size()),
+        impl_->render_context.get());
+
+    if (!impl_->file) {
+        fprintf(stderr, "[Rive] File::import failed (%zu bytes)\n", size);
+        impl_->file_bytes.clear();
+        return false;
+    }
+
+    // Default artboard + first state machine if any.
+    set_artboard(-1);
+    if (impl_->artboard && impl_->artboard->stateMachineCount() > 0) {
+        set_state_machine(0);
+    }
+    return true;
+#else
+    (void)data; (void)size;
+    return false;
+#endif
+}
+
+void RiveRenderer::unload() {
+#ifdef PICTOR_HAS_RIVE
+    impl_->reset_file();
+#endif
+}
+
+bool RiveRenderer::has_file() const {
+#ifdef PICTOR_HAS_RIVE
+    return impl_ && impl_->file != nullptr;
+#else
+    return false;
+#endif
+}
+
+// ─── Scene selection ─────────────────────────────────────────
+
+bool RiveRenderer::set_artboard(int index) {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->file) return false;
+    impl_->reset_scene();
+    impl_->artboard = (index < 0)
+        ? impl_->file->artboardDefault()
+        : impl_->file->artboardAt(static_cast<size_t>(index));
+    return impl_->artboard != nullptr;
+#else
+    (void)index;
+    return false;
+#endif
+}
+
+bool RiveRenderer::set_state_machine(int index) {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->artboard) return false;
+    if (index < 0) { impl_->scene.reset(); return true; }
+    impl_->scene = impl_->artboard->stateMachineAt(static_cast<size_t>(index));
+    return impl_->scene != nullptr;
+#else
+    (void)index;
+    return false;
+#endif
+}
+
+bool RiveRenderer::set_animation(int index) {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->artboard) return false;
+    if (index < 0) { impl_->scene.reset(); return true; }
+    impl_->scene = impl_->artboard->animationAt(static_cast<size_t>(index));
+    return impl_->scene != nullptr;
+#else
+    (void)index;
+    return false;
+#endif
+}
+
+bool RiveRenderer::has_scene() const {
+#ifdef PICTOR_HAS_RIVE
+    return impl_ && impl_->scene != nullptr;
+#else
+    return false;
+#endif
+}
+
+// ─── Per-frame ───────────────────────────────────────────────
+
+void RiveRenderer::advance(float delta_time) {
+#ifdef PICTOR_HAS_RIVE
+    if (impl_->scene) {
+        impl_->scene->advanceAndApply(delta_time);
+    } else if (impl_->artboard) {
+        impl_->artboard->advance(delta_time);
+    }
+#else
+    (void)delta_time;
+#endif
+}
+
+#ifdef PICTOR_HAS_VULKAN
+bool RiveRenderer::render(VkCommandBuffer cmd,
+                           VkImage         target_image,
+                           VkImageView     target_view,
+                           VkExtent2D      extent,
+                           VkFormat        format,
+                           uint32_t        current_frame_number,
+                           uint32_t        safe_frame_number,
+                           VkImageLayout   final_layout) {
+#ifdef PICTOR_HAS_RIVE
+    if (!impl_->initialized || !impl_->artboard) return false;
+
+    // (Re)create the render target when dimensions change.
+    if (!impl_->render_target ||
+        impl_->cached_w != extent.width || impl_->cached_h != extent.height) {
+        auto* vkimpl = impl_->vulkan_impl();
+        impl_->render_target = vkimpl->makeRenderTarget(
+            extent.width, extent.height, format,
+            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
+            VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+            VK_IMAGE_USAGE_STORAGE_BIT);
+        impl_->renderer = std::make_unique<rive::RiveRenderer>(
+            impl_->render_context.get());
+        impl_->cached_w = extent.width;
+        impl_->cached_h = extent.height;
+    }
+
+    // Look up the image's last known access state. First sight of an image
+    // (e.g. just-acquired swapchain image) → default-constructed ImageAccess
+    // (UNDEFINED layout, which tells Rive it may clobber the contents).
+    rive::gpu::vkutil::ImageAccess last_access;
+    if (auto it = impl_->image_access.find(target_image);
+        it != impl_->image_access.end()) {
+        last_access = it->second;
+    }
+
+    impl_->render_target->setTargetImageView(target_view,
+                                             target_image,
+                                             last_access);
+
+    // Begin a frame.
+    rive::gpu::RenderContext::FrameDescriptor frame_desc;
+    frame_desc.renderTargetWidth    = extent.width;
+    frame_desc.renderTargetHeight   = extent.height;
+    frame_desc.clearColor           = impl_->options.clear_color;
+    frame_desc.msaaSampleCount      = impl_->options.msaa_sample_count;
+    frame_desc.disableRasterOrdering = impl_->options.force_atomic_mode;
+    impl_->render_context->beginFrame(std::move(frame_desc));
+
+    // Draw the artboard.
+    impl_->renderer->save();
+    impl_->artboard->draw(impl_->renderer.get());
+    impl_->renderer->restore();
+
+    // Flush into the caller's command buffer.
+    rive::gpu::RenderContext::FlushResources flush;
+    flush.renderTarget         = impl_->render_target.get();
+    flush.externalCommandBuffer = cmd;
+    flush.currentFrameNumber    = current_frame_number;
+    flush.safeFrameNumber       = safe_frame_number;
+    impl_->render_context->flush(flush);
+
+    // Rive's flush completes with the target image in some layout that
+    // depends on the rendering path taken (atomic vs raster-ordered, MSAA,
+    // etc.). Read it back and, if the caller requested a different final
+    // layout, emit a single barrier — this is the only place that knows
+    // precisely where Rive left off.
+    rive::gpu::vkutil::ImageAccess after_flush =
+        impl_->render_target->targetLastAccess();
+
+    if (final_layout != VK_IMAGE_LAYOUT_UNDEFINED &&
+        final_layout != after_flush.layout) {
+        VkImageMemoryBarrier b{};
+        b.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        b.oldLayout           = after_flush.layout;
+        b.newLayout           = final_layout;
+        b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.image               = target_image;
+        b.subresourceRange    = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        b.srcAccessMask       = after_flush.accessMask;
+        b.dstAccessMask       = 0;
+        vkCmdPipelineBarrier(cmd,
+                             after_flush.pipelineStages,
+                             VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &b);
+
+        // Record the transition so the next render() that sees this image
+        // reports the correct starting layout back to Rive.
+        impl_->image_access[target_image] = rive::gpu::vkutil::ImageAccess{
+            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+            VK_ACCESS_NONE,
+            final_layout,
+        };
+    } else {
+        impl_->image_access[target_image] = after_flush;
+    }
+    return true;
+#else
+    (void)cmd; (void)target_image; (void)target_view; (void)extent;
+    (void)format; (void)final_layout;
+    (void)current_frame_number; (void)safe_frame_number;
+    return false;
+#endif
+}
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor


### PR DESCRIPTION
## Summary
- Pictor 側に **`pictor::RiveRenderer`** を追加 (PIMPL, public header に Rive 型を露出しない)
- `rive::gpu::RenderContextVulkanImpl` を薄くラップし、.riv の import / state machine 進行 / Vulkan 描画までを 1 本のクラスで提供
- 画像レイアウト追跡は wrapper 内部で自動化 — 呼び出し側は `final_layout=VK_IMAGE_LAYOUT_PRESENT_SRC_KHR` を渡すだけで atomic/raster-ordered/MSAA どのパスでも正しく遷移する
- 公式 .riv を再生する `pictor_rive_demo` を `demo/rive/` に追加
- CMake オプト-イン方式 (`-DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=...`)。OFF 既定では `rive_renderer.cpp` が安全 no-op スタブとしてビルドされ、rive-runtime 未配置でも pictor.lib は完走する

## 使い方
\`\`\`sh
# 1. rive-runtime を別途ビルド (premake5 ベース)
git clone https://github.com/rive-app/rive-runtime
cd rive-runtime/renderer
./build_rive.sh release --with_vulkan
# Windows の場合: build/build_rive.bat release --with_vulkan --toolset=msc --windows_runtime=dynamic_release

# 2. Pictor 側
cd Pictor
cmake -B build -DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=<path/to/rive-runtime>
cmake --build build --config Release --target pictor_rive_demo
./build/Release/pictor_rive_demo <file.riv> [state_machine_index]
\`\`\`

## 構成
- \`include/pictor/vector/rive_renderer.h\` — public API (Rive 依存なし)
- \`src/vector/rive_renderer.cpp\` — 実装 (PIMPL, PICTOR_HAS_RIVE でガード)
- \`cmake/FindRive.cmake\` — 事前ビルドされた rive-runtime の検出。\`renderer/out/<config>/\` / \`out/<config>/\` 両レイアウト対応。RIVE_VULKAN / WITH_RIVE_TEXT / WITH_RIVE_LAYOUT を INTERFACE_COMPILE_DEFINITIONS で伝播
- \`demo/rive/main.cpp\` — GLFW + VulkanContext + RiveRenderer による .riv 再生 (Space: state machine⇔animation, Left/Right: artboard 巡回, Esc: quit)

## Test plan
- [x] \`cmake --build build --config Release --target pictor\` (PICTOR_ENABLE_RIVE=OFF 既定, スタブビルド)
- [x] rive-runtime を \`--with_vulkan --toolset=msc --windows_runtime=dynamic_release\` でビルド
- [x] \`cmake -DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=<path>\` 再configure 成功
- [x] \`pictor_rive_demo.exe\` ビルド成功 (4.3 MB)
- [ ] 公式 .riv 実機再生 (Pictor 実行はユーザ環境で検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)