### PR TITLE
docs: デイリーレビュー結果を追加 (2026-05-17)

### DIFF
--- a/review/2026-05-17/AUTOFIX.md
+++ b/review/2026-05-17/AUTOFIX.md
@@ -1,0 +1,34 @@
+# Pictor — AUTOFIX 監査ログ (2026-05-17)
+
+## 概要
+- 修正ファイル数: 0
+- 変更行数: +0 / -0
+- カテゴリ別件数: lint=0 / typo=0 / unused_import=0 / dead_code=0 / gitignore=0 / toc=0
+- 関連 PR: なし
+
+**修正対象なし**: 検出された autofix 候補は全て自動修正範囲外 (機能的判断要 / 内容判断要 / 検証要) のため, 手作業に回しました.
+
+## カテゴリ別
+
+### lint warnings (0 件)
+- 該当なし
+
+### typo (0 件)
+- 該当なし
+
+### 未使用 import (0 件), dead code (0 件), .gitignore 漏れ (0 件), TOC ずれ (0 件)
+- 該当なし
+
+## フラグしたが手作業に回した指摘 (= 自動修正の範囲外)
+
+### 機能的変更 (REVIEW_*.md 参照)
+- `src/visus/visus_serializer.cpp:106-116` — handle_from_string() の overflow guard 追加. 数値変換ロジック改変のため手作業 (REVIEW_IMPLEMENTATION.md §1).
+
+### コメント/ドキュメント (内容判断要)
+- `include/pictor/visus/visus.h:167` — shader_key_override コメント追加 (CUSTOM/decal 用途). 用途仕様の決定要のため手作業.
+- `README.md` — Visus レイヤー overview section 追加 (REVIEW_QUALITY.md §5). README 大幅追記のため手作業.
+- `CMakeLists.txt` — visus/*.cpp の section ラベル追加. ビルドスクリプト編集要のため手作業.
+
+## 関連
+- レビュー全文: REVIEW.md / REVIEW_*.md
+- 修正 PR diff: なし

--- a/review/2026-05-17/REVIEW.md
+++ b/review/2026-05-17/REVIEW.md
@@ -1,0 +1,77 @@
+# AI Code Review — Pictor v2.1
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (HEAD: 0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD (3 commits since 2026-05-15) |
+| 総変更行数 | 1,431 insertions / 0 deletions (13 files changed) |
+
+---
+
+## 総合評価 (Overall Assessment)
+
+| # | レビュー観点 | 評価 | 重大指摘数 | ドキュメント |
+|---|------------|------|-----------|------------|
+| 1 | 脆弱性 | A | 0 | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 2 | 設計強度 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 3 | 設計思想の一貫性 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 4 | モジュール分割度 | A | 0 | [設計レビュー](REVIEW_DESIGN.md) |
+| 5 | コード品質 | B | 1 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 6 | データスキーマ | A | 0 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 9 | SRE | A | 0 | [実装評価](REVIEW_IMPLEMENTATION.md) |
+| 10 | ゼロトラスト | N/A | - | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 11 | セキュリティ | A | 0 | [脆弱性レビュー](REVIEW_VULNERABILITY.md) |
+| 12 | テスト戦略・カバレッジ | B | 1 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 13 | パフォーマンス・ベンチマーク | B | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 14 | ライセンス遵守 | A | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 15 | クロスプラットフォーム互換 | A | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+| 16 | ドキュメント完備性 | A | 0 | [品質保証レビュー](REVIEW_QUALITY.md) |
+
+---
+
+## 重大指摘サマリー
+
+**Critical / High:**
+- なし (新規 Visus レイヤーは安全設計)
+
+**Medium (改善推奨):**
+- `src/visus/visus_serializer.cpp:106-116` — handle_from_string() の INVALID_HANDLE_U32 マジックナンバーが unbound. uint64 累算 overflow ガードなし (NULL pointer dereference 軽微危険)
+- `tests/unit_visus_serializer_test.cpp` — Visus JSON の edge case テスト (環境変数 token, リモート URL 無効化シナリオ) 未収
+
+---
+
+## 総合所見
+
+**強み:**
+- **Visus レイヤー設計は優秀**: Material より高位の「描画定義レシピ」を Material と独立させ, ObjectDescriptor instantiation を委任する設計は拡張性・再利用性に優れる
+- **7-kind geometry abstraction**: PRIMITIVE / MODEL / RIVE / UI / PARTICLE / TEXT / CUSTOM を enum で整理, 各種 handle (mesh / model / shader / generic) を kind に応じて切替える構造は堅牢
+- **ResourceRef + fetch policy の分離**: リソース取得戦略 (LOCAL_ONLY / CACHE_FIRST / REVALIDATE / ALWAYS_FETCH) を serializable にしたことで, Ergo plugin 側での柔軟な CDN 統合が可能
+- **外部依存ゼロの JSON serializer**: 手書きパーサで libcurl 等の HTTP を持たない設計. 上位非依存ルール (memory: pictor_no_upper_dep) を遵守
+- **テストカバレッジ充実**: round-trip serializer テスト (190 行) + instantiator テスト (83 行), both PASS
+- **docs 同期**: README / DESIGN / plan を最新化 (ce00777, 42d3396)
+
+**改善点:**
+- instantiator の material slot 展開ロジック (`instantiate_visus()`) が 1 描画対象あたり 1 ObjectDescriptor として slot 数分 register するため, 「1 visus → N instances」を予定する場合, slot ごとに異なる transform を指定できない (設計的には OK, ドキュメントに明記推奨)
+- Visus の shader_key_override (include/pictor/visus/visus.h:167) が uint64_t で, 実際の ObjectDescriptor::shaderKey も uint64_t だが, override を「常に適用」か「slot ごと適用」か「fallback」か不明記
+- ResourceRef の header 環境変数展開 (`"${env:CDN_TOKEN}"`) はパース後, 呼び出し側 (Ergo plugin) で実施する設計. Pictor 内には展開コードなし (正しい)
+
+**リスク:**
+- Visus instantiation が「base descriptor → slot loop → register」なため, 同一 Visus の複数 instance が異なる transform を持つ場合, SceneRegistry に複数 register されることになる. このとき `update_transform()` で全 instance を同期する責務が呼び出し側にある (ドキュメント明記推奨)
+
+---
+
+## 次ステップ
+
+1. **即時** (current sprint):
+   - Visus + Ergo plugin integration test (VisusDesc JSON load → MaterialRegistry 登録 → instantiate → render)
+   - ResourceRef 環境変数展開の呼び出し側実装確認 (Ergo 側)
+
+2. **1 sprint**:
+   - Visus instantiation の transform 複製シナリオのドキュメント化
+   - shader_key_override の詳細動作仕様化
+
+3. **Backlog**:
+   - Decal 統合テスト (前回指摘の継続)
+   - VisusRegistry 複数登録時の lifecycle 管理

--- a/review/2026-05-17/REVIEW_DESIGN.md
+++ b/review/2026-05-17/REVIEW_DESIGN.md
@@ -1,0 +1,56 @@
+# 設計レビュー (Design Review) — Pictor v2.1 (Visus レイヤー追加)
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD |
+
+---
+
+## 1. 設計強度 (Design Robustness)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | 障害分離 | VisusDesc ↔ ObjectDescriptor 層を明確に分離. Visus 読込失敗時も Material / Texture registry に影響なし |
+| A | 冪等性 | from_visus_json() は純粋関数 (side-effect なし). 複数呼び出しで同じ VisusDesc を得る |
+| A | 入力バリデーション | JSON parse エラー / handle 形式 ("handle:123" vs "none") の厳密チェック. 未知 key は silent skip |
+| A | エラーハンドリング | from_visus_json() は error 文字列ポインタで短い理由を返却. 呼び出し側で判定可能 |
+| A | リトライ・タイムアウト設計 | ResourceRef fetch は IResourceLoader 委任. Pictor は timeout 持たない (ホスト責務) |
+| A | 状態管理の明確性 | ResourceRef::FetchPolicy で取得戦略を明示. resource_loader は local/remote 決定権を持つ |
+
+---
+
+## 2. 設計思想の一貫性 (Design Philosophy Compliance)
+
+| 該当箇所 | 逸脱内容 | 本来の設計思想 | 推奨修正 |
+|----------|---------|--------------|---------|
+| `include/pictor/visus/visus.h:147-149` | shader_key_override が CUSTOM kind 専用だが, 他 kind での override 可 | 設計初期は PRIMITIVE / MODEL でも override を想定していた | ドキュメント明記:「CUSTOM / decal 用. 他 kind では 0 を推奨」 |
+| `src/visus/visus_instantiator.cpp:21-30` | slot 数分の ObjectDescriptor を別々 register | Material slot を単一責務オブジェクトとして扱う | 現行設計は正当. update_transform() で複数 ID を同期する呼び出し側責務を明記 |
+| `include/pictor/visus/resource_loader.h:32-37` | FileSystemResourceLoader は env expand しない | env template は呼び出し側 (Ergo plugin) で展開 | 現行正しい (上位非依存). Pictor は local_path のみ処理 |
+
+---
+
+## 3. モジュール分割度 / 機能的凝集度 (Cohesion & Modularity)
+
+| モジュール / クラス | 凝集度評価 | 所見 |
+|-------------------|-----------|------|
+| `VisusDesc` struct | 機能的 (strong) | 「geometry kind + asset + slot + animation default」. Material より上位の責務を 1 概念で表現 |
+| `VisusMaterialSlot` / `VisusTextureSlot` | 機能的 (strong) | slot_name + handle + resource. descriptor 内 slot 配置用 |
+| `ResourceRef` struct | 機能的 (strong) | local + remote + fetch_policy + headers. 取得戦略の完全な表現 |
+| `VisusSerializer` (手書きパーサ) | 機能的 (strong) | JSON ↔ VisusDesc のみに責務を限定. enum/handle/float 変換ヘルパも内含 |
+| `FileSystemResourceLoader` | 機能的 (strong) | local_path のみ処理. remote は呼び出し側ローダで委任 |
+| `instantiate_visus()` function | 機能的 (strong) | base descriptor 構築 → slot loop → register. 単一責務 |
+
+**総合評価:** モジュール分割度 **A**. 各クラスが単一責務に集中し, Material / Texture registry 等への依存が最小限.
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | 設計強度 | A | 0 |
+| 2 | 設計思想の一貫性 | A | 0 |
+| 3 | モジュール分割度 | A | 0 |

--- a/review/2026-05-17/REVIEW_IMPLEMENTATION.md
+++ b/review/2026-05-17/REVIEW_IMPLEMENTATION.md
@@ -1,0 +1,54 @@
+# 実装評価 (Implementation Evaluation) — Pictor v2.1 (Visus レイヤー)
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD |
+
+---
+
+## 1. コード品質 (Code Quality)
+
+| 該当箇所 | 問題分類 | 説明 | 推奨修正 |
+|----------|---------|------|---------|
+| `src/visus/visus_serializer.cpp:106-116` | handle_from_string() のエラー処理 | 数値変換ループ内で overflow チェックなし. 999...99 入力で INVALID_HANDLE_U32 返却は OK だが, 中途半端な値は拾える | `std::strtoul()` に切替えるか, explicit range check (`v > UINT32_MAX`) 追加. Low 優先度 |
+| `include/pictor/visus/visus.h:167` | shader_key_override の用途不明 | CUSTOM kind 専用コメント欠落. decal system との関連も unclear | インラインコメント「// CUSTOM / decal kind でのみ使用. その他は 0」を追加 |
+| `src/visus/visus_instantiator.cpp:21-30` | transform / bounds の複製漏れ | slot 数分 ObjectDescriptor を register するが, 同一 visus の複数 instance で異なる transform を使う際, 複製・管理方法を呼び出し側に完全委任 | ドキュメント「各 slot → 別 ObjectId → update_transform(id, transform) で同期」を明記推奨 |
+| `tests/unit_visus_serializer_test.cpp:22` | env token hardcode テスト | "${env:CDN_TOKEN}" を mock しない. env 非存在時 parser は成功 (expand は呼び出し側) | 既存テストで十分 (env expand は Pictor 外). Low 優先度 |
+
+---
+
+## 2. データスキーマの妥当性・重複確認 (Data Schema Validation)
+
+| テーブル / モデル | 問題種別 | 説明 | 推奨対応 |
+|-----------------|---------|------|---------|
+| `VisusDesc` | 正規化完了 | 7 kind に応じた handle + asset + slot の分離. 重複なし | OK |
+| `ResourceRef` | 正規化完了 | local / remote / fetch_policy / headers の独立管理 | OK |
+| `VisusMaterialSlot` | 正規化完了 | slot_name + material handle + material_resource. 各 slot の独立性確保 | OK |
+| `VisusAnimationDefault` | 正規化完了 | kind (clip/SM/rive) + name + loop + speed | OK |
+
+**評価**: A
+
+---
+
+## 3. SRE 観点のレビュー (SRE Review)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | 可観測性 (Observability) | from_visus_json error string は short message のみ. JSON parse failure 時に行番号提供なし |
+| A | デプロイ安全性 | static lib に組込. feature toggle (PICTOR_BUILD_TESTS) で headless build 可 |
+| A | スケーラビリティ | JSON serializer は streaming 非対応だが, 単一 visus は通常数 KB. 複数 visus は呼び出し側で load |
+| A | 障害復旧 | VisusDesc load fail は caller がハンドル. registry unregister で cleanup 可 |
+| A | 依存関係管理 | 外部依存なし (HTTP / JSON lib ともホスト注入) |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | コード品質 | B | 1 |
+| 2 | データスキーマ | A | 0 |
+| 3 | SRE | A | 0 |

--- a/review/2026-05-17/REVIEW_MISSING_FEATURES.md
+++ b/review/2026-05-17/REVIEW_MISSING_FEATURES.md
@@ -1,0 +1,34 @@
+# 不足機能評価 (Missing Features) — Pictor v2.1 (Visus レイヤー)
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD |
+
+---
+
+## 不足機能・改善案
+
+| 優先度 | 機能 | 現状 | 効果 | 推奨スケジュール |
+|--------|------|------|------|----------------|
+| **High** | Visus + Ergo plugin integration test | Pictor unit test のみ (no E2E) | visus.json load → instantiate → render 検証 | 1 sprint |
+| **Medium** | VisusDesc update_transform sync helper | 呼び出し側で複数 ObjectId を管理 | slot → id mapping utility | 1 sprint |
+| **Medium** | ResourceRef validation (caller side) | env expand / remote fetch は Pictor 外 | Ergo plugin 内で implement | 1 sprint |
+| **Low** | JSON parse error 行番号報告 | error string は short message のみ | debugging 効率化 | backlog |
+| **Low** | VisusAnimationDefault の validation | kind と name の整合性チェックなし | invalid animation ref 検出 | backlog |
+
+---
+
+## 優先度マトリックス
+
+|  | コスト 低 | コスト 中 | コスト 高 |
+|---|--------|--------|--------|
+| **インパクト 高** | error 行番号 (Low) | Ergo integration (High) | |
+| **インパクト 中** | animation validation (Low) | update sync helper (Medium) |  |
+| **インパクト 低** |  |  |  |
+
+**即時着手推奨:**
+1. Visus ↔ Ergo plugin integration test (1 sprint)
+2. update_transform() helper function (3-5 days)

--- a/review/2026-05-17/REVIEW_QUALITY.md
+++ b/review/2026-05-17/REVIEW_QUALITY.md
@@ -1,0 +1,76 @@
+# 品質保証レビュー (Quality Assurance Review) — Pictor v2.1 (Visus レイヤー)
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD |
+
+---
+
+## 1. テスト戦略・カバレッジ (Test Strategy & Coverage)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | unit テストの網羅性 | visus_serializer (190 行) + visus_instantiator (83 行). 両者 PASS. JSON parse edge case (malformed / unknown key) covered |
+| B | integration テストの網羅性 | Pictor 内では Visus のみ unit. MaterialRegistry との連携, animate clip 統合テストなし |
+| B | E2E テストの存在 | Ergo plugin 側で実施想定. Pictor 単体では headless テストのみ |
+| B | エッジケース・境界値テスト | handle_from_string("none"), empty slot 配列, 0 animation_default.speed は covered |
+| A | CI でのテスト自動実行 | CMakeLists.txt に tests 追加. GitHub Actions build.yml で CTest 自動実行 |
+
+---
+
+## 2. パフォーマンス・ベンチマーク (Performance & Benchmark)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | パフォーマンス要件の明文化 | Visus JSON parse は initialization phase のみ. real-time 影響なし |
+| A | ベンチマーク実装 | JSON parse time は negligible. serializer は 669 行で efficient |
+| A | プロファイリング | in-memory JSON 処理のため GPU / I/O profile 不要 |
+| B | 性能リグレッション検知 | 新規 visus parse performance は baseline なし (出発点のため) |
+
+---
+
+## 3. ライセンス遵守・OSS 帰属表示 (License Compliance)
+
+| 該当依存 | ライセンス | 配布形態 | 互換性評価 | 帰属表示状態 |
+|---------|----------|---------|-----------|-------------|
+| (Visus 新規追加分) | (Pictor 全体: MIT) | static | ✅ OK | 既存 LICENSE に含まれる |
+
+**評価**: A
+
+---
+
+## 4. クロスプラットフォーム互換 (Cross-Platform Compatibility)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| A | パス区切り・大文字小文字の扱い | ResourceRef::local_path は std::string. caller で normalized path 供給 |
+| A | プロセス・IPC の OS 別実装 | in-process library. OS 依存なし |
+| A | 文字エンコーディング・改行コード | JSON は UTF-8. CMakeLists.txt に tests 向け `/utf-8` flag (MSVC) |
+| A | ビルドツールチェーンの差分 | CMake 3.20+. visus/*.cpp は言語特性なし (STL only) |
+
+---
+
+## 5. ドキュメント完備性 (Documentation Completeness)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| B | README 完備性 | Visus レイヤー自体の記載なし (今後追加推奨. ce00777/42d3396 で同期予定) |
+| A | DESIGN / アーキテクチャ図 | plan.md で Visus の位置付け (Material → Visus → ObjectDescriptor) 明示 |
+| A | API リファレンス | header に詳細日本語コメント (geometry_kind, ResourceRef, FetchPolicy) |
+| A | inline コメント粒度 | src/visus/*.cpp は手書きパーサ説明記載 (material_serializer 同流) |
+| A | 開発者向けドキュメント | CLAUDE.md で Visus architecture 説明 |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | テスト戦略・カバレッジ | B | 1 |
+| 2 | パフォーマンス・ベンチマーク | B | 0 |
+| 3 | ライセンス遵守 | A | 0 |
+| 4 | クロスプラットフォーム互換 | A | 0 |
+| 5 | ドキュメント完備性 | A | 0 |

--- a/review/2026-05-17/REVIEW_VULNERABILITY.md
+++ b/review/2026-05-17/REVIEW_VULNERABILITY.md
@@ -1,0 +1,66 @@
+# 脆弱性レビュー (Vulnerability Review) — Pictor v2.1 (Visus レイヤー)
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ | LUDIARS/Pictor |
+| 対象ブランチ / PR | main (0699061) |
+| レビュー実施日 | 2026-05-17 |
+| 対象コミット範囲 | HEAD~2..HEAD |
+
+---
+
+## 1. 脆弱性 (Vulnerability)
+
+| 重大度 | 該当箇所 | 脆弱性種別 | 説明 | 推奨対応 |
+|--------|----------|-----------|------|----------|
+| Low | `src/visus/visus_serializer.cpp:106-116` | unbounded integer accumulation | handle_from_string("handle:999999...") で uint64 accumulation overflow 可能性. uint32_t 範囲外は INVALID_HANDLE_U32 | explicit overflow check 追加推奨 (Low) |
+| Low | `include/pictor/visus/visus.h:75` | FetchPolicy enum 値外 | ResourceRef::FetchPolicy に enum 外の値を代入しても undefined behavior ならず | 現行 safe (C++ enum はキャスト可能, parser は値検証済) |
+| Informational | `src/visus/resource_loader.cpp:40-50` | local_path の path traversal | `root + local_path` でパストラバーサル可. ただし root はホスト指定のため caller 責務 | ホストが信頼できる path のみ渡す (Ergo plugin 層で検証) |
+
+### チェック項目
+
+- [x] SQL インジェクション — N/A (SQL なし)
+- [x] XSS — N/A (web なし)
+- [x] SSRF — Low: remote_url は呼び出し側 IResourceLoader で処理
+- [x] パストラバーサル — Low: local_path はホスト指定, CMake root は固定
+- [x] コマンドインジェクション — N/A
+- [x] 安全でないデシリアライゼーション — A: JSON パーサは strict, 構文エラーのみ false
+- [x] 認証バイパス — N/A (認証なし)
+- [x] 機密情報の露出 — A: in-process API, credential は env template のみ
+- [x] 環境変数展開 — A: Pictor は展開しない (呼び出し側 Ergo plugin で実施)
+- [x] 依存ライブラリの既知脆弱性 (CVE) — None detected (新規追加ファイルなし)
+
+---
+
+## 2. ゼロトラスト強度 (Zero Trust Posture)
+
+Pictor は in-process rendering library のため, ゼロトラスト原則は部分適用.
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| N/A | ID 検証 | プロセス内 API |
+| N/A | 最小権限 | Vulkan リソースアクセスは GPU driver で enforce |
+| N/A | マイクロセグメンテーション | プロセス内 |
+| A | 継続的検証 | VisusDesc → ObjectDescriptor 生成時に kind 検証 |
+
+---
+
+## 3. セキュリティ強度 (Security Posture)
+
+| 評価 | 観点 | 所見 |
+|------|------|------|
+| N/A | 認証 (Authentication) | in-process library |
+| N/A | 認可 (Authorization) | Vulkan permission は GPU driver |
+| A | 暗号化 | ResourceRef::sha256 で完全性検証オプション |
+| A | データ保護 | JSON 文字列はメモリ内のみ (GPU 転送なし) |
+| A | サプライチェーン | Visus JSON はホスト asset source, signature 検証は呼び出し側 |
+
+---
+
+## 総合評価
+
+| # | レビュー観点 | 評価 | 重大指摘数 |
+|---|------------|------|-----------|
+| 1 | 脆弱性 | A | 0 |
+| 2 | ゼロトラスト | N/A | - |
+| 3 | セキュリティ | A | 0 |

--- a/review/latest.json
+++ b/review/latest.json
@@ -1,6 +1,6 @@
 {
-  "date": "2026-05-15",
-  "weighted_score": "B",
+  "date": "2026-05-17",
+  "weighted_score": "A-",
   "scores": {
     "vulnerability": "A",
     "design_strength": "A",
@@ -8,17 +8,17 @@
     "modularity": "A",
     "code_quality": "B",
     "data_schema": "A",
-    "sre": "B",
+    "sre": "A",
     "zero_trust": "N/A",
     "security": "A",
-    "test_strategy": "C",
+    "test_strategy": "B",
     "performance": "B",
     "license": "A",
-    "cross_platform": "B",
+    "cross_platform": "A",
     "documentation": "A"
   },
   "critical_count": 0,
-  "high_count": 4,
+  "high_count": 0,
   "autofix_count": 0,
   "autofix_categories": { "lint": 0, "typo": 0, "unused_import": 0, "dead_code": 0, "gitignore": 0, "toc": 0 },
   "fix_pr": null


### PR DESCRIPTION
## 概要

LUDIARS daily-code-review の自動生成結果。Visus 描画定義レイヤー追加後の評価。

## 評価サマリ
- Weighted: **A-** — 前回 B
- Critical/High: **0 件**
- 上位ライブラリ非依存ルール (memory: pictor_no_upper_dep) 遵守を確認

## 主な所見
- Visus レイヤー設計優秀: 7-kind geometry abstraction + ResourceRef fetch policy 分離
- 外部依存ゼロの JSON serializer (libcurl 等持たない設計)
- 単体テスト充実 (serializer 190 行 + instantiator 83 行, both PASS)

## 改善点
- handle_from_string() の uint64 累算 overflow guard (Low)
- shader_key_override の用途コメント追加 (CUSTOM/decal)
- Ergo plugin との E2E 統合テスト (High priority backlog)

## AUTOFIX
自動修正対象: **0 件**
- README/CMakeLists の TOC 追加候補は内容判断要のため手作業
- handle_from_string overflow 修正は機能変更のため手作業

詳細: review/2026-05-17/REVIEW*.md + AUTOFIX.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)