### PR TITLE
docs: デイリーレビュー結果を追加

### DIFF
--- a/review/2026-05-13/AUTOFIX.md
+++ b/review/2026-05-13/AUTOFIX.md
@@ -1,0 +1,19 @@
+# AUTOFIX.md — Pictor (2026-05-13)
+
+本セッションは review-only。ソースコード修正は行わない。下記は将来的な自動修正候補の列挙のみ。
+
+**autofix_count = 0**
+
+## 自動修正候補 (列挙のみ)
+
+1. `src/core/pictor_renderer.cpp:65-117` のステップ番号コメントのリナンバ (`// 11.` 重複の解消)。
+2. `src/animation/rive_animation.h` の class / public 関数に `[[deprecated("Use pictor::RiveRenderer in <pictor/vector/rive_renderer.h>")]]` 付与。 (REVIEW_IMPLEMENTATION I1 / REVIEW_QUALITY Q7)
+3. `.github/workflows/ci.yml` 新規追加 — `cmake -B build -DPICTOR_BUILD_DEMO=OFF -DPICTOR_BUILD_TESTS=ON && cmake --build build && ctest --test-dir build --output-on-failure` を Ubuntu + Windows matrix で実行。 (REVIEW_MISSING M1)
+4. `CLAUDE.md` 新規追加 — 「上位ライブラリ非依存」「Rive 統合は cmake/FindRive.cmake が単一情報源」「Debug 実行が既定 (feedback_pictor_debug_default.md)」「exe 起動は user 側 (feedback_pictor_no_run.md)」を記載。 (REVIEW_MISSING M2)
+5. `plan.md` → `DESIGN.md` リネーム + README からの参照更新。 (REVIEW_MISSING M2)
+6. `src/vector/rive_renderer.cpp:148-158` の `shutdown()` 内で `impl_->image_access.clear()` 追加 + render target 再作成時 (`:302-314`) にも clear。 (REVIEW_IMPLEMENTATION I3)
+7. `src/vector/rive_renderer.cpp:162-178` `load_riv_file` に `MAX_RIV_BYTES` (例 64 MiB) の上限チェック追加。 同様に `src/animation/rive_animation.cpp:25-42`。 (REVIEW_VULNERABILITY V1)
+8. `include/pictor/vector/rive_renderer.h` に `enum class RiveError` + `RiveError last_error() const` を追加し、 `fprintf(stderr, ...)` 由来の診断を構造化する。 (REVIEW_DESIGN D8 / REVIEW_QUALITY Q6)
+9. `include/pictor/surface/vulkan_context.h` (要確認) に `const std::vector<VkImage>& swapchain_images() const` 追加 → `demo/rive/main.cpp:178-188` の毎フレーム `vkGetSwapchainImagesKHR` 2 回呼びを削除。 (REVIEW_IMPLEMENTATION I2)
+
+いずれもソース修正を伴うため、 別 PR / 別セッションで実施する。

--- a/review/2026-05-13/REVIEW.md
+++ b/review/2026-05-13/REVIEW.md
@@ -1,0 +1,46 @@
+# Pictor レビューサマリー (2026-05-13)
+
+- 対象: E:/Document/Ars/Pictor (HEAD = 23529e6, 272 ファイル)
+- 役割: LUDIARS 下層描画ライブラリ (Vulkan + 任意 Rive Renderer + WebGL2)。上位ライブラリに依存しない。
+- レビュー観点: 設計 / 脆弱性 / 実装 / 不足機能 / 品質
+
+## 総合評価
+
+| 観点 | 評価 |
+|------|------|
+| Design (設計) | **A-** |
+| Vulnerability (脆弱性) | **B+** |
+| Implementation (実装) | **B+** |
+| Missing Features (不足) | **B** |
+| Quality (品質) | **B+** |
+
+**Weighted score: 84 / 100**  (Design 0.25 / Vulnerability 0.20 / Implementation 0.25 / Missing 0.15 / Quality 0.15)
+
+## 主要所見
+
+- 「Pictor は上位ライブラリに依存しない」原則は遵守されている (`memoria` / `actio` / `ergo` / `ergo_custos` / `adventurecube` などへの参照 0、検出語は無関係なコメントのみ)。`demo/rive/main.cpp` も Pictor + GLFW + Vulkan のみで構成され、上位レイヤへの依存はない。
+- Rive Renderer 統合 (`PICTOR_ENABLE_RIVE` / `PICTOR_RIVE_DIR`) は `cmake/FindRive.cmake:32-153` と `src/vector/rive_renderer.cpp:1-396` で完結。PICTOR_HAS_RIVE 未定義時は安全な no-op stub になり、下流が無条件に依存できる設計は良好 (`include/pictor/vector/rive_renderer.h:27-34`)。
+- 一方で `src/animation/rive_animation.cpp:7-176` は旧プレースホルダ実装が残存し、`RiveRenderer` (新) と `RiveAnimation` (旧 stub) が混在。後者は実際に Rive ランタイムを使っていないのに公開 API として残っており、利用者を誤誘導するリスク。
+- 脆弱性は致命的なものなし。ファイル I/O (`load_riv_file` / FBX) でサイズ上限・パストラバーサルチェック未実装、外部 .riv の信頼境界が未定義。
+- 不足: CI ビルドワークフロー (`.github/workflows/` は Claude review のみで、build/test を回す GHA がない)。`CLAUDE.md` / `DESIGN.md` が無く `plan.md` が事実上の DESIGN を兼ねる。
+
+## 件数
+
+- 指摘合計: 19 件
+  - Design: 4
+  - Vulnerability: 4
+  - Implementation: 5
+  - Missing: 3
+  - Quality: 3
+- AUTOFIX 自動修正候補: 0 件 (本レビューでは列挙のみ)
+
+## 出力ファイル
+
+- REVIEW.md (本ファイル)
+- REVIEW_DESIGN.md
+- REVIEW_VULNERABILITY.md
+- REVIEW_IMPLEMENTATION.md
+- REVIEW_MISSING_FEATURES.md
+- REVIEW_QUALITY.md
+- AUTOFIX.md
+- latest.json

--- a/review/2026-05-13/REVIEW_DESIGN.md
+++ b/review/2026-05-13/REVIEW_DESIGN.md
@@ -1,0 +1,16 @@
+# REVIEW_DESIGN.md — Pictor (2026-05-13)
+
+評価: **A-**
+## 良い点
+
+- D1. 3 層 SoA パイプライン (`plan.md:45-79`) を `PictorRenderer` (`src/core/pictor_renderer.cpp:12-235`) で実現。
+- D2. Rive 境界良好。header の「Rive 型 public 非露出」明示 + `#ifdef PICTOR_HAS_RIVE` + Pimpl。
+- D3. `cmake/FindRive.cmake:42-77` が premake 名揺れと出力レイアウト 2 系統に両対応。
+- D4. 上位非依存遵守。272 ファイル走査で ergo / adventurecube / synergos / memoria / cernere / actio / excubitor 参照 0。
+
+## 懸念
+
+- D5. Rive 二重実装 (中)。`rive_animation.cpp:7-176` は Default placeholder、`rive_renderer.cpp` 本実装と並存。前者を deprecate。
+- D6. `plan.md` (817 行) が DESIGN を兼ね、LUDIARS 標準 `DESIGN.md + spec/` から外れる。
+- D7. demo `add_executable` 16 個が `CMakeLists.txt:199-288` 直書き。`add_pictor_demo()` 関数化推奨。
+- D8. `PICTOR_HAS_RIVE` 未定義時 fallback が「静かに false」(`:111-179`)。`last_error()` API 推奨。

--- a/review/2026-05-13/REVIEW_IMPLEMENTATION.md
+++ b/review/2026-05-13/REVIEW_IMPLEMENTATION.md
@@ -1,0 +1,17 @@
+# REVIEW_IMPLEMENTATION.md — Pictor (2026-05-13)
+
+評価: **B+**
+
+74 cpp + 84 header で広範囲カバー。placeholder と本実装の同居が課題。
+
+## 指摘
+
+- I1. Rive 二重実装 (中)。`rive_animation.cpp:50-175` は Default artboard + `memset 0` の stub。deprecate or 削除。
+- I2. demo 側 swapchain 解決 (低)。`demo/rive/main.cpp:178-188` が毎フレーム `vkGetSwapchainImagesKHR` 2 回呼出。`VulkanContext::swapchain_images()` で 1 行化。
+- I3. `image_access` map TTL なし (低)。`rive_renderer.cpp:64 / 320 / 378-385` が recreate 後の旧ハンドルを保持。`shutdown()` / RT 再作成時に `clear()`。
+- I4. ステップ番号重複 (低)。`pictor_renderer.cpp:65 / :68` の `// 11.` 同番号で以降ズレ。
+- I5. `final_layout` センチネル (低)。`:359-360` の `UNDEFINED = 省略` は header 明示済だが、fence/semaphore 責務も追記したい。
+
+## 良い点
+
+- CMake オプション 7 軸で粒度分離、`FindRive.cmake:108-115` の自己解決メッセージ、headless demo + CTest (`tests/CMakeLists.txt:11-37`) で CI smoke run 適合。

--- a/review/2026-05-13/REVIEW_MISSING_FEATURES.md
+++ b/review/2026-05-13/REVIEW_MISSING_FEATURES.md
@@ -1,0 +1,16 @@
+# REVIEW_MISSING_FEATURES.md — Pictor (2026-05-13)
+
+評価: **B**
+
+主要機能は揃うが、運用支援と LUDIARS 共通構成にギャップ。
+
+## 不足
+
+- M1. CI build/test 不在 (中)。`.github/workflows/` は Claude review のみ。`tests/` の 5 CTest を回す GHA を追加すべき。
+- M2. CLAUDE.md / DESIGN.md / spec/ 不在 (中)。`plan.md` → `DESIGN.md` リネーム + `CLAUDE.md` 新設 (上位非依存 / Rive 単一情報源 / Debug 既定) を推奨。
+- M3. Rive smoke test 不在 (低)。minimal .riv 未同梱で `PICTOR_ENABLE_RIVE=ON` の load→render→shutdown を CI 検証できない。
+
+## 観察
+
+- `docs/android-build.md` は plan 止まり、Android toolchain 分岐未実装。
+- `tools/feature-selector` は `PICTOR_BUILD_TOOLS=OFF` 既定で影響軽微。

--- a/review/2026-05-13/REVIEW_QUALITY.md
+++ b/review/2026-05-13/REVIEW_QUALITY.md
@@ -1,0 +1,18 @@
+# REVIEW_QUALITY.md — Pictor (2026-05-13)
+
+評価: **B+**
+
+C++20 + AVX2 + Vulkan。MSVC `/W4` + GCC/Clang `-Wall -Wextra` 有効 (`CMakeLists.txt:189-193`)。
+
+## 良い点
+
+- Q1. ヘッダ doc 豊富 (`rive_renderer.h:15-33` / `pictor_renderer.cpp:15-117`)。
+- Q2. `FindRive.cmake:37-55` の lib_dir 探索や config 既定補完が現実的。
+- Q3. demo の Vulkan / headless ガードで CI 適応度高。
+- Q4. test 命名 (`unit_* / pixel_* / fps_*`) で層が一目瞭然。
+
+## 指摘
+
+- Q5. コメント番号不整合 (低)。`src/core/pictor_renderer.cpp:65 / :68` の `// 11.` 重複で以降ズレ。
+- Q6. `fprintf(stderr, ...)` 散在 (低)。`src/vector/rive_renderer.cpp:112-197` 等。`set_log_handler` callback 推奨。
+- Q7. placeholder 存続コスト (中, I1 関連)。`rive_animation.cpp` は silent-success stub。deprecate 推奨。

--- a/review/2026-05-13/REVIEW_VULNERABILITY.md
+++ b/review/2026-05-13/REVIEW_VULNERABILITY.md
@@ -1,0 +1,16 @@
+# REVIEW_VULNERABILITY.md — Pictor (2026-05-13)
+
+評価: **B+**
+
+ネット・認証なしで攻撃面は小さい。致命的脆弱性なし。
+
+## 指摘
+
+- V1. ファイルサイズ上限なし (低〜中)。`src/vector/rive_renderer.cpp:162-178` の `load_riv_file` が `tellg()` サイズで無制限確保 → OOM。`src/animation/rive_animation.cpp:25-42` も同様。`MAX_RIV_BYTES` 推奨。
+- V2. パストラバーサル契約未定義 (低)。`load_*_file(path)` 系が生 OS パスを `std::ifstream` に渡す。呼出元信頼前提を README に明記すべき。
+- V3. Rive 入力検証を全面委任 (低)。`rive::File::import` (`src/vector/rive_renderer.cpp:190-199`) に raw bytes 直流し。`PICTOR_RIVE_DIR` の commit SHA pin を README 明示推奨。
+- V4. CI build/test 不在 (中)。`tests/` に 5 CTest あるが PR で回す GHA がない。
+
+## 良い点
+
+- 機微情報なし、ネット I/O なし。`PICTOR_HAS_RIVE` 未定義時 no-op (`:111-115`)。Pimpl + `#ifdef` で Rive シンボル非漏出。

--- a/review/2026-05-13/latest.json
+++ b/review/2026-05-13/latest.json
@@ -1,0 +1,66 @@
+{
+  "repo": "LUDIARS/Pictor",
+  "short_code": "Pc",
+  "review_date": "2026-05-13",
+  "reviewer": "claude-opus-4-7 (ludiars-review)",
+  "commit": "23529e6",
+  "tracked_files": 272,
+  "weighted_score": 84,
+  "grades": {
+    "design": "A-",
+    "vulnerability": "B+",
+    "implementation": "B+",
+    "missing_features": "B",
+    "quality": "B+"
+  },
+  "weights": {
+    "design": 0.25,
+    "vulnerability": 0.20,
+    "implementation": 0.25,
+    "missing_features": 0.15,
+    "quality": 0.15
+  },
+  "findings": {
+    "design": 4,
+    "vulnerability": 4,
+    "implementation": 5,
+    "missing_features": 3,
+    "quality": 3,
+    "total": 19
+  },
+  "autofix_count": 0,
+  "autofix_candidates": 9,
+  "upper_layer_dependency_check": {
+    "policy": "Pictor must not depend on upper layers (Ergo / AC / ergo_custos / Synergos / Memoria / Cernere / Actio / Excubitor / AdventureCube)",
+    "result": "pass",
+    "notes": "Full-text scan for upper-layer module names returned 0 source-level dependencies. Matches were unrelated English words (action, interaction, fraction, etc.). demo/rive/main.cpp depends only on pictor/* + GLFW + vulkan.h."
+  },
+  "rive_integration_check": {
+    "build_flag": "PICTOR_ENABLE_RIVE",
+    "path_var": "PICTOR_RIVE_DIR",
+    "config_var": "PICTOR_RIVE_CONFIG",
+    "find_module": "cmake/FindRive.cmake",
+    "wrapper_header": "include/pictor/vector/rive_renderer.h",
+    "wrapper_impl": "src/vector/rive_renderer.cpp",
+    "demo": "demo/rive/main.cpp",
+    "no_op_stub_when_disabled": true,
+    "duplicate_legacy_stub": "src/animation/rive_animation.cpp (placeholder, should be deprecated)"
+  },
+  "files": [
+    "REVIEW.md",
+    "REVIEW_DESIGN.md",
+    "REVIEW_VULNERABILITY.md",
+    "REVIEW_IMPLEMENTATION.md",
+    "REVIEW_MISSING_FEATURES.md",
+    "REVIEW_QUALITY.md",
+    "AUTOFIX.md",
+    "latest.json"
+  ],
+  "key_findings": [
+    "Upper-layer non-dependency policy is upheld (0 cross-repo references).",
+    "Rive Renderer integration is well-isolated via Pimpl + #ifdef PICTOR_HAS_RIVE; no Rive symbols leak into public headers.",
+    "Legacy src/animation/rive_animation.cpp is a placeholder that silently succeeds — should be deprecated or removed now that src/vector/rive_renderer.cpp is the real integration.",
+    "No build/test CI workflow despite 5 CTest targets being ready under tests/.",
+    "Repo lacks CLAUDE.md / DESIGN.md / spec/ that other LUDIARS repos standardize on; plan.md doubles as DESIGN."
+  ]
+}

--- a/review/2026-05-15/AUTOFIX.md
+++ b/review/2026-05-15/AUTOFIX.md
@@ -1,0 +1,24 @@
+# AUTOFIX.md
+
+## 概要
+- 修正ファイル数: 0
+- 変更行数: +0 / -0
+- カテゴリ別件数: lint=0 / typo=0 / unused_import=0 / dead_code=0 / gitignore=0 / toc=0
+- 関連 PR: なし
+
+## 修正対象なし
+
+旧 frame work (bloom_effect.cpp 等) は git diff 確認の上完全削除済。残置のヘッダ shim も post-process refactor 設計 §3.1 で scheduled removal。本日のレビュー範囲では自動修正可能な確実指摘なし。
+
+## フラグしたが手作業に回した指摘 (= 自動修正の範囲外)
+
+- `src/postprocess/postprocess_pipeline.cpp:52-64`, `src/decal/decal_system.cpp:95` — `find_memory_type_()` 失敗時の `UINT32_MAX` 返却を `std::optional<uint32_t>` 等に変更。挙動変更を伴う (REVIEW_IMPLEMENTATION.md §1)
+- tests/CMakeLists.txt — `DecalSystem` / `PostProcessPipeline` 統合テスト追加 (REVIEW_QUALITY.md §1)
+- .github/workflows/build.yml — CI matrix (Windows/macOS/Linux/Android) 追加 (REVIEW_QUALITY.md §4)
+- Structured logging migration (`fprintf(stderr)` → JSON log) — REVIEW_IMPLEMENTATION.md §3 / REVIEW_MISSING_FEATURES.md
+- README.md TOC 追加 — 記述スタイル変更のため auto-fix 対象外
+- `*.pdb` を .gitignore に追加 — Debug/Release dirs で既に ignored、影響軽微
+
+## 関連
+- レビュー全文: REVIEW.md / REVIEW_*.md
+- 修正 PR diff: なし

--- a/review/2026-05-15/REVIEW.md
+++ b/review/2026-05-15/REVIEW.md
@@ -1,0 +1,71 @@
+# AI Code Review — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (HEAD: b98cd9f) |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD (9 commits since 2026-05-13) |
+| 総変更行数 | 3,029 insertions / 982 deletions (40 files changed) |
+
+---
+
+## 総合評価 (Overall Assessment)
+
+| # | レビュー観点 | 評価 | 重大指摘数 | ドキュメント |
+|---|------------|------|-----------|------------|
+| 1 | 脆弱性 | A | 0 | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 2 | 設計強度 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 3 | 設計思想の一貫性 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 4 | モジュール分割度 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 5 | コード品質 | B | 2 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 6 | データスキーマ | A | 0 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 9 | SRE | B | 1 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 10 | ゼロトラスト | N/A | - | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 11 | セキュリティ | A | 0 | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 12 | テスト戦略・カバレッジ | C | 1 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 13 | パフォーマンス・ベンチマーク | B | 1 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 14 | ライセンス遵守 | A | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 15 | クロスプラットフォーム互換 | B | 2 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 16 | ドキュメント完備性 | A | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+
+---
+
+## 重大指摘サマリー
+
+**Critical / High:**
+- `src/postprocess/postprocess_pipeline.cpp:224` — エラーハンドリング: `find_memory_type_()` が `UINT32_MAX` 返却時の処理が不十分
+- `src/postprocess/postprocess_pipeline.cpp:634` — デカールシステム統合時の深度フォーマット検証が限定的
+
+**Medium (改善推奨):**
+- テスト: デカール・ポストプロセス統合テストが欠落
+- パフォーマンス: リアルタイムプロファイリングの文書化が不足
+
+---
+
+## 総合所見
+
+**強み:**
+- 設計が明確で段階的 (P1/P2/P3 で機能を分割)
+- Vulkan 品質が高い (エラーコード・メモリプロパティ検証・フォーマット確認)
+- ドキュメントが充実 (設計書・実装段階を詳細に記載)
+- MIT ライセンスで著作権が明確。CI/CD が 3 本の GitHub Actions workflow で構成
+
+**改善点:**
+- 統合テストの欠落 (decal + postprocess の相互作用テストなし)
+- エラー伝播が printf/stderr 依存で、構造化ログなし
+- Android NDK 対応計画は詳細だが **実装は Phase 1 の CMake 改修まで未着手**
+- 性能リグレッション検知の仕組みなし
+
+**リスク:**
+- メモリリーク防止に `shutdown()` の呼び出しが重要だが、自動管理 (RAII) が限定的
+- デカール 64 個上限のハードコード (拡張性に制限)
+
+---
+
+## 次ステップ
+
+1. **即時**: `find_memory_type_()` の `UINT32_MAX` 検証を強化、error logging を構造化
+2. **1 sprint**: decal + postprocess 統合テスト (headless unit test)
+3. **1 sprint**: Android NDK Phase 1 (CMake ブロック追加)
+4. **中期**: パフォーマンスベンチマーク (decal 描画コスト測定)

--- a/review/2026-05-15/REVIEW_DESIGN.md
+++ b/review/2026-05-15/REVIEW_DESIGN.md
@@ -1,0 +1,52 @@
+# 設計レビュー (Design Review) — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD |
+
+---
+
+## 1. 設計強度 (Design Robustness)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | 障害分離 | シーン描画・ポストプロセス・デカール が render pass で明確に分離 |
+| A | 冪等性 | `initialize_vulkan()` → `shutdown()` → `initialize()` の往復が安全 |
+| B | 入力バリデーション | HDR フォーマット対応確認済み、`DecalSystem::add()` の range check 欠落 |
+| A | エラーハンドリング | 各初期化段階で bool / VkResult 確認、失敗時は stderr 出力 |
+| B | リトライ・タイムアウト設計 | Vulkan コマンドのタイムアウトはホスト責務 |
+| A | 状態管理の明確性 | `is_initialized()` で初期化済みを確認可能 |
+
+---
+
+## 2. 設計思想の一貫性 (Design Philosophy Compliance)
+
+| 該当箇所 | 逸脱内容 | 本来の設計思想 | 推奨修正 |
+|----------|---------|--------------|---------|
+| `src/postprocess/postprocess_pipeline.cpp:61-63` | HDR フォーマット失敗を silent IDENTITY に | フォーマット検証は initialize_vulkan 時に全実施 | 現行で OK |
+| `src/decal/decal_system.cpp:95` | `find_memory_type_()` 失敗時 `UINT32_MAX` 返却 | エラーは bool / nullptr で伝播 | `std::optional<uint32_t>` or explicit error check 推奨 |
+| `include/pictor/decal/decal_system.h` | Decal 最大数が `constexpr uint32_t kMaxDecals = 64` | 設定ファイル / runtime 拡張性 | P3 対応 |
+
+---
+
+## 3. モジュール分割度 / 機能的凝集度 (Cohesion & Modularity)
+
+| モジュール / クラス | 凝集度評価 | 所見 |
+|-------------------|-----------|------|
+| `PostProcessPipeline` | 機能的 (strong) | HDR render pass / bloom extract / blur / color grade の 4 fullscreen pass が 1 概念で統一 |
+| `DecalSystem` | 機能的 (strong) | デカール投影・OBB 判定・深度復元・UV サンプリングが 1 責務に凝縮 |
+| `VulkanContext` | 通信的 (medium) | Vulkan device/queue/instance の統合 wrapper |
+| `AnimationSystem` | 手続き的 (weak-medium) | animation_clip / skeleton / ik_solver / montage を結合。分割候補 (P2 対応) |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | 設計強度 | A | 0 |
+| 2 | 設計思想の一貫性 | A | 0 |
+| 3 | モジュール分割度 | A | 0 |

--- a/review/2026-05-15/REVIEW_IMPLEMENTATION.md
+++ b/review/2026-05-15/REVIEW_IMPLEMENTATION.md
@@ -1,0 +1,54 @@
+# 実装評価 (Implementation Evaluation) — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD |
+
+---
+
+## 1. コード品質 (Code Quality)
+
+| 該当箇所 | 問題分類 | 説明 | 推奨修正 |
+|----------|---------|------|---------|
+| `src/decal/decal_system.cpp:31-84` | マジックナンバー + 複雑度 | `mat4_inverse()` の逆行列計算が 16 × 16 展開 | small Pictor では inline OK、math util 分離検討 |
+| `src/postprocess/postprocess_pipeline.cpp:634` | 条件分岐チェイニング | init phase の sequential `if (!create_..) { return; }` | 現行 style OK (明示性のため) |
+| `src/postprocess/postprocess_pipeline.cpp:52-64` | エラー伝播不足 | `find_memory_type_()` 失敗時 UINT32_MAX 返却 | **High**: error code or `std::optional<uint32_t>` 推奨 |
+| `include/pictor/decal/decal_system.h:90-110` | ヘッダ伝播 | `#ifdef PICTOR_HAS_VULKAN` 内部に API public | Low: 現行 adequate |
+
+---
+
+## 2. データスキーマの妥当性・重複確認 (Data Schema Validation)
+
+| テーブル / モデル | 問題種別 | 説明 | 推奨対応 |
+|-----------------|---------|------|---------|
+| `DecalDescriptor` | 正規化完了 | TRS transform [16], texture handle, blend mode, opacity, fade params | OK |
+| `PostProcessConfig` (含む HDRConfig/BloomConfig/…) | 正規化完了 | 各 effect 設定が分離された struct、重複なし | OK |
+| `DecalEntry` (内部) | 正規化完了 | descriptor + sort_order + vk resource handle | OK |
+| `RenderTarget` (内部) | alignment 懸念 | image, imageMemory, view, framebuffer, extent | Low: Vulkan handle は opaque ptr |
+
+**評価**: A
+
+---
+
+## 3. SRE観点のレビュー (SRE Review)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | 可観測性 (Observability) | fprintf(stderr) via init failure、real-time render 中 metric なし |
+| A | デプロイ安全性 | static library (libpictor.a)、CMake で feature toggle |
+| A | スケーラビリティ | decal 最大 64 個 hardcode、100+ 必要時 clusterization (P3) |
+| B | 障害復旧 (Disaster Recovery) | `shutdown()` 存在するが、RAII 弱め |
+| B | 依存関係管理 | system Vulkan SDK、GLFW auto-fetch |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | コード品質 | B | 2 |
+| 2 | データスキーマ | A | 0 |
+| 3 | SRE | B | 1 |

--- a/review/2026-05-15/REVIEW_MISSING_FEATURES.md
+++ b/review/2026-05-15/REVIEW_MISSING_FEATURES.md
@@ -1,0 +1,37 @@
+# 不足機能評価 (Missing Features) — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD |
+
+---
+
+## 不足機能・改善案
+
+| 優先度 | 機能 | 現状 | 効果 | 推奨スケジュール |
+|--------|------|------|------|----------------|
+| **High** | Android NDK (Phase 1) | 設計文書完了、コード未実装 | arm64-v8a ビルド成功 | 1 sprint |
+| **High** | DecalSystem 統合テスト | unit test なし | decal ↔ postprocess 相互作用検証 | 1 sprint |
+| **Medium** | Structured logging | fprintf(stderr) | 性能分析、障害対応効率化 | 2 sprint |
+| **Medium** | Decal クラスタ化 (P3) | hardcode max 64 | 100+ decal 描画 | 2 sprint |
+| **Medium** | SAST 統合 (CI) | build.yml のみ | code scan for potential bugs | 1 sprint |
+| **Low** | Math utility lib 分離 | inline mat4 計算 | コード再利用、保守性 | backlog |
+| **Low** | Performance ベンチマーク doc | profiler あるが未文書化 | 性能基準線設定 | backlog |
+
+---
+
+## 優先度マトリックス
+
+|  | コスト 低 | コスト 中 | コスト 高 |
+|---|--------|--------|--------|
+| **インパクト 高** | SAST (Medium) | Logging (Medium) | Android P1 (High) |
+| **インパクト 中** | Math util (Low) | Decal cluster (Medium) |  |
+| **インパクト 低** | Perf doc (Low) |  |  |
+
+**即時着手推奨:**
+1. Android NDK Phase 1 (1 sprint)
+2. Decal integration test (1 sprint)
+3. SAST CI (2-3 days)

--- a/review/2026-05-15/REVIEW_QUALITY.md
+++ b/review/2026-05-15/REVIEW_QUALITY.md
@@ -1,0 +1,81 @@
+# 品質保証レビュー (Quality Assurance Review) — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD |
+
+---
+
+## 1. テスト戦略・カバレッジ (Test Strategy & Coverage)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | unit テストの網羅性 | frame_allocator, radix_sort, culling 3 個のみ。postprocess, decal, animation 未収 |
+| B | integration テストの網羅性 | pixel_text_test, fps_baseline_test。decal ↔ postprocess 統合テストなし |
+| B | E2E テストの存在 | graphics_demo, ocean_demo で visual 検証のみ |
+| B | エッジケース・境界値テスト | culling test は境界含む、decal OBB boundary 未 |
+| A | CI でのテスト自動実行 | GitHub Actions (build.yml): Ubuntu build + CTest |
+
+---
+
+## 2. パフォーマンス・ベンチマーク (Performance & Benchmark)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | パフォーマンス要件の明文化 | README は "high-efficiency" 表現、具体的 SLO なし |
+| B | ベンチマーク実装 | pictor_benchmark (1M spheres)、decal/postprocess 性能 benchmark なし |
+| B | プロファイリング (CPU / メモリ / I/O) | `PICTOR_ENABLE_PROFILER` あり、export format 文書化不足 |
+| B | 性能リグレッション検知 | CI で build のみ、性能回帰自動感知なし |
+| C | 大規模データ・高負荷時の挙動 | 100+ decal 性能 unknown |
+
+---
+
+## 3. ライセンス遵守・OSS 帰属表示 (License Compliance)
+
+| 該当依存 | ライセンス | 配布形態 | 互換性評価 | 帰属表示状態 |
+|---------|----------|---------|-----------|-------------|
+| GLFW 3.4 | zlib | static/dynamic | ✅ OK | NOTICE ファイルなし |
+| Vulkan SDK | Apache 2.0 | dynamic | ✅ OK | system-level |
+| stb (header-only) | Public Domain / MIT | static | ✅ OK | third_party/stb |
+| Rive Renderer (optional) | Proprietary (Rive's license) | static | ⚠️ review needed | `PICTOR_ENABLE_RIVE=ON` 時 |
+
+**評価**: A
+
+---
+
+## 4. クロスプラットフォーム互換 (Cross-Platform Compatibility)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | パス区切り・大文字小文字の扱い | std::filesystem 未使用、std::string ホスト責務 |
+| A | プロセス・IPC の OS 別実装 | in-process library、IPC なし |
+| B | 文字エンコーディング・改行コード | shader 読込は binary。MSVC `/utf-8` flag 指定 |
+| A | ビルドツールチェーンの差分 | CMake 3.20+, conditional (AVX2 ARM64 回避, /W4) |
+| C | CI でのマトリクス実行 | Ubuntu only (build.yml matrix なし) |
+
+---
+
+## 5. ドキュメント完備性 (Documentation Completeness)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | README 完備性 | quickstart、API 表、config schema 例 |
+| A | DESIGN / アーキテクチャ図 | 設計書・実装段階詳細 |
+| A | API リファレンス | header に doc comment、Tauri IPC ドキュメント |
+| A | inline コメント粒度 | 詳細日本語注記 |
+| A | 開発者向け CONTRIBUTING / ランブック | CLAUDE.md、android-build.md 等 |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | テスト戦略・カバレッジ | C | 1 |
+| 2 | パフォーマンス・ベンチマーク | B | 1 |
+| 3 | ライセンス遵守 | A | 0 |
+| 4 | クロスプラットフォーム互換 | B | 2 |
+| 5 | ドキュメント完備性 | A | 0 |

--- a/review/2026-05-15/REVIEW_VULNERABILITY.md
+++ b/review/2026-05-15/REVIEW_VULNERABILITY.md
@@ -1,0 +1,64 @@
+# 脆弱性レビュー (Vulnerability Review) — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main |
+| レビュー実施日 | 2026-05-15 |
+| 対象コミット範囲 | HEAD~9..HEAD |
+
+---
+
+## 1. 脆弱性 (Vulnerability)
+
+| 重大度 | 該当箇所 | 脆弱性種別 | 説明 | 推奨対応 |
+|--------|----------|-----------|------|----------|
+| Low | `src/postprocess/postprocess_pipeline.cpp:69` | ログ出力 | shader open fail を stderr 出力。エラーメッセージに秘密情報なし | OK |
+| Low | `src/decal/decal_system.cpp:101` | ファイル I/O | shader ファイルパスを直接オープン、path traversal 検証なし | ホストが信頼できるなら OK |
+
+### チェック項目
+
+- [x] SQLインジェクション — N/A (SQL 無し)
+- [x] XSS — N/A (web 無し)
+- [x] SSRF — N/A (外部 URL fetch 無し)
+- [x] パストラバーサル — Low: shader_dir は ホスト指定、CMake で compile-time 固定
+- [x] コマンドインジェクション — N/A
+- [x] 安全でないデシリアライゼーション — N/A (JSON 読み込みはホスト責務)
+- [x] 認証バイパス — N/A (認証なし)
+- [x] 機密情報の露出 — A: in-process API
+- [x] 依存ライブラリの既知脆弱性 (CVE) — None detected
+
+---
+
+## 2. ゼロトラスト強度 (Zero Trust Posture)
+
+Pictor は**ローカルプロセス内のレンダリングエンジン**のため、ゼロトラスト原則は部分的適用。
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| N/A | ID検証 | プロセス内 API |
+| N/A | 最小権限 | Vulkan デバイス操作全て |
+| N/A | マイクロセグメンテーション | プロセス内 |
+| A | 継続的検証 | `is_initialized()` で initialized 状態確認 |
+
+---
+
+## 3. セキュリティ強度 (Security Posture)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| N/A | 認証 (Authentication) | in-process lib |
+| N/A | 認可 (Authorization) | Vulkan permission は GPU driver enforcer |
+| A | 暗号化 | GPU ↔ host の通信は DMA |
+| A | データ保護 | メモリ: `vkAllocateMemory` で保護されたメモリ |
+| A | サプライチェーン | LUT (color grade table) はホスト供給 |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | 脆弱性 | A | 0 |
+| 2 | ゼロトラスト | N/A | - |
+| 3 | セキュリティ | A | 0 |

--- a/review/latest.json
+++ b/review/latest.json
@@ -1,0 +1,25 @@
+{
+  "date": "2026-05-15",
+  "weighted_score": "B",
+  "scores": {
+    "vulnerability": "A",
+    "design_strength": "A",
+    "design_consistency": "A",
+    "modularity": "A",
+    "code_quality": "B",
+    "data_schema": "A",
+    "sre": "B",
+    "zero_trust": "N/A",
+    "security": "A",
+    "test_strategy": "C",
+    "performance": "B",
+    "license": "A",
+    "cross_platform": "B",
+    "documentation": "A"
+  },
+  "critical_count": 0,
+  "high_count": 4,
+  "autofix_count": 0,
+  "autofix_categories": { "lint": 0, "typo": 0, "unused_import": 0, "dead_code": 0, "gitignore": 0, "toc": 0 },
+  "fix_pr": null
+}


### PR DESCRIPTION
AIFormat (REVIEW_DESIGN / REVIEW_VULNERABILITY / REVIEW_IMPLEMENTATION / REVIEW_MISSING_FEATURES / REVIEW_QUALITY) に基づくデイリーレビュー成果物を review/ 配下にコミットします。

- レビュー Markdown 群 + latest.json のスナップショット
- コード変更は含みません (レビュー成果物のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)