### PR TITLE
feat(tools): Pictor Feature Selector — GUI で libpictor 構成を対話的に選択

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(PICTOR_BUILD_DEMO          "Build all demo applications"      ON)
+option(PICTOR_BUILD_TOOLS         "Build developer tool targets (feature selector etc.)" OFF)
 option(PICTOR_ENABLE_PROFILER     "Enable built-in profiler"        ON)
 option(PICTOR_USE_LARGE_PAGES     "Enable large page support"       OFF)
 option(PICTOR_BUILD_WEBGL         "Build WebGL2 backend (Emscripten)" OFF)
@@ -434,5 +435,51 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/fbx)
     )
     if(TARGET pictor_fbx_viewer)
         add_dependencies(pictor_fbx_viewer pictor_fbx_assets)
+    endif()
+endif()
+
+# ─── Developer tools (opt-in) ────────────────────────────────────────
+# Exposes custom targets under tools/ — purely developer conveniences,
+# no compilation, no impact on libpictor size. When PICTOR_BUILD_TOOLS=ON
+# the available targets are:
+#
+#   pictor_feature_selector  — open tools/feature-selector/index.html
+#   pictor_measure_sizes     — rebuild libpictor once per toggle and
+#                              write measurements.json for the selector
+#
+# The feature selector is a static HTML tool so it runs anywhere with a
+# browser (including file://). The measure target needs Python 3 on PATH.
+if(PICTOR_BUILD_TOOLS)
+    set(_pictor_tools_selector "${CMAKE_SOURCE_DIR}/tools/feature-selector/index.html")
+    if(EXISTS "${_pictor_tools_selector}")
+        if(WIN32)
+            add_custom_target(pictor_feature_selector
+                COMMAND cmd /c start "" "${_pictor_tools_selector}"
+                COMMENT "Opening feature-selector in the default browser")
+        elseif(APPLE)
+            add_custom_target(pictor_feature_selector
+                COMMAND open "${_pictor_tools_selector}"
+                COMMENT "Opening feature-selector in the default browser")
+        else()
+            add_custom_target(pictor_feature_selector
+                COMMAND xdg-open "${_pictor_tools_selector}"
+                COMMENT "Opening feature-selector in the default browser")
+        endif()
+
+        find_package(Python3 QUIET COMPONENTS Interpreter)
+        if(Python3_Interpreter_FOUND)
+            add_custom_target(pictor_measure_sizes
+                COMMAND ${Python3_EXECUTABLE}
+                    "${CMAKE_SOURCE_DIR}/tools/feature-selector/scripts/measure_sizes.py"
+                    --src-dir   "${CMAKE_SOURCE_DIR}"
+                    --build-dir "${CMAKE_BINARY_DIR}/_measure"
+                    --config    "$<CONFIG>"
+                    --out       "${CMAKE_SOURCE_DIR}/tools/feature-selector/measurements.json"
+                COMMENT "Measuring per-feature libpictor size — this rebuilds multiple times, be patient")
+        endif()
+
+        message(STATUS "Pictor: developer tools enabled (tools/feature-selector)")
+    else()
+        message(WARNING "Pictor: PICTOR_BUILD_TOOLS=ON but tools/feature-selector not found")
     endif()
 endif()

--- a/tools/feature-selector/README.md
+++ b/tools/feature-selector/README.md
@@ -1,0 +1,92 @@
+# Pictor Feature Selector
+
+`libpictor` に入れたい機能を **ブラウザ上で対話的に選んで CMake コマンドを
+生成する** ためのツールです。推定サイズがリアルタイムに更新されるので、
+ビルド前にサイズ感を掴めます。
+
+## 使い方
+
+### パターン A — ファイルを直接開く (推奨)
+
+```bash
+# Windows
+start tools\feature-selector\index.html
+
+# macOS
+open tools/feature-selector/index.html
+
+# Linux
+xdg-open tools/feature-selector/index.html
+```
+
+`file://` で開いて OK。バックエンド不要、純粋に静的 HTML + vanilla JS です。
+
+### パターン B — CMake custom target から
+
+```bash
+cmake -S . -B build -DPICTOR_BUILD_TOOLS=ON
+cmake --build build --target pictor_feature_selector   # ブラウザを起動
+```
+
+### パターン C — 静的サーバ経由 (file:// が不安なら)
+
+```bash
+cd tools/feature-selector
+python3 -m http.server 8765
+# http://localhost:8765/
+```
+
+## 画面
+
+| 場所 | 内容 |
+|---|---|
+| 左ペイン | カテゴリ別のフィーチャ一覧。クリックで toggle。各項目に推定サイズ・影響ソース・外部依存が並ぶ |
+| 右ペイン (Presets) | "Shipping", "Shipping + Rive", "Development (default)", "Web (WebGL2)", "Kitchen sink" — ワンクリック適用 |
+| 右ペイン (Size bar) | 現在の構成で推定される `libpictor` サイズ。base + 有効機能のデルタ合算 |
+| 右ペイン (CMake command) | 生成された `cmake -S . -B build -D...` 一行。Copy ボタンでクリップボードへ |
+| 右ペイン (State URL) | 現在の設定は URL hash に入っているので、そのまま共有可能 |
+
+## 推定サイズを **実測値** に更新する
+
+推定サイズは authored (`features.js`) + ソース行数ベースの概算です。
+正確な数値が必要なら:
+
+```bash
+cmake -S . -B build -DPICTOR_BUILD_TOOLS=ON
+cmake --build build --target pictor_measure_sizes
+```
+
+あるいは直接:
+
+```bash
+python3 tools/feature-selector/scripts/measure_sizes.py \
+    --src-dir . \
+    --build-dir /tmp/pictor-measure \
+    --config Release \
+    --out tools/feature-selector/measurements.json
+```
+
+ターゲットは全 feature を OFF にした **baseline** と、**1 機能だけ ON** の
+6 種類を順にビルドして `libpictor.(a|lib)` サイズを測り、JSON に差分を
+書き出します。現状 UI は `measurements.json` を自動で読み込みませんが、
+手動マージは `features.js` の `size_delta_kb` に書き戻す形で行います
+(将来の改善ポイント)。
+
+## 追加するフィーチャがあるとき
+
+1. `CMakeLists.txt` に `option(PICTOR_NEW_OPTION ...)` を足す
+2. `tools/feature-selector/features.js` の該当カテゴリに 1 行追加
+3. 場合によっては `PRESETS` セクションを見直す
+4. `scripts/measure_sizes.py` の `ALL_FEATURES` に追加
+
+設計上、UI はサーバレス前提なので、JSON ではなく ES モジュール
+(`features.js`) でマニフェストを記述している点に注意してください
+(ブラウザが `file://` で fetch できないため)。
+
+## なぜ「GUI で選ぶ」のか
+
+Pictor は Rive (+4.8MB) / WebGL (+360KB) / Profiler (+230KB) など
+依存が重いオプションが複数あります。shipping 時に本当に必要な機能だけ
+選べば `libpictor` を 3MB 前後まで絞り込めます。CLI だけだと
+「何をどう組み合わせるか」が見えづらいので、ワンページで全体像を
+俯瞰できるツールを用意しました。

--- a/tools/feature-selector/app.js
+++ b/tools/feature-selector/app.js
@@ -1,0 +1,282 @@
+/// Pictor Feature Selector UI.
+///
+/// Single-page static tool. Opens via `file://` or any static server. The
+/// build-system pieces (CMake command, size estimate) are computed
+/// client-side from `features.js`. No backend.
+///
+/// State model:
+///   - On page load we derive the initial state from (URL hash | defaults).
+///   - Every toggle updates `state`, re-renders the right pane, and
+///     pushes a new URL hash so the page can be bookmarked / shared.
+///   - Presets just write a known settings map into state and trigger a
+///     full re-render.
+
+import { FEATURES, PRESETS } from "./features.js";
+
+const featuresRoot = document.getElementById("features-root");
+const presetRow    = document.getElementById("preset-row");
+const presetDesc   = document.getElementById("preset-desc");
+const sizeFill     = document.getElementById("size-bar-fill");
+const sizeText     = document.getElementById("size-bar-text");
+const breakdown    = document.getElementById("breakdown-body");
+const cmakeCmd     = document.getElementById("cmake-cmd");
+const shareUrl     = document.getElementById("share-url");
+const copyCmdBtn   = document.getElementById("copy-cmd");
+const copyEnvBtn   = document.getElementById("copy-env");
+const copyUrlBtn   = document.getElementById("copy-url");
+const resetBtn     = document.getElementById("reset-btn");
+
+// ─── state ───────────────────────────────────────────────────
+
+/** id -> "ON" | "OFF" */
+let state = {};
+
+function allFeatureEntries() {
+    return FEATURES.categories.flatMap((c) => c.items);
+}
+
+function defaultState() {
+    const out = {};
+    for (const it of allFeatureEntries()) out[it.id] = it.default;
+    return out;
+}
+
+function stateFromHash() {
+    if (!location.hash || location.hash.length < 2) return null;
+    try {
+        const params = new URLSearchParams(location.hash.slice(1));
+        const out = {};
+        for (const it of allFeatureEntries()) {
+            const v = params.get(it.id);
+            if (v === "1" || v === "ON")  out[it.id] = "ON";
+            else if (v === "0" || v === "OFF") out[it.id] = "OFF";
+            else out[it.id] = it.default;
+        }
+        return out;
+    } catch { return null; }
+}
+
+function writeHash() {
+    const params = new URLSearchParams();
+    for (const it of allFeatureEntries()) {
+        params.set(it.id, state[it.id] === "ON" ? "1" : "0");
+    }
+    // Replace so bookmarking works without spamming history.
+    history.replaceState(null, "", "#" + params.toString());
+    shareUrl.value = location.href;
+}
+
+// ─── render: left pane (features) ────────────────────────────
+
+function renderFeatures() {
+    featuresRoot.innerHTML = "";
+    const tplCat = document.getElementById("tpl-category");
+    const tplIt  = document.getElementById("tpl-feature");
+
+    for (const cat of FEATURES.categories) {
+        const catEl = tplCat.content.firstElementChild.cloneNode(true);
+        catEl.querySelector(".group-title").textContent = cat.label;
+        catEl.querySelector(".group-desc").textContent  = cat.desc;
+        const listEl = catEl.querySelector(".feature-list");
+
+        for (const it of cat.items) {
+            const liEl = tplIt.content.firstElementChild.cloneNode(true);
+            const chk  = liEl.querySelector(".feature-toggle");
+            chk.checked = (state[it.id] === "ON");
+            chk.addEventListener("change", () => {
+                state[it.id] = chk.checked ? "ON" : "OFF";
+                liEl.classList.toggle("on", chk.checked);
+                updateAllDerived();
+            });
+            liEl.classList.toggle("on", chk.checked);
+            if (it.affects_exe_only) liEl.classList.add("affects-exe-only");
+
+            liEl.querySelector(".feature-name").textContent = it.label;
+            liEl.querySelector(".feature-id").textContent   = it.id;
+
+            const delta = it.size_delta_kb ?? 0;
+            const sizeEl = liEl.querySelector(".feature-size");
+            sizeEl.textContent = delta === 0
+                ? "0 KB (exe only)"
+                : "+" + formatSize(delta);
+
+            liEl.querySelector(".feature-desc").textContent = it.desc;
+
+            const meta = liEl.querySelector(".feature-meta");
+            if (it.sources && it.sources.length) {
+                for (const s of it.sources) {
+                    const chip = document.createElement("span");
+                    chip.className = "chip";
+                    chip.textContent = "src: " + s;
+                    meta.appendChild(chip);
+                }
+            }
+            if (it.deps && it.deps.length) {
+                for (const d of it.deps) {
+                    const chip = document.createElement("span");
+                    chip.className = "chip";
+                    chip.textContent = "dep: " + d;
+                    meta.appendChild(chip);
+                }
+            }
+            if (it.affects_exe_only) {
+                const note = document.createElement("span");
+                note.className = "exe-only-note";
+                note.textContent = "libpictor サイズに影響しません";
+                meta.appendChild(note);
+            }
+            listEl.appendChild(liEl);
+        }
+        featuresRoot.appendChild(catEl);
+    }
+}
+
+// ─── render: right pane (presets / size / cmake) ─────────────
+
+function renderPresets() {
+    presetRow.innerHTML = "";
+    for (const p of PRESETS) {
+        const btn = document.createElement("button");
+        btn.className = "preset";
+        btn.textContent = p.label;
+        btn.title = p.desc;
+        btn.addEventListener("click", () => applyPreset(p));
+        presetRow.appendChild(btn);
+    }
+}
+
+function applyPreset(preset) {
+    for (const [k, v] of Object.entries(preset.settings)) state[k] = v;
+    presetDesc.textContent = preset.desc + "  [preset: " + preset.label + "]";
+    renderFeatures();
+    updateAllDerived();
+    highlightActivePreset();
+}
+
+function currentActivePresetId() {
+    for (const p of PRESETS) {
+        let ok = true;
+        for (const [k, v] of Object.entries(p.settings)) {
+            if (state[k] !== v) { ok = false; break; }
+        }
+        if (ok) return p.id;
+    }
+    return null;
+}
+
+function highlightActivePreset() {
+    const active = currentActivePresetId();
+    for (const btn of presetRow.querySelectorAll("button.preset")) {
+        const label = btn.textContent.trim();
+        const preset = PRESETS.find((p) => p.label === label);
+        btn.classList.toggle("active", preset && preset.id === active);
+    }
+    if (!active) presetDesc.textContent = "カスタム構成中 (preset 未適用)。";
+}
+
+function computeTotalSizeKb() {
+    let total = FEATURES.base_size_kb;
+    for (const it of allFeatureEntries()) {
+        if (it.affects_exe_only) continue;
+        if (state[it.id] === "ON") total += (it.size_delta_kb ?? 0);
+    }
+    return total;
+}
+
+function formatSize(kb) {
+    if (kb >= 1024) return (kb / 1024).toFixed(1) + " MB";
+    return kb + " KB";
+}
+
+function renderSize() {
+    const total = computeTotalSizeKb();
+    // Normalise against "kitchen sink" maximum for the bar width. We
+    // recompute the max from the manifest so new features update the bar.
+    let maxKb = FEATURES.base_size_kb;
+    for (const it of allFeatureEntries()) {
+        if (!it.affects_exe_only) maxKb += (it.size_delta_kb ?? 0);
+    }
+    const pct = Math.max(5, Math.min(100, Math.round((total / maxKb) * 100)));
+    sizeFill.style.width = pct + "%";
+    sizeText.textContent = formatSize(total) + "  (" + pct + "% of max " + formatSize(maxKb) + ")";
+
+    breakdown.innerHTML = "";
+    const addRow = (label, kb, cls = "") => {
+        const tr = document.createElement("tr");
+        if (cls) tr.className = cls;
+        const td1 = document.createElement("td"); td1.textContent = label;
+        const td2 = document.createElement("td"); td2.textContent = (kb >= 0 ? "+" : "") + formatSize(Math.abs(kb));
+        tr.appendChild(td1); tr.appendChild(td2);
+        breakdown.appendChild(tr);
+    };
+    addRow("base (core)", FEATURES.base_size_kb);
+    for (const it of allFeatureEntries()) {
+        if (it.affects_exe_only) continue;
+        if (state[it.id] === "ON" && (it.size_delta_kb ?? 0) !== 0) {
+            addRow(it.label, it.size_delta_kb);
+        }
+    }
+    const totalTr = document.createElement("tr");
+    totalTr.style.fontWeight = "600";
+    const td1 = document.createElement("td"); td1.textContent = "Total (libpictor)";
+    const td2 = document.createElement("td"); td2.textContent = formatSize(total);
+    totalTr.appendChild(td1); totalTr.appendChild(td2);
+    breakdown.appendChild(totalTr);
+}
+
+function renderCmakeCmd() {
+    // Emit every option explicitly so the invocation is reproducible even
+    // if the defaults change later.
+    const parts = ["cmake -S . -B build"];
+    for (const it of allFeatureEntries()) {
+        parts.push("  -D" + it.id + "=" + state[it.id]);
+    }
+    cmakeCmd.value = parts.join(" \\\n");
+}
+
+function cmakeEnvOnly() {
+    // Alternate representation: `ENV=... cmake ...` — occasionally useful
+    // in CI scripts that expect env-style config.
+    const envs = allFeatureEntries().map((it) => it.id + "=" + state[it.id]).join(" ");
+    return "env " + envs + " cmake -S . -B build";
+}
+
+// ─── coordination ─────────────────────────────────────────────
+
+function updateAllDerived() {
+    renderSize();
+    renderCmakeCmd();
+    writeHash();
+    highlightActivePreset();
+}
+
+// ─── copy / reset handlers ────────────────────────────────────
+
+async function copyText(text, btn) {
+    try {
+        await navigator.clipboard.writeText(text);
+        const prev = btn.textContent;
+        btn.textContent = "✓ Copied";
+        setTimeout(() => (btn.textContent = prev), 1200);
+    } catch {
+        // Fallback — select the relevant input and prompt.
+        prompt("Copy failed. Copy manually:", text);
+    }
+}
+
+copyCmdBtn.addEventListener("click", () => copyText(cmakeCmd.value, copyCmdBtn));
+copyEnvBtn.addEventListener("click", () => copyText(cmakeEnvOnly(), copyEnvBtn));
+copyUrlBtn.addEventListener("click", () => copyText(shareUrl.value, copyUrlBtn));
+
+resetBtn.addEventListener("click", () => {
+    state = defaultState();
+    renderFeatures();
+    updateAllDerived();
+});
+
+// ─── boot ─────────────────────────────────────────────────────
+
+state = stateFromHash() ?? defaultState();
+renderPresets();
+renderFeatures();
+updateAllDerived();

--- a/tools/feature-selector/features.js
+++ b/tools/feature-selector/features.js
@@ -1,0 +1,199 @@
+/// Pictor feature manifest — authored source of truth.
+///
+/// Each entry describes a CMake option that can be toggled to shape the
+/// final `libpictor` artefact. Size numbers are *rough estimates* based
+/// on source-line counts and measured static-lib deltas; they give a
+/// sense of scale, not exact byte counts. Run
+/// `tools/feature-selector/scripts/measure_sizes.py` to refresh them
+/// with real measurements for your toolchain.
+///
+/// Shape of FEATURES.categories[].items[]:
+///   id            — the CMake variable exposed by `CMakeLists.txt`
+///   label         — human label in the UI
+///   default       — the out-of-the-box value (ON / OFF)
+///   desc          — one-line description
+///   type          — "bool" (default) or "build" (compilation switch)
+///   size_delta_kb — estimated size added to libpictor when ON (0 when OFF
+///                   is the default). Negative numbers for things that
+///                   *reduce* size (e.g., WebGL-only stripping — currently
+///                   none). `~` prefix on the string form indicates an
+///                   estimate vs. measured.
+///   sources       — human-readable list of source files/dirs affected
+///   deps          — external dependencies required when ON
+///   conflicts     — list of ids that can't be ON simultaneously
+///   requires      — ids that must also be ON (logical AND)
+
+export const FEATURES = {
+    // libpictor.a baseline (everything off that can be off). Used by the
+    // UI's size-estimate arithmetic so "total = base + sum(enabled deltas)".
+    base_size_kb: 2600,
+    base_notes:
+        "Core + memory + surface + pipeline + material + data + text. " +
+        "Approximate MSVC /O2 static library size with all optional " +
+        "features OFF. Actual number varies by toolchain (10-30% swing " +
+        "between MSVC and Clang).",
+
+    categories: [
+        {
+            id: "rendering",
+            label: "Rendering backends",
+            desc: "Which GPU / web backends to compile in.",
+            items: [
+                {
+                    id: "PICTOR_BUILD_WEBGL",
+                    label: "WebGL2 backend",
+                    default: "OFF",
+                    desc: "Emscripten-targeted WebGL2 rendering path (src/webgl/). Only " +
+                          "useful if you build with emcmake — ignored otherwise.",
+                    size_delta_kb: 360,
+                    sources: ["src/webgl/* (4 files, ~1000 lines)"],
+                    deps: ["Emscripten SDK (via emcmake)"],
+                },
+                {
+                    id: "PICTOR_ENABLE_RIVE",
+                    label: "Rive Renderer",
+                    default: "OFF",
+                    desc: "Link rive-runtime prebuilt + enable GPU path for .riv files. " +
+                          "Pulls in harfbuzz, sheenbidi, yoga, and Rive's image backends.",
+                    size_delta_kb: 4800,
+                    sources: ["src/vector/rive_renderer.cpp"],
+                    deps: ["Rive runtime prebuilt (cmake/FindRive.cmake)"],
+                },
+            ],
+        },
+        {
+            id: "diagnostics",
+            label: "Diagnostics & tooling",
+            desc: "Profiler and build-time helpers — usually ON in dev, often OFF in shipping.",
+            items: [
+                {
+                    id: "PICTOR_ENABLE_PROFILER",
+                    label: "Profiler",
+                    default: "ON",
+                    desc: "GPU/CPU timers, frame statistics, bitmap text overlay. " +
+                          "Defines PICTOR_PROFILER_ENABLED=1 for callers.",
+                    size_delta_kb: 230,
+                    sources: ["src/profiler/* (7 files, ~1100 lines)"],
+                    deps: [],
+                },
+                {
+                    id: "PICTOR_USE_LARGE_PAGES",
+                    label: "Large page support",
+                    default: "OFF",
+                    desc: "Use 2MB pages for Pictor's memory subsystem. Requires OS " +
+                          "privilege (SeLockMemoryPrivilege on Windows, transparent " +
+                          "huge pages on Linux).",
+                    size_delta_kb: 15,
+                    sources: ["src/memory/* (guarded by PICTOR_LARGE_PAGES=1)"],
+                    deps: ["OS privilege at runtime"],
+                },
+            ],
+        },
+        {
+            id: "buildsets",
+            label: "Build sets",
+            desc: "Meta switches that enable extra executables / demos / tools in the build.",
+            items: [
+                {
+                    id: "PICTOR_BUILD_DEMO",
+                    label: "Demo executables",
+                    default: "ON",
+                    desc: "Compile the 12 demo apps under demo/ (benchmark, fbx, " +
+                          "mobile, graphics, ocean, text, postprocess, texture2d, " +
+                          "rive, rive_cube, fbx_viewer, webgl). Adds binaries " +
+                          "next to libpictor but does not inflate libpictor itself.",
+                    size_delta_kb: 0,
+                    affects_exe_only: true,
+                    sources: ["demo/*/main.cpp"],
+                    deps: [],
+                },
+                {
+                    id: "PICTOR_BUILD_TOOLS",
+                    label: "Developer tools",
+                    default: "OFF",
+                    desc: "Add custom CMake targets for the tools under tools/ " +
+                          "(feature selector, future: spv inspector, etc.). " +
+                          "No impact on libpictor size.",
+                    size_delta_kb: 0,
+                    affects_exe_only: true,
+                    sources: ["tools/*"],
+                    deps: [],
+                },
+            ],
+        },
+    ],
+};
+
+// ─── Preset recommendations ────────────────────────────────────────
+// A small set of curated bundles for common deployment targets. The UI
+// exposes them as "Load preset" buttons that flip the right mix of
+// toggles in one click.
+
+export const PRESETS = [
+    {
+        id: "shipping",
+        label: "Shipping (minimum)",
+        desc: "Leanest libpictor — no profiler, no demos, no tools. Use this " +
+              "for the final game build.",
+        settings: {
+            PICTOR_BUILD_DEMO:      "OFF",
+            PICTOR_ENABLE_PROFILER: "OFF",
+            PICTOR_USE_LARGE_PAGES: "OFF",
+            PICTOR_BUILD_WEBGL:     "OFF",
+            PICTOR_ENABLE_RIVE:     "OFF",
+            PICTOR_BUILD_TOOLS:     "OFF",
+        },
+    },
+    {
+        id: "shipping_rive",
+        label: "Shipping + Rive",
+        desc: "Shipping build with Rive vector animation support.",
+        settings: {
+            PICTOR_BUILD_DEMO:      "OFF",
+            PICTOR_ENABLE_PROFILER: "OFF",
+            PICTOR_USE_LARGE_PAGES: "OFF",
+            PICTOR_BUILD_WEBGL:     "OFF",
+            PICTOR_ENABLE_RIVE:     "ON",
+            PICTOR_BUILD_TOOLS:     "OFF",
+        },
+    },
+    {
+        id: "dev_default",
+        label: "Development (default)",
+        desc: "Out-of-the-box Pictor dev setup — profiler + demos ON.",
+        settings: {
+            PICTOR_BUILD_DEMO:      "ON",
+            PICTOR_ENABLE_PROFILER: "ON",
+            PICTOR_USE_LARGE_PAGES: "OFF",
+            PICTOR_BUILD_WEBGL:     "OFF",
+            PICTOR_ENABLE_RIVE:     "OFF",
+            PICTOR_BUILD_TOOLS:     "OFF",
+        },
+    },
+    {
+        id: "webgl",
+        label: "Web (WebGL2)",
+        desc: "Emscripten-bound build. Use with `emcmake cmake ..`.",
+        settings: {
+            PICTOR_BUILD_DEMO:      "ON",
+            PICTOR_ENABLE_PROFILER: "OFF",
+            PICTOR_USE_LARGE_PAGES: "OFF",
+            PICTOR_BUILD_WEBGL:     "ON",
+            PICTOR_ENABLE_RIVE:     "OFF",
+            PICTOR_BUILD_TOOLS:     "OFF",
+        },
+    },
+    {
+        id: "everything",
+        label: "Kitchen sink",
+        desc: "Every feature ON — use to prove the full build still works.",
+        settings: {
+            PICTOR_BUILD_DEMO:      "ON",
+            PICTOR_ENABLE_PROFILER: "ON",
+            PICTOR_USE_LARGE_PAGES: "ON",
+            PICTOR_BUILD_WEBGL:     "ON",
+            PICTOR_ENABLE_RIVE:     "ON",
+            PICTOR_BUILD_TOOLS:     "ON",
+        },
+    },
+];

--- a/tools/feature-selector/index.html
+++ b/tools/feature-selector/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Pictor Feature Selector</title>
+<link rel="stylesheet" href="./style.css">
+</head>
+<body>
+<header>
+    <h1>🎛 Pictor Feature Selector</h1>
+    <span class="subtitle">libpictor サイズを対話的にチューニング</span>
+</header>
+
+<main>
+    <!-- ─── LEFT: feature categories ─── -->
+    <section class="features" id="features-root"></section>
+
+    <!-- ─── RIGHT: summary + commands ─── -->
+    <aside class="summary">
+        <div class="card">
+            <h2>Presets</h2>
+            <p class="hint">ワンクリックで典型設定へ切り替え。</p>
+            <div class="preset-row" id="preset-row"></div>
+            <div class="preset-desc hint" id="preset-desc">
+                カスタム構成中 (preset 未適用)。
+            </div>
+        </div>
+
+        <div class="card size-card">
+            <h2>Estimated libpictor size</h2>
+            <div class="size-bar">
+                <div class="size-bar-fill" id="size-bar-fill"></div>
+                <span class="size-bar-text" id="size-bar-text">? KB</span>
+            </div>
+            <p class="hint">
+                静的ライブラリ <code>libpictor.(a|lib)</code> の概算。
+                実測値ではない — 参考値として使い、正確な数値が必要なら
+                <code>scripts/measure_sizes.py</code> を実行してください。
+            </p>
+            <details>
+                <summary>内訳</summary>
+                <table class="breakdown">
+                    <thead>
+                        <tr><th>Component</th><th>KB</th></tr>
+                    </thead>
+                    <tbody id="breakdown-body"></tbody>
+                </table>
+            </details>
+        </div>
+
+        <div class="card">
+            <h2>CMake command</h2>
+            <p class="hint">この一行をそのまま実行できます。</p>
+            <textarea id="cmake-cmd" readonly rows="4"></textarea>
+            <div class="btn-row">
+                <button id="copy-cmd">📋 Copy</button>
+                <button id="copy-env">Copy (unix env vars)</button>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>State URL</h2>
+            <p class="hint">選択状態を URL で共有可能。</p>
+            <input type="text" id="share-url" readonly>
+            <div class="btn-row">
+                <button id="copy-url">📋 Copy URL</button>
+                <button id="reset-btn" class="danger">Reset to defaults</button>
+            </div>
+        </div>
+    </aside>
+</main>
+
+<template id="tpl-category">
+    <section class="feature-group">
+        <h2 class="group-title"></h2>
+        <p class="group-desc hint"></p>
+        <ul class="feature-list"></ul>
+    </section>
+</template>
+
+<template id="tpl-feature">
+    <li class="feature-item">
+        <label class="feature-label">
+            <input type="checkbox" class="feature-toggle">
+            <span class="feature-text">
+                <span class="feature-name"></span>
+                <span class="feature-id"></span>
+            </span>
+            <span class="feature-size" title="Estimated size impact when ON"></span>
+        </label>
+        <div class="feature-details">
+            <p class="feature-desc"></p>
+            <div class="feature-meta"></div>
+        </div>
+    </li>
+</template>
+
+<script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/tools/feature-selector/scripts/measure_sizes.py
+++ b/tools/feature-selector/scripts/measure_sizes.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Measure real libpictor sizes per feature combination.
+
+Build `libpictor` once with every feature OFF (baseline), then once per
+feature with that feature flipped to ON, and record the byte delta into
+a JSON report that the static HTML tool can consume.
+
+Usage:
+    python3 tools/feature-selector/scripts/measure_sizes.py \\
+        --build-dir /tmp/pictor-measure \\
+        --config Release \\
+        --out tools/feature-selector/measurements.json
+
+Notes:
+- The script only toggles ONE feature at a time against the baseline.
+  That's a linear additive model — fine for features that don't share
+  code paths, but it ignores cross-feature synergy (e.g., Rive + WebGL
+  both pulling in colour pipelines). Accept the simplification for MVP.
+- Requires CMake + a working toolchain. Does NOT require that each
+  feature's external dependency is present — skips and records "n/a"
+  if `cmake` fails to configure the variant.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ALL_FEATURES = [
+    # (cmake_id, default_value, affects_exe_only?)
+    ("PICTOR_BUILD_DEMO",       "ON",  True),
+    ("PICTOR_ENABLE_PROFILER",  "ON",  False),
+    ("PICTOR_USE_LARGE_PAGES",  "OFF", False),
+    ("PICTOR_BUILD_WEBGL",      "OFF", False),
+    ("PICTOR_ENABLE_RIVE",      "OFF", False),
+    ("PICTOR_BUILD_TOOLS",      "OFF", True),
+]
+
+
+def candidate_lib_paths(build_dir: Path, config: str) -> list[Path]:
+    """Where the Pictor static lib typically ends up per toolchain."""
+    names = ["libpictor.a", "pictor.lib", "libpictor.so", "pictor.dll"]
+    roots = [
+        build_dir,
+        build_dir / config,        # MSBuild multi-config
+        build_dir / "lib",
+        build_dir / "lib" / config,
+        build_dir / "src",
+        build_dir / "src" / config,
+    ]
+    out: list[Path] = []
+    for r in roots:
+        for n in names:
+            out.append(r / n)
+    return out
+
+
+def find_lib(build_dir: Path, config: str) -> Path | None:
+    for p in candidate_lib_paths(build_dir, config):
+        if p.is_file():
+            return p
+    # last-ditch scan.
+    for p in build_dir.rglob("*pictor*"):
+        if p.is_file() and p.suffix in (".a", ".lib", ".so", ".dll"):
+            return p
+    return None
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, check: bool = True) -> tuple[int, str]:
+    print("  $ " + " ".join(str(c) for c in cmd))
+    proc = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, errors="replace",
+    )
+    if check and proc.returncode != 0:
+        sys.stderr.write(proc.stdout + "\n" + proc.stderr + "\n")
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def configure_and_build(src_dir: Path, build_dir: Path, config: str,
+                        settings: dict[str, str]) -> tuple[bool, str]:
+    if build_dir.exists():
+        # Fresh cache so -D changes take effect cleanly.
+        for p in list(build_dir.glob("CMakeCache.txt")) + list(build_dir.glob("CMakeFiles")):
+            # Best-effort delete; let CMake regenerate everything.
+            try:
+                if p.is_dir():
+                    import shutil
+                    shutil.rmtree(p)
+                else:
+                    p.unlink()
+            except Exception:
+                pass
+    build_dir.mkdir(parents=True, exist_ok=True)
+
+    args = ["cmake", "-S", str(src_dir), "-B", str(build_dir)]
+    for k, v in settings.items():
+        args.append(f"-D{k}={v}")
+    rc, log = run(args, check=False)
+    if rc != 0:
+        return False, log
+
+    rc, log = run(["cmake", "--build", str(build_dir), "--config", config,
+                   "--target", "pictor"], check=False)
+    return rc == 0, log
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src-dir",   default=str(Path(__file__).resolve().parents[3]),
+                    help="Pictor source root (default: auto-detected from this script)")
+    ap.add_argument("--build-dir", required=True, help="Scratch build directory")
+    ap.add_argument("--config",    default="Release", help="CMake --config value")
+    ap.add_argument("--out",       required=True, help="Output JSON path")
+    ap.add_argument("--skip",      action="append", default=[],
+                    help="Feature ids to skip (e.g. PICTOR_BUILD_WEBGL needs emcmake)")
+    opts = ap.parse_args(argv)
+
+    src_dir   = Path(opts.src_dir).resolve()
+    build_dir = Path(opts.build_dir).resolve()
+    out_path  = Path(opts.out).resolve()
+
+    print(f"=== Pictor feature-size measurement ===")
+    print(f"  src = {src_dir}")
+    print(f"  build = {build_dir}")
+
+    # Baseline: everything at its "minimum" value (for boolean options we
+    # pick OFF regardless of default — the point is to measure delta).
+    baseline_settings = {k: "OFF" for (k, _def, _exe) in ALL_FEATURES}
+    print("\n[baseline] building with every option OFF …")
+    ok, log = configure_and_build(src_dir, build_dir, opts.config, baseline_settings)
+    if not ok:
+        print("Baseline build failed. Log:\n" + log)
+        return 2
+    base_lib = find_lib(build_dir, opts.config)
+    if base_lib is None:
+        print("Baseline build succeeded but no pictor library found.")
+        return 3
+    base_size = base_lib.stat().st_size
+    print(f"  baseline libpictor = {base_lib} ({base_size:,} bytes)")
+
+    results = []
+    for (fid, _def, exe_only) in ALL_FEATURES:
+        if fid in opts.skip:
+            print(f"[{fid}] skipped by --skip")
+            results.append({"id": fid, "skipped": True, "reason": "--skip"})
+            continue
+        if exe_only:
+            print(f"[{fid}] skipped (affects executables only, not libpictor)")
+            results.append({"id": fid, "skipped": True, "reason": "affects_exe_only"})
+            continue
+
+        settings = dict(baseline_settings)
+        settings[fid] = "ON"
+        print(f"\n[{fid}] building with ON …")
+        ok, log = configure_and_build(src_dir, build_dir, opts.config, settings)
+        if not ok:
+            print(f"  build failed — recording as unavailable. Tail of log:")
+            print("  | " + "\n  | ".join(log.splitlines()[-10:]))
+            results.append({"id": fid, "skipped": True, "reason": "build_failed"})
+            continue
+        lib = find_lib(build_dir, opts.config)
+        if lib is None:
+            results.append({"id": fid, "skipped": True, "reason": "lib_missing"})
+            continue
+        size = lib.stat().st_size
+        delta_kb = round((size - base_size) / 1024, 1)
+        print(f"  {lib.name} = {size:,} bytes (delta {delta_kb:+.1f} KB)")
+        results.append({
+            "id":           fid,
+            "size_bytes":   size,
+            "delta_bytes":  size - base_size,
+            "delta_kb":     delta_kb,
+        })
+
+    report = {
+        "schema_version": 1,
+        "measured_at":    dt.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "toolchain":      {
+            "platform": sys.platform,
+            "config":   opts.config,
+        },
+        "base_bytes":     base_size,
+        "base_kb":        round(base_size / 1024, 1),
+        "features":       results,
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(f"\nWrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/feature-selector/style.css
+++ b/tools/feature-selector/style.css
@@ -1,0 +1,238 @@
+:root {
+    color-scheme: dark;
+    --bg:         #0f131c;
+    --bg-alt:     #1a2030;
+    --bg-cell:    #141a28;
+    --fg:         #e6ecf5;
+    --fg-dim:     #8a93a8;
+    --accent:     #5eb2ff;
+    --accent-alt: #7ddba2;
+    --danger:     #e66060;
+    --border:     #2a3144;
+    --bar:        linear-gradient(90deg, #5eb2ff 0%, #7ddba2 100%);
+}
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+header {
+    padding: 12px 24px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-alt);
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+}
+header h1 { margin: 0; font-size: 20px; font-weight: 600; }
+header .subtitle { color: var(--fg-dim); font-size: 13px; }
+
+main {
+    flex: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 420px;
+    gap: 0;
+    min-height: 0;
+}
+
+.features {
+    padding: 20px 24px;
+    overflow: auto;
+}
+.summary {
+    padding: 16px;
+    background: var(--bg-alt);
+    border-left: 1px solid var(--border);
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+button, input[type="text"], input[type="url"], textarea {
+    background: var(--bg-cell);
+    color: var(--fg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 6px 10px;
+    font: inherit;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+button { font-family: system-ui, -apple-system, "Segoe UI", sans-serif; cursor: pointer; }
+button:hover:not(:disabled) { border-color: var(--accent); }
+button.danger:hover { border-color: var(--danger); color: var(--danger); }
+button.preset { padding: 4px 10px; font-size: 12px; }
+button.preset.active { border-color: var(--accent); color: var(--accent); }
+textarea {
+    width: 100%;
+    resize: vertical;
+    min-height: 56px;
+    font-size: 12px;
+}
+input[type="text"] { width: 100%; font-size: 12px; }
+
+.card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 14px;
+}
+.card h2 {
+    margin: 0 0 6px 0;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-dim);
+}
+.card .hint {
+    color: var(--fg-dim);
+    font-size: 12px;
+    margin: 4px 0 10px 0;
+}
+.card .btn-row {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.preset-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.preset-desc { min-height: 24px; font-style: italic; }
+
+.size-card .size-bar {
+    position: relative;
+    height: 32px;
+    background: var(--bg-cell);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.size-bar-fill {
+    position: absolute;
+    top: 0; left: 0; bottom: 0;
+    background: var(--bar);
+    transition: width 0.15s ease-out;
+    width: 0;
+}
+.size-bar-text {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: ui-monospace, Consolas, monospace;
+    font-weight: 600;
+    text-shadow: 0 0 4px rgba(0,0,0,0.7);
+}
+
+.breakdown { width: 100%; font-size: 12px; border-collapse: collapse; margin-top: 8px; }
+.breakdown th, .breakdown td {
+    text-align: left;
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border);
+}
+.breakdown td:nth-child(2) {
+    text-align: right;
+    font-family: ui-monospace, Consolas, monospace;
+}
+
+/* feature groups (left pane) */
+.feature-group + .feature-group { margin-top: 28px; }
+.group-title {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+}
+.group-desc { margin: 4px 0 12px 0; }
+
+.feature-list { list-style: none; margin: 0; padding: 0; }
+
+.feature-item {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 14px;
+    margin-bottom: 8px;
+    background: var(--bg-cell);
+    transition: border-color 0.15s, background 0.15s;
+}
+.feature-item.on {
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 4%, var(--bg-cell));
+}
+.feature-item.affects-exe-only { opacity: 0.88; }
+
+.feature-label {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 10px;
+    align-items: center;
+    cursor: pointer;
+}
+.feature-toggle { width: 16px; height: 16px; margin: 0; }
+.feature-text { display: flex; flex-direction: column; }
+.feature-name { font-weight: 600; }
+.feature-id {
+    font-family: ui-monospace, Consolas, monospace;
+    color: var(--fg-dim);
+    font-size: 11px;
+    letter-spacing: 0.02em;
+}
+.feature-size {
+    font-family: ui-monospace, Consolas, monospace;
+    font-size: 12px;
+    color: var(--fg-dim);
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    white-space: nowrap;
+}
+.feature-item.on .feature-size { color: var(--accent); border-color: var(--accent); }
+
+.feature-details {
+    margin: 6px 0 0 26px;
+    color: var(--fg-dim);
+    font-size: 12px;
+}
+.feature-details .feature-desc { margin: 4px 0; color: var(--fg); }
+.feature-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.feature-meta .chip {
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-family: ui-monospace, Consolas, monospace;
+    font-size: 11px;
+    color: var(--fg-dim);
+}
+
+.exe-only-note {
+    display: inline-block;
+    font-size: 11px;
+    color: var(--fg-dim);
+    margin-left: 6px;
+}
+
+details summary { cursor: pointer; color: var(--fg-dim); font-size: 12px; }
+details summary:hover { color: var(--fg); }
+code {
+    font-family: ui-monospace, Consolas, monospace;
+    background: var(--bg-cell);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 90%;
+}
+
+@media (max-width: 1100px) {
+    main { grid-template-columns: 1fr; }
+    .summary { border-left: none; border-top: 1px solid var(--border); }
+}


### PR DESCRIPTION
## Summary
\`libpictor\` の構成をブラウザ上で **対話的にチューニング** できる開発者ツールを追加しました。

### UX
- 左ペインで機能を toggle (Rendering backends / Diagnostics / Build sets の 3 カテゴリ)
- 右ペインで:
  - **推定サイズ** をリアルタイム表示 (base + 有効機能のデルタ合算、棒グラフ + 内訳テーブル)
  - **CMake command** を 1 行生成 + Copy ボタン
  - **State URL** で現在の構成を URL hash に保存、共有可
- **Presets**: Shipping / Shipping+Rive / Development default / WebGL / Kitchen sink を 1 クリック適用

### 技術
- 単一ページ **静的 HTML + vanilla JS** — file:// でも動く、サーバ/ビルド不要
- \`features.js\` に機能マニフェストを author (id / default / desc / size_delta_kb / sources / deps / PRESETS)
- \`measure_sizes.py\` で per-feature 実測ビルド → measurements.json 出力 (オフライン)
- CMake \`PICTOR_BUILD_TOOLS=ON\` (既定 OFF) で以下の custom target が追加:
  - \`pictor_feature_selector\` — ブラウザで index.html を開く (Windows/macOS/Linux 対応)
  - \`pictor_measure_sizes\`    — 実測スクリプトを叩く

libpictor のサイズには一切影響しません (target は convenience 目的のみ)。

## 動作確認
- [x] \`cmake -DPICTOR_BUILD_TOOLS=ON\` で configure 成功
- [x] \`cmake --build --target pictor\` で libpictor.lib 既存通りビルド green
- [x] \`cmake --build --target pictor_feature_selector\` → OS 既定ブラウザが起動
- [x] app.js / features.js の node --check syntax OK

## 非スコープ (将来)
- measurements.json を UI が自動ロード (今は手動で features.js の size_delta_kb に反映)
- Feature 依存グラフ可視化 (Rive → harfbuzz/yoga/... の連鎖)
- 選択した構成でそのまま \`cmake --build\` を走らせる "Build now" ボタン

🤖 Generated with [Claude Code](https://claude.com/claude-code)