### PR TITLE
feat(postprocess): post-process を設定駆動化 (方針2 phase 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(pictor STATIC
 
     # Post-Process (host-driven, real Vulkan)
     src/postprocess/postprocess_pipeline.cpp
+    src/postprocess/postprocess_config_bridge.cpp
 
     # Decals (projected, host-driven)
     src/decal/decal_system.cpp

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -5,6 +5,7 @@
 #include "pictor/update/update_scheduler.h"
 #include "pictor/gpu/gpu_driven_pipeline.h"
 #include "pictor/gi/gi_lighting_system.h"
+#include "pictor/postprocess/postprocess_effect.h"
 #include <string>
 #include <vector>
 
@@ -17,11 +18,56 @@ struct ShadowConfig {
     ShadowFilterMode filter_mode     = ShadowFilterMode::PCF;
 };
 
-/// Post-process effect definition (§8.2)
-struct PostProcessDef {
-    std::string name;
-    bool        enabled = true;
+/// Post-process effect kind.
+///
+/// Identifies which `PostProcessConfig` slot a `PostProcessDef` drives.
+/// `UNKNOWN` covers effect names that have no host-driven implementation in
+/// `PostProcessPipeline` yet (SSAO / TAA / FXAA / VolumetricFog …): they
+/// still round-trip through JSON / the editor, but the post-process bridge
+/// ignores them (系統B phase 2 territory — see
+/// `spec/rendering-extensibility-design.md` §3).
+enum class PostProcessKind : uint8_t {
+    UNKNOWN       = 0,  ///< Name has no PostProcessConfig mapping
+    BLOOM         = 1,  ///< -> PostProcessConfig::bloom
+    TONE_MAPPING  = 2,  ///< -> PostProcessConfig::tone_mapping
+    VIGNETTE      = 3,  ///< -> PostProcessConfig::vignette
+    COLOR_GRADING = 4,  ///< -> PostProcessConfig::color_grading (LUT)
+    DEPTH_OF_FIELD = 5, ///< -> PostProcessConfig::depth_of_field
 };
+
+/// Post-process effect definition (§8.2).
+///
+/// Phase 1 of 方針2 (`spec/rendering-extensibility-design.md` §3): besides
+/// `name` / `enabled`, the def now carries a typed `kind` and one parameter
+/// struct per supported effect. Only the struct matching `kind` is
+/// meaningful; the others stay at their defaults. The serializer round-trips
+/// the active effect's parameters, and `build_post_process_config()`
+/// (`postprocess_config_bridge.h`) folds the stack into a `PostProcessConfig`
+/// that drives the real `PostProcessPipeline`.
+///
+/// `kind` is normally derived from `name` (case-insensitive) via
+/// `post_process_kind_from_name()`; an explicit `kind` field in the JSON
+/// overrides that inference.
+struct PostProcessDef {
+    std::string     name;
+    bool            enabled = true;
+    PostProcessKind kind    = PostProcessKind::UNKNOWN;
+
+    // Effect parameters — only the struct matching `kind` is consumed by the
+    // bridge. Defaults mirror `PostProcessConfig`'s per-effect defaults.
+    BloomConfig          bloom;
+    ToneMappingConfig    tone_mapping;
+    VignetteConfig       vignette;
+    ColorGradingConfig   color_grading;
+    DepthOfFieldConfig   depth_of_field;
+};
+
+/// Map an effect name (case-insensitive) to a `PostProcessKind`.
+/// Accepts the canonical preset spellings plus common aliases:
+///   Bloom, Tonemapping/ToneMapping/Tonemap, Vignette,
+///   ColorGrading/LUT/Grade, DoF/DepthOfField.
+/// Returns `UNKNOWN` for names with no host-driven implementation.
+PostProcessKind post_process_kind_from_name(const std::string& name);
 
 /// Render pass definition (§8.3)
 struct RenderPassDef {

--- a/include/pictor/pipeline/pipeline_profile_serializer.h
+++ b/include/pictor/pipeline/pipeline_profile_serializer.h
@@ -46,9 +46,16 @@ namespace pictor {
 //       }
 //     ],
 //     "post_process": [
-//       { "name": "Bloom",       "enabled": true },
-//       { "name": "Tonemapping", "enabled": true }
+//       { "name": "Bloom", "enabled": true, "kind": "Bloom",
+//         "bloom": { "threshold": 0.75, "intensity": 0.8, "radius": 5.0,
+//                    "mip_levels": 5, "scatter": 0.7 } },
+//       { "name": "Tonemapping", "enabled": true, "kind": "ToneMapping",
+//         "tone_mapping": { "op": "ACES_FILMIC", "exposure": 1.0,
+//                           "gamma": 2.2, "saturation": 1.0 } }
 //     ],
+//     // `kind` ∈ Bloom|ToneMapping|Vignette|ColorGrading|DepthOfField|Unknown
+//     // (省略時は name から推論)。 effect param ブロックは kind 一致時のみ
+//     // 消費 (spec §3.4)。 Unknown (SSAO/TAA/FXAA…) は bridge が無視する。
 //     "shadow": {
 //       "cascade_count": 3, "resolution": 2048, "filter_mode": "PCF"
 //     },

--- a/include/pictor/postprocess/postprocess_config_bridge.h
+++ b/include/pictor/postprocess/postprocess_config_bridge.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/// Post-process config bridge — 系統A → 系統B の橋渡し.
+///
+/// `PipelineProfileDef::post_process_stack` (系統A: 宣言データ) を実描画が
+/// 消費する `PostProcessConfig` (系統B: `PostProcessPipeline::set_config`)
+/// へ畳み込む。 方針2 phase 1 の中核
+/// (`spec/rendering-extensibility-design.md` §3)。
+///
+/// 動作:
+///   - スタックを走査し、各 `PostProcessDef` の `kind` で対応する
+///     `PostProcessConfig` のエフェクトスロットを上書きする。
+///   - `enabled` はそのスロットの `.enabled` に転写される。
+///   - スタックに現れないエフェクトは `enabled=false` に倒される
+///     (= プロファイルが Bloom を載せなければ Bloom は切れる)。
+///   - `PostProcessKind::UNKNOWN` (SSAO / TAA / FXAA 等、 host-driven な
+///     `PostProcessPipeline` に実装の無いエフェクト) は黙って無視される。
+///     これらは系統B phase 2 の領分。
+///
+/// `PostProcessPipeline` の固定 4-pass 構造はそのまま。 本ブリッジは
+/// 「既存エフェクトのパラメータと on/off を設定駆動にする」 だけで、
+/// 任意 pass の挿入は行わない (phase 2 / 設計書 §3 参照)。
+
+#include "pictor/postprocess/postprocess_effect.h"
+
+#include <vector>
+
+namespace pictor {
+
+struct PostProcessDef;
+struct PipelineProfileDef;
+
+/// Fold a post-process stack into a `PostProcessConfig`.
+///
+/// `base` seeds non-effect fields (notably `hdr` and `gaussian_blur`, which
+/// have no `PostProcessDef` representation) so callers can keep their HDR /
+/// blur setup. Every effect that *can* be expressed by a `PostProcessDef`
+/// (bloom / tone-mapping / vignette / color-grading / depth-of-field) is
+/// reset to disabled first, then re-enabled + parameterised by whatever the
+/// stack contains. Pass a default-constructed `PostProcessConfig` for `base`
+/// to drive the whole stack purely from the profile.
+PostProcessConfig build_post_process_config(const std::vector<PostProcessDef>& stack,
+                                            const PostProcessConfig& base = {});
+
+/// Convenience overload — folds `profile.post_process_stack`.
+PostProcessConfig build_post_process_config(const PipelineProfileDef& profile,
+                                            const PostProcessConfig& base = {});
+
+} // namespace pictor

--- a/spec/pipeline-profile-config.md
+++ b/spec/pipeline-profile-config.md
@@ -52,10 +52,15 @@ JSON を変更すると即座に C++ ランタイム状態へ反映されるも�
 - **実 `VkRenderPass` の attachment 構成・サブパス・ロード/ストア op** —
   `vulkan_context.cpp` でハードコード。`render_passes[].render_targets` /
   `input_textures` は構造体に格納されるが、実 framebuffer 構成には未配線。
-- **post-process の実シェーダチェーン** — `postprocess_pipeline.cpp` でハードコード。
-  `post_process[]` の順序・enabled は構造体に入るが、実 GPU パスの増減は連動しない。
-  各エフェクトの **パラメータ** (bloom 強度等) は `PostProcessDef` に格納フィールドが
-  無く、JSON 上でエディタ用に round-trip するのみ (C++ には届かない / §3.4 参照)。
+- **post-process の実シェーダチェーン (固定 4-pass 構造)** —
+  `postprocess_pipeline.cpp` の extract → blur H → blur V → grade の
+  4-pass 構造・固定ターゲット数・固定 descriptor はハードコードのまま。
+  `post_process[]` に**新規 pass を挿入**しても (SSAO / TAA 等) 実 GPU
+  パスは増えない (= 系統B phase 2)。
+  一方、既存エフェクト (Bloom / ToneMapping / Vignette / ColorGrading /
+  DoF) の **パラメータと on/off** は `PostProcessDef` 拡張 +
+  `build_post_process_config()` ブリッジ経由で実描画に届く (§3.4、
+  方針2 phase 1 で実装済み)。
 - **各 pass の実ドローコール記録** — `RenderPassScheduler::execute()` の
   `PassType::OPAQUE` / `TRANSPARENT` / `SHADOW` / `DEPTH_ONLY` / `POST_PROCESS` /
   `COMPUTE` の各 case はコメントスタブ。pass の有効/無効・順序は反映されるが、
@@ -64,8 +69,10 @@ JSON を変更すると即座に C++ ランタイム状態へ反映されるも�
 
 > **要約**: このコンフィグは「系統A のプロファイル定義データを完全に外部化」する。
 > プロファイル選択・pass 列・メモリ/更新/GI/GPU-driven/プロファイラの設定値は
-> 実ランタイムに効く。実 Vulkan の描画トポロジ (attachment 構成 / 実シェーダ
-> チェーン / ドロー記録) は系統B のままで、その可変化は別タスク。
+> 実ランタイムに効く。post-process の既存エフェクトのパラメータ・on/off も
+> `build_post_process_config()` ブリッジ経由で実描画に効く (§3.4)。実 Vulkan
+> の描画トポロジ (attachment 構成 / 実シェーダチェーンの pass 増減 / ドロー
+> 記録) は系統B のままで、その可変化は別タスク。
 
 ---
 
@@ -120,15 +127,48 @@ UTF-8 テキスト (BOM 許容)。標準 JSON。コメント不可。
 |------|----|----|------|
 | `name` | string | `""` | エフェクト名 (`Bloom` / `SSAO` / `Tonemapping` / `TAA` / `FXAA` / `VolumetricFog` 等) |
 | `enabled` | bool | `true` | 有効/無効 |
+| `kind` | enum string | (name から推論) | エフェクト種別。§3.4 参照 |
+| `bloom` / `tone_mapping` / `vignette` / `color_grading` / `depth_of_field` | object | — | `kind` に対応するエフェクトのパラメータ。§3.4 参照 |
 
-### 3.4 post-process のエフェクトパラメータ (将来拡張)
+### 3.4 post-process のエフェクトパラメータ (実装済み — 方針2 phase 1)
 
-`PostProcessDef` には現状 `name` / `enabled` しかフィールドが無い。
-エフェクト固有パラメータ (bloom threshold 等) を `post_process[]` の要素に
-書いた場合、シリアライザは**黙ってスキップ**する (構文エラーにはしない)。
-これは Ergo-web エディタがパラメータを JSON 上で保持・編集できるようにする
-ための前方互換措置。C++ 側へパラメータを届けるには `PostProcessDef` の
-構造体拡張が別途必要 (本タスクのスコープ外)。
+`PostProcessDef` は `kind` (種別タグ) + エフェクトごとのパラメータ構造体を
+持つ。`kind` で選ばれた構造体だけが意味を持ち、`build_post_process_config()`
+(`include/pictor/postprocess/postprocess_config_bridge.h`) が
+`post_process[]` スタックを `PostProcessConfig` に畳み込んで、実描画の
+`PostProcessPipeline::set_config` へ渡せるようにする。これで Bloom /
+ToneMapping / Vignette / ColorGrading(LUT) / DoF の **パラメータと on/off が
+設定駆動**になる (設計書 `rendering-extensibility-design.md` §3)。
+
+**`kind`** — 次のいずれか:
+`Bloom` / `ToneMapping` / `Vignette` / `ColorGrading` / `DepthOfField` /
+`Unknown`。省略時は `name` から推論される (大文字小文字不問、
+`Tonemap` / `LUT` / `Grade` / `DoF` 等の別名も受理)。`SSAO` / `TAA` /
+`FXAA` / `VolumetricFog` 等、host-driven な `PostProcessPipeline` に実装の
+無いエフェクトは `Unknown` に解決され、ブリッジは黙って無視する (固定
+4-pass 構造の解体 = 系統B phase 2 の領分)。
+
+**エフェクトパラメータブロック** — `kind` に一致するキーだけが消費される
+(他は前方互換のため黙ってスキップ)。各ブロックのフィールドは
+`include/pictor/postprocess/postprocess_effect.h` の構造体に対応する:
+
+- `bloom`: `threshold`, `soft_threshold`, `intensity`, `radius`,
+  `mip_levels` (uint), `scatter` (float)。
+- `tone_mapping`: `op` (enum: `ACES_FILMIC` / `REINHARD` / `REINHARD_EXT` /
+  `UNCHARTED2` / `LINEAR_CLAMP`), `exposure`, `gamma`, `white_point`,
+  `saturation`。
+- `vignette`: `intensity`, `radius`, `softness`, `color` ([r,g,b] float 配列)。
+- `color_grading`: `lut_path` (string), `lut_intensity`, `lut_size` (uint)。
+- `depth_of_field`: `focus_distance`, `focus_range`, `bokeh_radius`,
+  `near_start`, `near_end`, `far_start`, `far_end`, `sample_count` (uint)。
+
+`enabled=false` のエフェクトもパラメータは保持・round-trip される
+(ブリッジは `.enabled=false` を転写するだけ)。スタックに現れない
+エフェクトはブリッジで `enabled=false` に倒される。
+
+ブリッジが扱わない `HDRConfig` / `GaussianBlurConfig` は `PostProcessDef`
+表現を持たない。`build_post_process_config(stack, base)` の `base` 引数で
+ホスト側の HDR / blur 設定を持ち越せる。
 
 ### 3.5 `shadow` (オブジェクト) — `ShadowConfig`
 
@@ -271,6 +311,25 @@ void PictorRenderer::reload_active_profile();
 `apply_profile()` を呼ぶ。`apply_profile()` は `RenderPassScheduler::reconfigure()`、
 `UpdateScheduler::set_config()`、GI / GPU-driven の再構成、バッチ無効化を行う。
 
+post-process ブリッジ (`postprocess_config_bridge.h`):
+
+```cpp
+#include "pictor/postprocess/postprocess_config_bridge.h"
+
+// post_process スタックを PostProcessConfig に畳み込む。
+// `base` で HDR / gaussian_blur (PostProcessDef 表現なし) を持ち越す。
+PostProcessConfig build_post_process_config(
+    const std::vector<PostProcessDef>& stack, const PostProcessConfig& base = {});
+PostProcessConfig build_post_process_config(
+    const PipelineProfileDef& profile, const PostProcessConfig& base = {});
+```
+
+`PostProcessPipeline` は host-driven で `PictorRenderer` は所有しない。
+ホストはプロファイルの `post_process_stack` を `build_post_process_config()`
+に渡し、結果を `PostProcessPipeline::set_config()` (または
+`initialize_vulkan` の `config` 引数) へ渡すことで、プロファイルの
+post-process 設定を実描画に反映する。
+
 ---
 
 ## 5. プリセット外部化
@@ -291,7 +350,9 @@ C++ ファクトリ (`create_lite_profile()` 等) は **削除していない**�
 
 - **`shader_override` / `render_targets` / `input_textures`** — `RenderPassDef`
   に格納されるが `RenderPassScheduler` が消費しない。系統B 配線時に意味を持つ。
-- **post-process パラメータ** — §3.4。`PostProcessDef` 拡張は別タスク。
+- **post-process パラメータ** — §3.4。`PostProcessDef` 拡張 + ブリッジは
+  方針2 phase 1 で実装済み。残るのは任意 pass 挿入 (固定 4-pass の解体 =
+  系統B phase 2)。
 - **enum の前方互換** — 未知の enum 文字列は preset/既定値にフォールバックする
   (構文エラーにはしない)。新しい `PassType` 等を追加したら本ドキュメントを更新。
 - **検証は最小限** — シリアライザは「構文が JSON か」しか見ない。

--- a/spec/rendering-extensibility-design.md
+++ b/spec/rendering-extensibility-design.md
@@ -1,0 +1,76 @@
+# レンダリング拡張設計 (Rendering Extensibility Design)
+
+> 2026-05-22 起草。KuzuSurvivors のレビューで判明した Pictor の構造的ギャップに対する 3 方針の設計書。
+> 実装に先立つ設計の正本。関連: [`pipeline-profile-config.md`](pipeline-profile-config.md)、Ergo `spec/tool/render_pipeline.md`。
+
+## 1. 背景・診断
+
+Pictor のレンダリングは **2 系統に分断**されている（`pipeline-profile-config.md` §1）。
+
+| 系統 | 実体 | 状態 |
+|---|---|---|
+| 系統A | `PipelineProfileDef`（宣言データ） | JSON で外部化済み (`*.profile.json`)、ツール編集可 |
+| 系統B | 実 `VkRenderPass` チェーン (`vulkan_context.cpp` / `postprocess_pipeline.cpp`) | 完全ハードコード、系統A と未配線 |
+
+KS の C++ 移植レビューで挙がった Pictor 側の不足:
+- **カスタムシェーダ機構が無い** — マテリアルは固定 PBR、任意フラグメントシェーダの差し込み口が無い。
+- **post-process がツール設定できない** — 編集 UI はあるがパラメータが C++ に届かず、実チェーンはハードコード。
+- **パイプラインの可視化が DAG のみ** — 流れ（実行順）が直感的でない。
+
+本書はこれに対する 3 方針の設計。共通原則: **系統A の拡張は容易、系統B（実描画）への配線が本質的作業**。各方針を「phase 1（設定・選択を可能に）」と「phase 2（系統B のハードコード解体）」に分ける。
+
+## 2. 方針1 — カスタムシェーダを Visus で選択
+
+### 現状の seam
+`include/pictor/visus/visus.h` に既にカスタムシェーダ用の構造がある:
+- `VisusGeometryKind::CUSTOM = 7`（shader override 用）
+- `VisusDesc::asset`（CUSTOM 時は shader file を指す）/ `VisusDesc::shader`（`ShaderHandle`）/ `shader_key_override` / `VisusTextureSlot`
+- `visus_serializer.cpp` は `shader` / `shader_key_override` を round-trip 済み。
+
+→ **Visus データモデルは CUSTOM シェーダ参照を半分表現できている。**
+
+### 欠けているもの
+1. `VisusDesc::asset` がシェーダ「ファイル」を 1 つしか指せない（pipeline は最低 vert+frag が要る）。
+2. `instantiate_visus` が `desc.shader` を `ObjectDescriptor` に伝播していない（`ObjectDescriptor` に shader フィールド自体が無い、`shaderKey: uint64_t` のみ）。
+3. Pictor にシェーダ→`VkPipeline` の共通ロード経路が無い（各所でハードコードした `.spv` パスから個別生成）。
+4. マテリアルは `BaseMaterialBuilder` の固定 PBR。
+
+### 設計
+**Visus を seam にする**（CUSTOM kind がそのために用意されている）。固定 PBR マテリアル層は温存し、カスタムシェーダは「マテリアルを置換」ではなく「CUSTOM kind の Visus が PBR 経路をバイパス」する形で両立させる。
+
+- `VisusDesc` に CUSTOM 用シェーダステージ配列を追加（vert/frag/comp、各 `ResourceRef`）。
+- Pictor に最小の `ShaderRegistry` + 「カスタムシェーダ → `VkPipeline`」生成経路を新設（`PostProcessPipeline` の pipeline 生成コードが雛形）。
+- `ObjectDescriptor` に `ShaderHandle customShader` を追加（または `shaderKey` 上位ビットでカスタム識別）。
+- `instantiate_visus` で `desc.shader` を `ObjectDescriptor` に伝播。
+- Ergo `visus` プラグインに CUSTOM kind のシェーダ参照 UI（現状は生 JSON エディタ）。
+
+- **phase 1**: 上記の差し込み経路（固定 vert+frag のカスタムシェーダを Visus から選択 → 描画に反映）。
+- **phase 2**: シェーダ permutation / uniform バインドの作り込み、ShaderGraph 相当。
+
+## 3. 方針2 — post-process を含むレンダリングパスのツール設定
+
+### 現状
+- 編集 UI（render_pipeline プラグイン Profile Editor）は `*.profile.json` の `post_process[]` を CRUD 可能。
+- C++ `PostProcessDef`（`pipeline_profile.h`）は `name` / `enabled` のみ。エフェクトのパラメータが C++ に届かない。
+- 実 post-process は `PostProcessPipeline` に**固定 4-pass**（extract → blur H → blur V → grade）でハードコード。`PostProcessConfig`（各エフェクト構造体）は別系統で `set_config` 経由で渡される。
+
+### 設計
+- **phase 1（実装対象）**: `PostProcessDef` を拡張（`kind` + パラメータ、`PostProcessConfig` を受け皿に活用）→ `pipeline_profile_serializer` で round-trip → `PipelineProfileDef` の post-process スタック → `PostProcessConfig` → `PostProcessPipeline::set_config` のブリッジを実装。これで既存エフェクト（Bloom / ToneMapping / Vignette / ColorGrading(LUT) / DoF）のパラメータと on/off が**設定駆動**になる。Ergo 側は `profile_schema.ts` を型付きフィールド化 + Editor UI でパラメータ編集。
+- **phase 2（別途）**: 任意の新規 post-process pass 挿入（SSAO / TAA / FXAA 等）。`PostProcessPipeline` の固定 4-pass・固定ターゲット数・固定 descriptor 構造の解体が必要。
+
+## 4. 方針3 — パイプライン/パスのタイムライン表示（実装済み 2026-05-22）
+
+render_pipeline プラグインに 3 つ目のモード **Timeline** を追加（Scanner DAG / Timeline / Profile Editor）。
+- 静的ガントチャート: topological level + レーン割当 + sub-pass ネスト + attachment ライフタイム。外部ライブラリ不使用。
+- **phase 2**: GPU timestamp の WS 注入で実測タイムライン化（UI 側は配線済み、`render_pipeline` プラグイン `index.ts` の relay 追加 + Pictor 側 `VkQueryPool` timestamp が残）。
+
+## 5. 実装順序と phase 境界
+
+| 順 | 方針 | 状態 | リポジトリ |
+|---|---|---|---|
+| 1 | 方針3 タイムライン | ✅ 実装済み（`feat/render-pipeline-timeline`） | Ergo |
+| 2 | 方針2 post-process 設定化（phase 1） | 設計済み・実装待ち | Pictor + Ergo |
+| 3 | 方針1 カスタムシェーダ（phase 1） | 設計済み・実装待ち | Pictor + Ergo |
+
+- 方針2 を先に行う理由: 系統A↔B 接続の最初の実例になり、方針2 で作る「シェーダ/パイプライン生成経路」を方針1 が再利用できる。
+- **phase 2（系統B のハードコード解体）は全方針で別タスク**。本フェーズは「既存の選択・設定」に限定し、`PostProcessPipeline` / pipeline 生成のハードコード構造の解体は含まない。

--- a/src/pipeline/pipeline_profile.cpp
+++ b/src/pipeline/pipeline_profile.cpp
@@ -1,7 +1,47 @@
 ﻿#include "pictor/pipeline/pipeline_profile.h"
 #include <algorithm>
+#include <cctype>
+#include <string>
 
 namespace pictor {
+
+namespace {
+
+/// ASCII-lowercase a copy of `s` for case-insensitive name matching.
+std::string ascii_lower(const std::string& s) {
+    std::string out = s;
+    for (char& c : out) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return out;
+}
+
+/// Resolve `kind` from `name` for every effect whose kind is still UNKNOWN.
+/// Factory presets use positional aggregate init (`{"Bloom", true}`), which
+/// leaves `kind` defaulted; this lets the serializer and the bridge see the
+/// proper typed kind without each preset having to spell it out.
+void normalize_post_process_kinds(PipelineProfileDef& def) {
+    for (auto& pp : def.post_process_stack) {
+        if (pp.kind == PostProcessKind::UNKNOWN) {
+            pp.kind = post_process_kind_from_name(pp.name);
+        }
+    }
+}
+
+} // namespace
+
+PostProcessKind post_process_kind_from_name(const std::string& name) {
+    const std::string n = ascii_lower(name);
+    if (n == "bloom")                                  return PostProcessKind::BLOOM;
+    if (n == "tonemapping" || n == "tonemap" ||
+        n == "tone_mapping")                           return PostProcessKind::TONE_MAPPING;
+    if (n == "vignette")                               return PostProcessKind::VIGNETTE;
+    if (n == "colorgrading" || n == "color_grading" ||
+        n == "lut" || n == "grade")                    return PostProcessKind::COLOR_GRADING;
+    if (n == "dof" || n == "depthoffield" ||
+        n == "depth_of_field")                         return PostProcessKind::DEPTH_OF_FIELD;
+    return PostProcessKind::UNKNOWN;
+}
 
 PipelineProfileManager::PipelineProfileManager() = default;
 PipelineProfileManager::~PipelineProfileManager() = default;
@@ -111,6 +151,7 @@ PipelineProfileDef PipelineProfileManager::create_lite_profile() {
         {"FXAA", true},
     };
 
+    normalize_post_process_kinds(def);
     return def;
 }
 
@@ -181,6 +222,7 @@ PipelineProfileDef PipelineProfileManager::create_standard_profile() {
         {"TAA", true},
     };
 
+    normalize_post_process_kinds(def);
     return def;
 }
 
@@ -268,6 +310,7 @@ PipelineProfileDef PipelineProfileManager::create_ultra_profile() {
         {"VolumetricFog", true},
     };
 
+    normalize_post_process_kinds(def);
     return def;
 }
 
@@ -328,6 +371,7 @@ PipelineProfileDef PipelineProfileManager::create_mobile_low_profile() {
         {"Tonemapping", true},
     };
 
+    normalize_post_process_kinds(def);
     return def;
 }
 
@@ -384,6 +428,7 @@ PipelineProfileDef PipelineProfileManager::create_mobile_high_profile() {
         {"Tonemapping", true},
         {"FXAA",        true},
     };
+    normalize_post_process_kinds(def);
 
     return def;
 }

--- a/src/pipeline/pipeline_profile_serializer.cpp
+++ b/src/pipeline/pipeline_profile_serializer.cpp
@@ -95,6 +95,54 @@ ShadowFilterMode shadow_filter_from_str(std::string_view s, ShadowFilterMode fal
     return fallback;
 }
 
+const char* post_process_kind_to_str(PostProcessKind k) {
+    switch (k) {
+        case PostProcessKind::UNKNOWN:        return "Unknown";
+        case PostProcessKind::BLOOM:          return "Bloom";
+        case PostProcessKind::TONE_MAPPING:   return "ToneMapping";
+        case PostProcessKind::VIGNETTE:       return "Vignette";
+        case PostProcessKind::COLOR_GRADING:  return "ColorGrading";
+        case PostProcessKind::DEPTH_OF_FIELD: return "DepthOfField";
+    }
+    return "Unknown";
+}
+
+// Accepts the canonical token plus the same aliases as
+// post_process_kind_from_name() so an explicit `kind` and a bare `name`
+// resolve identically.
+PostProcessKind post_process_kind_from_str(std::string_view s, PostProcessKind fallback) {
+    if (s == "Bloom")          return PostProcessKind::BLOOM;
+    if (s == "ToneMapping" || s == "Tonemapping" || s == "Tonemap" ||
+        s == "tone_mapping")   return PostProcessKind::TONE_MAPPING;
+    if (s == "Vignette")       return PostProcessKind::VIGNETTE;
+    if (s == "ColorGrading" || s == "color_grading" || s == "LUT" ||
+        s == "Grade")          return PostProcessKind::COLOR_GRADING;
+    if (s == "DepthOfField" || s == "depth_of_field" || s == "DoF")
+                               return PostProcessKind::DEPTH_OF_FIELD;
+    if (s == "Unknown")        return PostProcessKind::UNKNOWN;
+    return fallback;
+}
+
+const char* tone_map_operator_to_str(ToneMapOperator op) {
+    switch (op) {
+        case ToneMapOperator::ACES_FILMIC:  return "ACES_FILMIC";
+        case ToneMapOperator::REINHARD:     return "REINHARD";
+        case ToneMapOperator::REINHARD_EXT: return "REINHARD_EXT";
+        case ToneMapOperator::UNCHARTED2:   return "UNCHARTED2";
+        case ToneMapOperator::LINEAR_CLAMP: return "LINEAR_CLAMP";
+    }
+    return "ACES_FILMIC";
+}
+
+ToneMapOperator tone_map_operator_from_str(std::string_view s, ToneMapOperator fallback) {
+    if (s == "ACES_FILMIC")  return ToneMapOperator::ACES_FILMIC;
+    if (s == "REINHARD")     return ToneMapOperator::REINHARD;
+    if (s == "REINHARD_EXT") return ToneMapOperator::REINHARD_EXT;
+    if (s == "UNCHARTED2")   return ToneMapOperator::UNCHARTED2;
+    if (s == "LINEAR_CLAMP") return ToneMapOperator::LINEAR_CLAMP;
+    return fallback;
+}
+
 const char* overlay_mode_to_str(OverlayMode m) {
     switch (m) {
         case OverlayMode::OFF:      return "OFF";
@@ -432,18 +480,113 @@ bool parse_render_pass(Parser& pr, RenderPassDef& out) {
     });
 }
 
-bool parse_post_process(Parser& pr, PostProcessDef& out) {
+// ---- post-process effect parameter parsers --------------------------------
+
+bool parse_bloom_config(Parser& pr, BloomConfig& out) {
     return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "enabled")             return p.parse_bool(out.enabled);
+        else if (key == "threshold")      return p.parse_float_field(out.threshold);
+        else if (key == "soft_threshold") return p.parse_float_field(out.soft_threshold);
+        else if (key == "intensity")      return p.parse_float_field(out.intensity);
+        else if (key == "radius")         return p.parse_float_field(out.radius);
+        else if (key == "mip_levels") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.mip_levels = static_cast<uint32_t>(v); return true;
+        } else if (key == "scatter")      return p.parse_float_field(out.scatter);
+        return p.skip_value();
+    });
+}
+
+bool parse_tone_mapping_config(Parser& pr, ToneMappingConfig& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "enabled")          return p.parse_bool(out.enabled);
+        else if (key == "op") {
+            std::string s; if (!p.parse_string(s)) return false;
+            out.op = tone_map_operator_from_str(s, out.op); return true;
+        } else if (key == "exposure")    return p.parse_float_field(out.exposure);
+        else if (key == "gamma")         return p.parse_float_field(out.gamma);
+        else if (key == "white_point")   return p.parse_float_field(out.white_point);
+        else if (key == "saturation")    return p.parse_float_field(out.saturation);
+        return p.skip_value();
+    });
+}
+
+bool parse_vignette_config(Parser& pr, VignetteConfig& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "enabled")        return p.parse_bool(out.enabled);
+        else if (key == "intensity") return p.parse_float_field(out.intensity);
+        else if (key == "radius")    return p.parse_float_field(out.radius);
+        else if (key == "softness")  return p.parse_float_field(out.softness);
+        else if (key == "color")
+            return p.parse_float3(out.color[0], out.color[1], out.color[2]);
+        return p.skip_value();
+    });
+}
+
+bool parse_color_grading_config(Parser& pr, ColorGradingConfig& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "enabled")            return p.parse_bool(out.enabled);
+        else if (key == "lut_path")      return p.parse_string(out.lut_path);
+        else if (key == "lut_intensity") return p.parse_float_field(out.lut_intensity);
+        else if (key == "lut_size") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.lut_size = static_cast<uint32_t>(v); return true;
+        }
+        return p.skip_value();
+    });
+}
+
+bool parse_depth_of_field_config(Parser& pr, DepthOfFieldConfig& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "enabled")             return p.parse_bool(out.enabled);
+        else if (key == "focus_distance") return p.parse_float_field(out.focus_distance);
+        else if (key == "focus_range")    return p.parse_float_field(out.focus_range);
+        else if (key == "bokeh_radius")   return p.parse_float_field(out.bokeh_radius);
+        else if (key == "near_start")     return p.parse_float_field(out.near_start);
+        else if (key == "near_end")       return p.parse_float_field(out.near_end);
+        else if (key == "far_start")      return p.parse_float_field(out.far_start);
+        else if (key == "far_end")        return p.parse_float_field(out.far_end);
+        else if (key == "sample_count") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.sample_count = static_cast<uint32_t>(v); return true;
+        }
+        return p.skip_value();
+    });
+}
+
+bool parse_post_process(Parser& pr, PostProcessDef& out) {
+    bool kind_explicit = false;
+    bool ok = parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
         if (key == "name") {
             return p.parse_string(out.name);
         } else if (key == "enabled") {
             return p.parse_bool(out.enabled);
+        } else if (key == "kind") {
+            std::string s;
+            if (!p.parse_string(s)) return false;
+            out.kind = post_process_kind_from_str(s, out.kind);
+            kind_explicit = true;
+            return true;
+        } else if (key == "bloom") {
+            return parse_bloom_config(p, out.bloom);
+        } else if (key == "tone_mapping") {
+            return parse_tone_mapping_config(p, out.tone_mapping);
+        } else if (key == "vignette") {
+            return parse_vignette_config(p, out.vignette);
+        } else if (key == "color_grading") {
+            return parse_color_grading_config(p, out.color_grading);
+        } else if (key == "depth_of_field") {
+            return parse_depth_of_field_config(p, out.depth_of_field);
         }
-        // Effect-specific parameters (e.g. bloom intensity) are accepted
-        // for forward-compatibility but PostProcessDef has no field for
-        // them yet — they round-trip through the editor JSON, not C++.
+        // Unknown keys are skipped (forward-compat, spec §2).
         return p.skip_value();
     });
+    if (!ok) return false;
+    // No explicit `kind` -> infer from the effect name (preset spelling).
+    if (!kind_explicit && out.kind == PostProcessKind::UNKNOWN) {
+        out.kind = post_process_kind_from_name(out.name);
+    }
+    return true;
 }
 
 bool parse_shadow_config(Parser& pr, ShadowConfig& out) {
@@ -775,10 +918,85 @@ std::string to_pipeline_profile_json(const PipelineProfileDef& def) {
         out += "\n";
         for (size_t i = 0; i < def.post_process_stack.size(); ++i) {
             const auto& pp = def.post_process_stack[i];
-            pad(out, 2);
-            out += "{ \"name\": "; quote(out, pp.name);
-            out += ", \"enabled\": "; emit_bool(out, pp.enabled);
-            out += " }";
+            pad(out, 2); out += "{\n";
+            pad(out, 3); out += "\"name\":    "; quote(out, pp.name); out += ",\n";
+            pad(out, 3); out += "\"enabled\": "; emit_bool(out, pp.enabled); out += ",\n";
+            pad(out, 3); out += "\"kind\":    ";
+            quote(out, post_process_kind_to_str(pp.kind));
+
+            // Emit only the parameter block matching `kind`. Effects with no
+            // host-driven implementation (UNKNOWN) carry name/enabled/kind
+            // only — their parameters live in the editor JSON, not here.
+            switch (pp.kind) {
+                case PostProcessKind::BLOOM: {
+                    const auto& b = pp.bloom;
+                    out += ",\n";
+                    pad(out, 3); out += "\"bloom\": {\n";
+                    pad(out, 4); out += "\"threshold\":      "; emit_float(out, b.threshold); out += ",\n";
+                    pad(out, 4); out += "\"soft_threshold\": "; emit_float(out, b.soft_threshold); out += ",\n";
+                    pad(out, 4); out += "\"intensity\":      "; emit_float(out, b.intensity); out += ",\n";
+                    pad(out, 4); out += "\"radius\":         "; emit_float(out, b.radius); out += ",\n";
+                    pad(out, 4); out += "\"mip_levels\":     "; emit_uint(out, b.mip_levels); out += ",\n";
+                    pad(out, 4); out += "\"scatter\":        "; emit_float(out, b.scatter); out += "\n";
+                    pad(out, 3); out += "}\n";
+                    break;
+                }
+                case PostProcessKind::TONE_MAPPING: {
+                    const auto& t = pp.tone_mapping;
+                    out += ",\n";
+                    pad(out, 3); out += "\"tone_mapping\": {\n";
+                    pad(out, 4); out += "\"op\":          "; quote(out, tone_map_operator_to_str(t.op)); out += ",\n";
+                    pad(out, 4); out += "\"exposure\":    "; emit_float(out, t.exposure); out += ",\n";
+                    pad(out, 4); out += "\"gamma\":       "; emit_float(out, t.gamma); out += ",\n";
+                    pad(out, 4); out += "\"white_point\": "; emit_float(out, t.white_point); out += ",\n";
+                    pad(out, 4); out += "\"saturation\":  "; emit_float(out, t.saturation); out += "\n";
+                    pad(out, 3); out += "}\n";
+                    break;
+                }
+                case PostProcessKind::VIGNETTE: {
+                    const auto& v = pp.vignette;
+                    out += ",\n";
+                    pad(out, 3); out += "\"vignette\": {\n";
+                    pad(out, 4); out += "\"intensity\": "; emit_float(out, v.intensity); out += ",\n";
+                    pad(out, 4); out += "\"radius\":    "; emit_float(out, v.radius); out += ",\n";
+                    pad(out, 4); out += "\"softness\":  "; emit_float(out, v.softness); out += ",\n";
+                    pad(out, 4); out += "\"color\":     [";
+                    emit_float(out, v.color[0]); out += ", ";
+                    emit_float(out, v.color[1]); out += ", ";
+                    emit_float(out, v.color[2]); out += "]\n";
+                    pad(out, 3); out += "}\n";
+                    break;
+                }
+                case PostProcessKind::COLOR_GRADING: {
+                    const auto& c = pp.color_grading;
+                    out += ",\n";
+                    pad(out, 3); out += "\"color_grading\": {\n";
+                    pad(out, 4); out += "\"lut_path\":      "; quote(out, c.lut_path); out += ",\n";
+                    pad(out, 4); out += "\"lut_intensity\": "; emit_float(out, c.lut_intensity); out += ",\n";
+                    pad(out, 4); out += "\"lut_size\":      "; emit_uint(out, c.lut_size); out += "\n";
+                    pad(out, 3); out += "}\n";
+                    break;
+                }
+                case PostProcessKind::DEPTH_OF_FIELD: {
+                    const auto& d = pp.depth_of_field;
+                    out += ",\n";
+                    pad(out, 3); out += "\"depth_of_field\": {\n";
+                    pad(out, 4); out += "\"focus_distance\": "; emit_float(out, d.focus_distance); out += ",\n";
+                    pad(out, 4); out += "\"focus_range\":    "; emit_float(out, d.focus_range); out += ",\n";
+                    pad(out, 4); out += "\"bokeh_radius\":   "; emit_float(out, d.bokeh_radius); out += ",\n";
+                    pad(out, 4); out += "\"near_start\":     "; emit_float(out, d.near_start); out += ",\n";
+                    pad(out, 4); out += "\"near_end\":       "; emit_float(out, d.near_end); out += ",\n";
+                    pad(out, 4); out += "\"far_start\":      "; emit_float(out, d.far_start); out += ",\n";
+                    pad(out, 4); out += "\"far_end\":        "; emit_float(out, d.far_end); out += ",\n";
+                    pad(out, 4); out += "\"sample_count\":   "; emit_uint(out, d.sample_count); out += "\n";
+                    pad(out, 3); out += "}\n";
+                    break;
+                }
+                case PostProcessKind::UNKNOWN:
+                    out += "\n";
+                    break;
+            }
+            pad(out, 2); out += "}";
             if (i + 1 < def.post_process_stack.size()) out += ",";
             out += "\n";
         }

--- a/src/postprocess/postprocess_config_bridge.cpp
+++ b/src/postprocess/postprocess_config_bridge.cpp
@@ -1,0 +1,68 @@
+#include "pictor/postprocess/postprocess_config_bridge.h"
+
+#include "pictor/pipeline/pipeline_profile.h"
+
+namespace pictor {
+
+namespace {
+
+/// Resolve a def's effect kind. JSON may carry an explicit `kind`; if it is
+/// UNKNOWN we fall back to inferring it from `name` (the preset spelling).
+PostProcessKind resolve_kind(const PostProcessDef& def) {
+    if (def.kind != PostProcessKind::UNKNOWN) return def.kind;
+    return post_process_kind_from_name(def.name);
+}
+
+} // namespace
+
+PostProcessConfig build_post_process_config(const std::vector<PostProcessDef>& stack,
+                                            const PostProcessConfig& base) {
+    PostProcessConfig cfg = base;
+
+    // The five effects a PostProcessDef can express are driven entirely by
+    // the stack: start them disabled so an effect absent from the profile is
+    // actually off. `hdr` / `gaussian_blur` have no PostProcessDef mapping —
+    // they keep whatever `base` provided.
+    cfg.bloom.enabled          = false;
+    cfg.tone_mapping.enabled   = false;
+    cfg.vignette.enabled       = false;
+    cfg.color_grading.enabled  = false;
+    cfg.depth_of_field.enabled = false;
+
+    for (const auto& def : stack) {
+        switch (resolve_kind(def)) {
+            case PostProcessKind::BLOOM:
+                cfg.bloom         = def.bloom;
+                cfg.bloom.enabled = def.enabled;
+                break;
+            case PostProcessKind::TONE_MAPPING:
+                cfg.tone_mapping         = def.tone_mapping;
+                cfg.tone_mapping.enabled = def.enabled;
+                break;
+            case PostProcessKind::VIGNETTE:
+                cfg.vignette         = def.vignette;
+                cfg.vignette.enabled = def.enabled;
+                break;
+            case PostProcessKind::COLOR_GRADING:
+                cfg.color_grading         = def.color_grading;
+                cfg.color_grading.enabled = def.enabled;
+                break;
+            case PostProcessKind::DEPTH_OF_FIELD:
+                cfg.depth_of_field         = def.depth_of_field;
+                cfg.depth_of_field.enabled = def.enabled;
+                break;
+            case PostProcessKind::UNKNOWN:
+                // SSAO / TAA / FXAA / VolumetricFog … — no host-driven
+                // implementation in PostProcessPipeline. Ignored (phase 2).
+                break;
+        }
+    }
+    return cfg;
+}
+
+PostProcessConfig build_post_process_config(const PipelineProfileDef& profile,
+                                            const PostProcessConfig& base) {
+    return build_post_process_config(profile.post_process_stack, base);
+}
+
+} // namespace pictor

--- a/tests/unit_pipeline_profile_serializer_test.cpp
+++ b/tests/unit_pipeline_profile_serializer_test.cpp
@@ -5,8 +5,10 @@
 #include "pictor/pipeline/pipeline_profile_serializer.h"
 #include "pictor/pipeline/pipeline_profile_loader.h"
 #include "pictor/pipeline/pipeline_builder.h"
+#include "pictor/postprocess/postprocess_config_bridge.h"
 #include "test_common.h"
 
+#include <cmath>
 #include <string>
 
 using namespace pictor;
@@ -213,6 +215,173 @@ void test_file_io() {
     PT_ASSERT(!err.empty(), "missing file populates error");
 }
 
+bool near_eq(float a, float b) { return std::fabs(a - b) < 1e-4f; }
+
+void test_post_process_param_roundtrip() {
+    // A profile with a typed post-process stack must round-trip every
+    // effect parameter, not just name/enabled (方針2 phase 1).
+    PipelineProfileDef src;
+    src.profile_name = "PPParams";
+
+    PostProcessDef bloom;
+    bloom.name = "Bloom";
+    bloom.kind = PostProcessKind::BLOOM;
+    bloom.enabled = true;
+    bloom.bloom.threshold      = 0.62f;
+    bloom.bloom.soft_threshold = 0.33f;
+    bloom.bloom.intensity      = 0.91f;
+    bloom.bloom.radius         = 7.5f;
+    bloom.bloom.mip_levels     = 6;
+    bloom.bloom.scatter        = 0.44f;
+
+    PostProcessDef tm;
+    tm.name = "ToneMapping";
+    tm.kind = PostProcessKind::TONE_MAPPING;
+    tm.enabled = false;
+    tm.tone_mapping.op         = ToneMapOperator::UNCHARTED2;
+    tm.tone_mapping.exposure   = 1.3f;
+    tm.tone_mapping.saturation = 1.1f;
+
+    PostProcessDef vig;
+    vig.name = "Vignette";
+    vig.kind = PostProcessKind::VIGNETTE;
+    vig.vignette.intensity = 0.5f;
+    vig.vignette.radius    = 0.6f;
+    vig.vignette.color[0]  = 0.1f;
+    vig.vignette.color[1]  = 0.2f;
+    vig.vignette.color[2]  = 0.3f;
+
+    PostProcessDef grade;
+    grade.name = "ColorGrading";
+    grade.kind = PostProcessKind::COLOR_GRADING;
+    grade.color_grading.lut_path      = "data/lut/warm.png";
+    grade.color_grading.lut_intensity = 0.8f;
+    grade.color_grading.lut_size      = 32;
+
+    PostProcessDef dof;
+    dof.name = "DoF";
+    dof.kind = PostProcessKind::DEPTH_OF_FIELD;
+    dof.depth_of_field.focus_distance = 12.5f;
+    dof.depth_of_field.bokeh_radius   = 5.0f;
+    dof.depth_of_field.sample_count   = 24;
+
+    // SSAO has no host-driven implementation — kind stays UNKNOWN.
+    PostProcessDef ssao;
+    ssao.name = "SSAO";
+
+    src.post_process_stack = {bloom, tm, vig, grade, dof, ssao};
+
+    std::string json = to_pipeline_profile_json(src);
+    PipelineProfileDef dst;
+    std::string err;
+    PT_ASSERT(from_pipeline_profile_json(json, dst, &err), err.c_str());
+
+    PT_ASSERT_OP(dst.post_process_stack.size(), ==, 6u, "post_process count round-trips");
+
+    const auto& b = dst.post_process_stack[0];
+    PT_ASSERT(b.kind == PostProcessKind::BLOOM, "bloom kind round-trips");
+    PT_ASSERT(b.enabled, "bloom enabled round-trips");
+    PT_ASSERT(near_eq(b.bloom.threshold, 0.62f), "bloom threshold round-trips");
+    PT_ASSERT(near_eq(b.bloom.intensity, 0.91f), "bloom intensity round-trips");
+    PT_ASSERT_OP(b.bloom.mip_levels, ==, 6u, "bloom mip_levels round-trips");
+
+    const auto& t = dst.post_process_stack[1];
+    PT_ASSERT(t.kind == PostProcessKind::TONE_MAPPING, "tonemap kind round-trips");
+    PT_ASSERT(!t.enabled, "tonemap disabled round-trips");
+    PT_ASSERT(t.tone_mapping.op == ToneMapOperator::UNCHARTED2,
+              "tonemap operator round-trips");
+    PT_ASSERT(near_eq(t.tone_mapping.exposure, 1.3f), "tonemap exposure round-trips");
+
+    const auto& v = dst.post_process_stack[2];
+    PT_ASSERT(near_eq(v.vignette.intensity, 0.5f), "vignette intensity round-trips");
+    PT_ASSERT(near_eq(v.vignette.color[2], 0.3f), "vignette color round-trips");
+
+    const auto& g = dst.post_process_stack[3];
+    PT_ASSERT(g.color_grading.lut_path == "data/lut/warm.png", "LUT path round-trips");
+    PT_ASSERT_OP(g.color_grading.lut_size, ==, 32u, "LUT size round-trips");
+
+    const auto& d = dst.post_process_stack[4];
+    PT_ASSERT(near_eq(d.depth_of_field.focus_distance, 12.5f),
+              "DoF focus_distance round-trips");
+    PT_ASSERT_OP(d.depth_of_field.sample_count, ==, 24u, "DoF sample_count round-trips");
+
+    // SSAO: kind inferred as UNKNOWN, no host implementation.
+    PT_ASSERT(dst.post_process_stack[5].kind == PostProcessKind::UNKNOWN,
+              "SSAO resolves to UNKNOWN kind");
+}
+
+void test_post_process_kind_inference() {
+    // A bare { "name": ... } with no explicit "kind" must still resolve to
+    // the right kind on parse (preset spelling compatibility).
+    const std::string j = R"({
+      "profile_name": "Inferred",
+      "post_process": [
+        { "name": "Bloom",       "enabled": true },
+        { "name": "Tonemapping", "enabled": true },
+        { "name": "Grade",       "enabled": true },
+        { "name": "FXAA",        "enabled": true }
+      ]
+    })";
+    PipelineProfileDef out;
+    std::string err;
+    PT_ASSERT(from_pipeline_profile_json(j, out, &err), err.c_str());
+    PT_ASSERT_OP(out.post_process_stack.size(), ==, 4u, "stack parsed");
+    PT_ASSERT(out.post_process_stack[0].kind == PostProcessKind::BLOOM,
+              "name 'Bloom' infers BLOOM");
+    PT_ASSERT(out.post_process_stack[1].kind == PostProcessKind::TONE_MAPPING,
+              "name 'Tonemapping' infers TONE_MAPPING");
+    PT_ASSERT(out.post_process_stack[2].kind == PostProcessKind::COLOR_GRADING,
+              "name 'Grade' infers COLOR_GRADING");
+    PT_ASSERT(out.post_process_stack[3].kind == PostProcessKind::UNKNOWN,
+              "name 'FXAA' infers UNKNOWN");
+}
+
+void test_post_process_bridge() {
+    // build_post_process_config folds a stack into a PostProcessConfig.
+    PipelineProfileDef profile;
+
+    PostProcessDef bloom;
+    bloom.name = "Bloom";
+    bloom.kind = PostProcessKind::BLOOM;
+    bloom.enabled = true;
+    bloom.bloom.intensity = 0.77f;
+
+    PostProcessDef vig;
+    vig.name = "Vignette";
+    vig.kind = PostProcessKind::VIGNETTE;
+    vig.enabled = false;            // present but disabled
+    vig.vignette.intensity = 0.9f;
+
+    PostProcessDef ssao;            // UNKNOWN — must be ignored
+    ssao.name = "SSAO";
+
+    profile.post_process_stack = {bloom, vig, ssao};
+
+    PostProcessConfig cfg = build_post_process_config(profile);
+
+    // Bloom: enabled with the def's parameter.
+    PT_ASSERT(cfg.bloom.enabled, "bridge enables Bloom from stack");
+    PT_ASSERT(near_eq(cfg.bloom.intensity, 0.77f), "bridge applies bloom intensity");
+
+    // Vignette present-but-disabled: parameters copied, enabled=false.
+    PT_ASSERT(!cfg.vignette.enabled, "bridge keeps Vignette disabled");
+    PT_ASSERT(near_eq(cfg.vignette.intensity, 0.9f),
+              "bridge still applies disabled-effect params");
+
+    // Tone-mapping NOT in the stack -> forced off.
+    PT_ASSERT(!cfg.tone_mapping.enabled, "effect absent from stack is disabled");
+    PT_ASSERT(!cfg.color_grading.enabled, "absent color_grading disabled");
+    PT_ASSERT(!cfg.depth_of_field.enabled, "absent depth_of_field disabled");
+
+    // `base` HDR / gaussian_blur survive (no PostProcessDef mapping).
+    PostProcessConfig base;
+    base.hdr.exposure = 2.5f;
+    base.gaussian_blur.enabled = true;
+    PostProcessConfig merged = build_post_process_config(profile, base);
+    PT_ASSERT(near_eq(merged.hdr.exposure, 2.5f), "bridge preserves base HDR");
+    PT_ASSERT(merged.gaussian_blur.enabled, "bridge preserves base gaussian_blur");
+}
+
 } // namespace
 
 int main() {
@@ -223,5 +392,8 @@ int main() {
     test_builder_structured_pass();
     test_preset_loader_fallback();
     test_file_io();
+    test_post_process_param_roundtrip();
+    test_post_process_kind_inference();
+    test_post_process_bridge();
     return report("unit_pipeline_profile_serializer_test");
 }


### PR DESCRIPTION
PostProcessDef を PostProcessKind + 5 エフェクトのパラメータ構造体に拡張、serializer round-trip、postprocess_config_bridge で profile→PostProcessConfig 折り畳み。Debug ビルド + CTest 8/8 PASS。

> ⚠️ PR #53 (feat/pipeline-external-config) にスタック。base は feat/pipeline-external-config。

🤖 Generated with [Claude Code](https://claude.com/claude-code)