### PR TITLE
feat(pipeline): Phase 3 系統B 解体 — Step A + Step B (attachments + 3 registries)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(pictor STATIC
     src/pipeline/pipeline_profile_loader.cpp
     src/pipeline/render_pass_scheduler.cpp
     src/pipeline/command_encoder.cpp
+    src/pipeline/attachment_def.cpp
 
     # Profiler
     src/profiler/cpu_timer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,9 @@ add_library(pictor STATIC
     src/pipeline/render_pass_scheduler.cpp
     src/pipeline/command_encoder.cpp
     src/pipeline/attachment_def.cpp
+    src/pipeline/attachment_registry.cpp
+    src/pipeline/render_pass_registry.cpp
+    src/pipeline/framebuffer_registry.cpp
 
     # Profiler
     src/profiler/cpu_timer.cpp

--- a/include/pictor/pipeline/attachment_def.h
+++ b/include/pictor/pipeline/attachment_def.h
@@ -1,0 +1,176 @@
+#pragma once
+
+/// Attachment definitions for the pipeline profile (`spec/pipeline-system-b-config.md`).
+///
+/// `AttachmentDef` declares a named GPU image used by render passes
+/// (`scene_hdr_color` / `scene_depth` / `swapchain` 等)。 All enums are
+/// Vulkan-free (own subset) so this header can be consumed by serializers
+/// and host code without depending on `<vulkan/vulkan.h>` — the
+/// translation to `VkFormat` / `VkImageLayout` / etc. is done in
+/// `attachment_registry.h` under the `PICTOR_HAS_VULKAN` guard.
+///
+/// Phase 3 (`spec/pipeline-system-b-config.md`): the editor / runtime
+/// drives the real `VkRenderPass` chain from these defs. v1 profiles
+/// (no `attachments[]`) get a built-in default of three attachments
+/// (`scene_hdr_color` / `scene_depth` / `swapchain`).
+
+#include "pictor/core/types.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pictor {
+
+// ============================================================
+// Attachment classification
+// ============================================================
+
+enum class AttachmentKind : uint8_t {
+    COLOR           = 0,   ///< Normal color attachment (HDR / LDR target)
+    DEPTH           = 1,   ///< Depth (or depth-stencil) attachment
+    SWAPCHAIN_COLOR = 2,   ///< Special: runtime injects the swapchain image
+};
+
+enum class AttachmentSizing : uint8_t {
+    SWAPCHAIN_RELATIVE = 0, ///< extent = swapchain_extent * scale
+    ABSOLUTE           = 1, ///< extent = (width, height) — explicit
+};
+
+/// Subset of Vulkan formats we use for attachments. The registry maps
+/// these to `VkFormat` at GPU-creation time. Values are stable across
+/// schema revisions (do NOT reorder).
+enum class AttachmentFormat : uint8_t {
+    UNDEFINED            = 0,
+
+    // ---- Color (LDR) ----
+    R8G8B8A8_UNORM       = 1,
+    R8G8B8A8_SRGB        = 2,
+    B8G8R8A8_UNORM       = 3,
+    B8G8R8A8_SRGB        = 4,
+
+    // ---- Color (HDR / float) ----
+    R16G16B16A16_SFLOAT  = 16,
+    R32G32B32A32_SFLOAT  = 17,
+    R11G11B10_UFLOAT     = 18,
+
+    // ---- Depth / depth-stencil ----
+    D16_UNORM            = 32,
+    D24_UNORM_S8_UINT    = 33,
+    D32_SFLOAT           = 34,
+    D32_SFLOAT_S8_UINT   = 35,
+};
+
+/// Bitmask of image usage flags (matches `VkImageUsageFlagBits` semantics).
+/// Stored as `uint32_t` in `AttachmentDef::usage`.
+enum AttachmentUsageBits : uint32_t {
+    USAGE_TRANSFER_SRC              = 1u << 0,
+    USAGE_TRANSFER_DST              = 1u << 1,
+    USAGE_SAMPLED                   = 1u << 2,
+    USAGE_STORAGE                   = 1u << 3,
+    USAGE_COLOR_ATTACHMENT          = 1u << 4,
+    USAGE_DEPTH_STENCIL_ATTACHMENT  = 1u << 5,
+    USAGE_TRANSIENT_ATTACHMENT      = 1u << 6,
+    USAGE_INPUT_ATTACHMENT          = 1u << 7,
+};
+
+/// VkAttachmentLoadOp 相当。
+enum class AttachmentLoadOp : uint8_t {
+    LOAD      = 0,
+    CLEAR     = 1,
+    DONT_CARE = 2,
+    NONE      = 3,
+};
+
+/// VkAttachmentStoreOp 相当。
+enum class AttachmentStoreOp : uint8_t {
+    STORE     = 0,
+    DONT_CARE = 1,
+    NONE      = 2,
+};
+
+/// VkImageLayout 相当のサブセット。
+enum class ImageLayout : uint8_t {
+    UNDEFINED                        = 0,
+    GENERAL                          = 1,
+    COLOR_ATTACHMENT_OPTIMAL         = 2,
+    DEPTH_STENCIL_ATTACHMENT_OPTIMAL = 3,
+    DEPTH_STENCIL_READ_ONLY_OPTIMAL  = 4,
+    SHADER_READ_ONLY_OPTIMAL         = 5,
+    TRANSFER_SRC_OPTIMAL             = 6,
+    TRANSFER_DST_OPTIMAL             = 7,
+    PRESENT_SRC_KHR                  = 8,
+};
+
+// ============================================================
+// Data
+// ============================================================
+
+/// One named GPU image used as an attachment / sampled target.
+/// `name` must be unique within a profile. The reserved name
+/// `"swapchain"` always has `kind == SWAPCHAIN_COLOR` and the runtime
+/// injects the per-image view.
+struct AttachmentDef {
+    std::string                  name;
+    AttachmentKind               kind    = AttachmentKind::COLOR;
+    AttachmentFormat             format  = AttachmentFormat::R16G16B16A16_SFLOAT;
+    AttachmentSizing             sizing  = AttachmentSizing::SWAPCHAIN_RELATIVE;
+    float                        scale   = 1.0f;
+    uint32_t                     width   = 0;     // sizing == ABSOLUTE 用
+    uint32_t                     height  = 0;     // 同上
+    uint32_t                     usage   = USAGE_COLOR_ATTACHMENT | USAGE_SAMPLED;
+    std::array<float, 4>         clear_color   = {{0.0f, 0.0f, 0.0f, 1.0f}};
+    float                        clear_depth   = 1.0f;
+    uint32_t                     clear_stencil = 0;
+};
+
+/// Per-pass override of how an attachment is used (`load/store/layout`).
+/// `attachment_name` must match an entry in `PipelineProfileDef::attachments[]`
+/// or the reserved name `"swapchain"`.
+struct AttachmentOpsDef {
+    std::string       attachment_name;
+    AttachmentLoadOp  load_op        = AttachmentLoadOp::CLEAR;
+    AttachmentStoreOp store_op       = AttachmentStoreOp::STORE;
+    ImageLayout       initial_layout = ImageLayout::UNDEFINED;
+    ImageLayout       final_layout   = ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+};
+
+// ============================================================
+// Helpers — name <-> enum (used by serializer & UI)
+// ============================================================
+
+const char* to_string(AttachmentKind);
+const char* to_string(AttachmentSizing);
+const char* to_string(AttachmentFormat);
+const char* to_string(AttachmentLoadOp);
+const char* to_string(AttachmentStoreOp);
+const char* to_string(ImageLayout);
+
+bool parse_attachment_kind   (std::string_view s, AttachmentKind&    out);
+bool parse_attachment_sizing (std::string_view s, AttachmentSizing&  out);
+bool parse_attachment_format (std::string_view s, AttachmentFormat&  out);
+bool parse_attachment_load_op (std::string_view s, AttachmentLoadOp&  out);
+bool parse_attachment_store_op(std::string_view s, AttachmentStoreOp& out);
+bool parse_image_layout      (std::string_view s, ImageLayout&       out);
+
+/// Test whether a format is depth (or depth-stencil).
+bool is_depth_format(AttachmentFormat f);
+
+/// `clear_depth` / `clear_color` validity — returns `false` for UNDEFINED.
+bool is_valid_format(AttachmentFormat f);
+
+/// Built-in default attachments (Phase 3 §6 fallback for v1 profiles or
+/// when a v2 profile has an empty `attachments[]`). Order is significant:
+/// the swapchain entry is always last so it can be patched by the runtime.
+std::array<AttachmentDef, 3> default_attachments();
+
+/// Built-in default `attachment_ops[]` for a render pass that lists `targets`.
+/// Mirrors §5 / §3.2 of the Phase 3 spec — COLOR=CLEAR/STORE, DEPTH=CLEAR/
+/// DONT_CARE, SWAPCHAIN=CLEAR/STORE→PRESENT_SRC_KHR.
+std::vector<AttachmentOpsDef> default_attachment_ops(
+        const std::vector<std::string>& targets,
+        const std::vector<AttachmentDef>& attachments);
+
+} // namespace pictor

--- a/include/pictor/pipeline/attachment_registry.h
+++ b/include/pictor/pipeline/attachment_registry.h
@@ -1,0 +1,145 @@
+#pragma once
+
+/// AttachmentRegistry — named GPU attachments resolved by `uint16_t` index.
+///
+/// `spec/pipeline-system-b-config.md` §3.3。 hot path から `std::string` を
+/// 完全排除するため、 init 時に `index_of()` で名前を `uint16_t` へ畳み込み、
+/// 以降は index で `view()` / `image()` / `format()` を引く。
+///
+/// Vulkan 依存部分は `PICTOR_HAS_VULKAN` ガード。 ガードなしでも
+/// AttachmentDef 配列を保持して名前↔index の解決はできる (テスト / 編集
+/// ツール / host process 連携用)。
+
+#include "pictor/pipeline/attachment_def.h"
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#ifdef PICTOR_HAS_VULKAN
+// On Windows, <vulkan/vulkan.h> transitively pulls <windows.h>, which
+// otherwise `#define`s GDI macros like `OPAQUE` / `TRANSPARENT` that collide
+// with our enum values (`PassType::OPAQUE`). Suppress the GDI portion.
+#ifndef NOGDI
+#define NOGDI
+#endif
+#include <vulkan/vulkan.h>
+#endif
+
+namespace pictor {
+
+class AttachmentRegistry {
+public:
+    static constexpr uint16_t INVALID_INDEX = 0xFFFFu;
+    static constexpr uint32_t MAX_FLIGHTS   = 4u;
+    static constexpr uint32_t MAX_SWAPCHAIN_IMAGES = 8u;
+
+    AttachmentRegistry();
+    ~AttachmentRegistry();
+
+    AttachmentRegistry(const AttachmentRegistry&)            = delete;
+    AttachmentRegistry& operator=(const AttachmentRegistry&) = delete;
+
+    // ---- Name → index (Vulkan 非依存、 init/edit 経路) -----------------
+
+    /// Replace the attachment defs (does not touch GPU resources yet).
+    /// `defs` の `name` は unique であること。 重複は最後勝ち + assert。
+    void set_defs(std::span<const AttachmentDef> defs);
+
+    /// Look up an attachment by name. Returns `INVALID_INDEX` if not found.
+    /// `string_view` 受けで `std::string` を作らないため、 hot path 直前
+    /// (compile 時) でも安全に呼べる。
+    uint16_t index_of(std::string_view name) const;
+
+    /// Number of registered attachments.
+    uint16_t count() const { return static_cast<uint16_t>(defs_.size()); }
+
+    /// Inspect a def by index.
+    const AttachmentDef& def(uint16_t index) const { return defs_[index]; }
+
+    /// All defs (read-only). Useful for UI / editor / serializer.
+    std::span<const AttachmentDef> defs() const { return defs_; }
+
+    // ---- Vulkan resources (PICTOR_HAS_VULKAN 時のみ) -------------------
+
+#ifdef PICTOR_HAS_VULKAN
+    /// Allocate VkImage / VkImageView for non-swapchain defs.
+    /// `flight_count` は SWAPCHAIN_COLOR 以外の attachment の多重化数
+    /// (per-flight)。 SWAPCHAIN_COLOR は `set_swapchain_images()` で別途
+    /// inject する。 戻り値 false は GPU リソース確保失敗 (validation /
+    /// out-of-memory)。
+    bool initialize_vulkan(VkPhysicalDevice physical_device,
+                           VkDevice         device,
+                           VkExtent2D       swapchain_extent,
+                           uint32_t         flight_count);
+
+    /// Resize all non-swapchain attachments. swapchain は host が
+    /// `set_swapchain_images()` で再 inject する。
+    bool resize(VkExtent2D new_extent);
+
+    /// Inject swapchain images (called by VulkanContext on
+    /// `recreate_swapchain`)。 `views.size() == images.size()` を期待。
+    void set_swapchain_images(std::span<const VkImage>     images,
+                              std::span<const VkImageView> views,
+                              VkFormat                     format,
+                              VkExtent2D                   extent);
+
+    /// Free all Vulkan resources owned by the registry.
+    void shutdown_vulkan();
+
+    /// Query helpers (hot-path safe — single array index lookup).
+    /// SWAPCHAIN_COLOR の場合 `slot_index` は swapchain image index、
+    /// それ以外は flight_index。
+    VkImageView view (uint16_t att_index, uint32_t slot_index) const;
+    VkImage     image(uint16_t att_index, uint32_t slot_index) const;
+    VkFormat    vk_format(uint16_t att_index) const;
+    VkExtent2D  extent(uint16_t att_index) const;
+    uint32_t    slot_count(uint16_t att_index) const; // flight or swapchain image count
+
+    VkDevice device() const { return device_; }
+    VkExtent2D current_extent() const { return current_extent_; }
+    uint32_t flight_count() const { return flight_count_; }
+    uint32_t swapchain_image_count() const { return swapchain_image_count_; }
+#endif // PICTOR_HAS_VULKAN
+
+private:
+    std::vector<AttachmentDef> defs_;
+
+#ifdef PICTOR_HAS_VULKAN
+    struct Resource {
+        // Non-swapchain: per-flight image+view+memory
+        // Swapchain    : per-image image+view (memory not owned)
+        std::vector<VkImage>        images;        // flight_count or swapchain_image_count
+        std::vector<VkImageView>    views;
+        std::vector<VkDeviceMemory> memories;      // empty for swapchain (not owned)
+        VkFormat                    vk_format = VK_FORMAT_UNDEFINED;
+        VkExtent2D                  extent    = {0, 0};
+        bool                        is_swapchain = false;
+    };
+
+    bool create_one_(uint16_t index, VkExtent2D extent);
+    void destroy_one_(Resource& r);
+
+    VkPhysicalDevice          physical_device_       = VK_NULL_HANDLE;
+    VkDevice                  device_                = VK_NULL_HANDLE;
+    VkExtent2D                current_extent_        = {0, 0};
+    uint32_t                  flight_count_          = 0;
+    uint32_t                  swapchain_image_count_ = 0;
+    std::vector<Resource>     resources_;
+#endif
+};
+
+#ifdef PICTOR_HAS_VULKAN
+/// AttachmentFormat → VkFormat. UNDEFINED maps to VK_FORMAT_UNDEFINED.
+VkFormat to_vk_format(AttachmentFormat f);
+
+/// Common bit-set translation for VkImageUsageFlags.
+VkImageUsageFlags to_vk_usage(uint32_t mask);
+
+VkAttachmentLoadOp  to_vk_load_op(AttachmentLoadOp op);
+VkAttachmentStoreOp to_vk_store_op(AttachmentStoreOp op);
+VkImageLayout       to_vk_layout(ImageLayout l);
+#endif
+
+} // namespace pictor

--- a/include/pictor/pipeline/framebuffer_registry.h
+++ b/include/pictor/pipeline/framebuffer_registry.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/// FramebufferRegistry — `VkFramebuffer` arrays keyed by `(pass_index, slot)`。
+///
+/// `spec/pipeline-system-b-config.md` §3.4。 swapchain attachment を含む
+/// render pass は per-swapchain-image (枚数 = 3 想定)、 それ以外は
+/// per-flight (枚数 = 2~3) の framebuffer を 1 本ずつ持つ。
+/// init 時に attachment 名 → AttachmentRegistry index に解決して
+/// VkFramebuffer を一括生成、 hot path では `get(pass_index, slot)` の
+/// flat 配列引きのみ。
+
+// pipeline_profile.h precedes <vulkan/vulkan.h> on purpose — see
+// `render_pass_registry.h` for the Win32 `OPAQUE` macro guard rationale.
+#include "pictor/pipeline/pipeline_profile.h"
+
+#include <cstdint>
+#include <vector>
+
+#ifdef PICTOR_HAS_VULKAN
+#ifndef NOGDI
+#define NOGDI    // see attachment_registry.h for rationale
+#endif
+#include <vulkan/vulkan.h>
+#endif
+
+namespace pictor {
+
+class AttachmentRegistry;
+class RenderPassRegistry;
+
+class FramebufferRegistry {
+public:
+    FramebufferRegistry();
+    ~FramebufferRegistry();
+
+    FramebufferRegistry(const FramebufferRegistry&)            = delete;
+    FramebufferRegistry& operator=(const FramebufferRegistry&) = delete;
+
+#ifdef PICTOR_HAS_VULKAN
+    /// Build VkFramebuffer arrays for every render pass.
+    /// - render passes that contain a SWAPCHAIN_COLOR attachment get
+    ///   `swapchain_image_count` framebuffers (per-image)
+    /// - all other render passes get `flight_count` framebuffers (per-flight)
+    bool initialize_vulkan(VkDevice                   device,
+                           const AttachmentRegistry&  attachments,
+                           const RenderPassRegistry&  render_passes,
+                           uint32_t                   flight_count,
+                           uint32_t                   swapchain_image_count);
+
+    /// Recreate framebuffers (e.g. after swapchain resize). Reuses the
+    /// previously registered passes / attachments.
+    bool resize(uint32_t flight_count, uint32_t swapchain_image_count);
+
+    void shutdown_vulkan();
+
+    /// Hot-path query — per-pass per-slot framebuffer. `slot` is the
+    /// flight index for per-flight passes, or the swapchain image index
+    /// for per-image passes.
+    VkFramebuffer get(uint16_t pass_index, uint32_t slot) const;
+
+    /// True iff `pass_index` is per-swapchain-image (rather than per-flight).
+    bool is_swapchain_pass(uint16_t pass_index) const;
+#endif
+
+private:
+#ifdef PICTOR_HAS_VULKAN
+    struct PassEntry {
+        std::vector<VkFramebuffer> framebuffers; // flight_count or swapchain_image_count
+        bool                       is_swapchain = false;
+        VkExtent2D                 extent = {0, 0};
+    };
+
+    bool build_one_(uint16_t pass_index,
+                    const AttachmentRegistry& attachments,
+                    const RenderPassRegistry& render_passes);
+
+    VkDevice                  device_   = VK_NULL_HANDLE;
+    uint32_t                  flight_   = 0;
+    uint32_t                  swap_     = 0;
+    const AttachmentRegistry* attachments_ = nullptr;
+    const RenderPassRegistry* render_passes_ = nullptr;
+    std::vector<PassEntry>    entries_;
+#endif
+};
+
+} // namespace pictor

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -6,6 +6,7 @@
 #include "pictor/gpu/gpu_driven_pipeline.h"
 #include "pictor/gi/gi_lighting_system.h"
 #include "pictor/postprocess/postprocess_effect.h"
+#include "pictor/pipeline/attachment_def.h"
 #include <string>
 #include <vector>
 
@@ -80,6 +81,13 @@ struct RenderPassDef {
     uint16_t                filter_mask      = 0xFFFF;
     bool                    gpu_driven_pass  = false;
     std::vector<std::string> required_streams; // prefetch hints
+
+    /// Per-attachment load / store ops, in `render_targets` order (Phase 3,
+    /// schema v2). If empty the runtime infers defaults via
+    /// `default_attachment_ops(render_targets, attachments)` —
+    /// CLEAR/STORE for color, CLEAR/DONT_CARE for depth, PRESENT_SRC_KHR
+    /// for swapchain. See `spec/pipeline-system-b-config.md` §3.2.
+    std::vector<AttachmentOpsDef> attachment_ops;
 };
 
 /// Profiler configuration (§8.2)
@@ -94,6 +102,12 @@ struct ProfilerConfig {
 struct PipelineProfileDef {
     std::string                profile_name;
     RenderingPath              rendering_path       = RenderingPath::FORWARD_PLUS;
+
+    /// Named attachments used by `render_passes[].render_targets` /
+    /// `input_textures`. Phase 3 (schema v2). If empty the runtime
+    /// substitutes `default_attachments()` (HDR color / depth / swapchain).
+    std::vector<AttachmentDef> attachments;
+
     std::vector<RenderPassDef> render_passes;
     ShadowConfig               shadow_config;
     std::vector<PostProcessDef> post_process_stack;

--- a/include/pictor/pipeline/render_pass_registry.h
+++ b/include/pictor/pipeline/render_pass_registry.h
@@ -1,0 +1,82 @@
+#pragma once
+
+/// RenderPassRegistry — VkRenderPass objects keyed by `uint16_t` index.
+///
+/// `spec/pipeline-system-b-config.md` §3.4。 init 時に
+/// `PipelineProfileDef::render_passes[]` を畳み込み、 attachment_ops が
+/// 指す attachment 名を `AttachmentRegistry::index_of()` で uint16_t に
+/// 解決して VkAttachmentDescription / VkSubpassDescription /
+/// VkSubpassDependency を組み立てる。 hot path では index で
+/// `VkRenderPass get(uint16_t)` を引くだけ。
+
+// `pipeline_profile.h` must precede `<vulkan/vulkan.h>` so its enum
+// initializers (e.g. `PassType::OPAQUE`) are parsed before any Win32
+// `OPAQUE` macro pollution. See `postprocess_pipeline.h` for the same
+// guard pattern.
+#include "pictor/pipeline/attachment_def.h"
+#include "pictor/pipeline/pipeline_profile.h"
+
+#include <cstdint>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#ifdef PICTOR_HAS_VULKAN
+#ifndef NOGDI
+#define NOGDI    // see attachment_registry.h for rationale
+#endif
+#include <vulkan/vulkan.h>
+#endif
+
+namespace pictor {
+
+class AttachmentRegistry;
+
+class RenderPassRegistry {
+public:
+    static constexpr uint16_t INVALID_INDEX = 0xFFFFu;
+
+    RenderPassRegistry();
+    ~RenderPassRegistry();
+
+    RenderPassRegistry(const RenderPassRegistry&)            = delete;
+    RenderPassRegistry& operator=(const RenderPassRegistry&) = delete;
+
+    // ---- Name → index (Vulkan 非依存) -----------------
+
+    /// Register the pass list (does not touch GPU yet). Each pass's
+    /// `pass_name` must be unique within the registry.
+    void set_passes(std::span<const RenderPassDef> passes);
+
+    uint16_t index_of(std::string_view pass_name) const;
+    uint16_t count() const { return static_cast<uint16_t>(passes_.size()); }
+    const RenderPassDef& pass(uint16_t i) const { return passes_[i]; }
+    std::span<const RenderPassDef> passes() const { return passes_; }
+
+#ifdef PICTOR_HAS_VULKAN
+    /// Build VkRenderPass objects for each registered pass.
+    /// Attachments referenced in `pass.render_targets[]` are resolved via
+    /// `attachments.index_of()`. Missing names → fatal log + skip.
+    bool initialize_vulkan(VkDevice device, const AttachmentRegistry& attachments);
+
+    void shutdown_vulkan();
+
+    VkRenderPass get(uint16_t index) const {
+        return (index < passes_render_passes_.size())
+            ? passes_render_passes_[index]
+            : VK_NULL_HANDLE;
+    }
+#endif
+
+private:
+    std::vector<RenderPassDef> passes_;
+
+#ifdef PICTOR_HAS_VULKAN
+    bool build_one_(uint16_t index, const AttachmentRegistry& attachments);
+
+    VkDevice                  device_ = VK_NULL_HANDLE;
+    std::vector<VkRenderPass> passes_render_passes_;
+#endif
+};
+
+} // namespace pictor

--- a/spec/pipeline-system-b-config.md
+++ b/spec/pipeline-system-b-config.md
@@ -42,17 +42,33 @@ C++ 起動順:
   4. FramebufferRegistry が render_passes[].render_targets + AttachmentRegistry から
      framebuffer を作成 (swapchain は per-image)
 
-Per-frame (RenderPassScheduler::execute):
-  for pass in profile.render_passes:
-    rp = RenderPassRegistry.get(pass.pass_name)
-    fb = FramebufferRegistry.get(pass.pass_name, frame_index)
-    bind input_textures → descriptor
-    vkCmdBeginRenderPass(rp, fb, ...)
-    if pass.shader_override != "none":
-        vkCmdBindPipeline(ShaderRegistry.pipeline(pass.shader_override))
-    record_batches(pass.filter_mask)
-    vkCmdEndRenderPass
+Init 時 (プロファイル切替 1 回):
+  PipelineCompiler が profile.render_passes[] (string 参照だらけ) を
+  compile() し、 std::vector<CompiledPass>(SoA-ish AoS) を作る。 全
+  string → index / handle を解決:
+    - attachment 名 → AttachmentRegistry の uint16_t index
+    - shader_override → VkPipeline (直値)
+    - render_pass / framebuffer → VkRenderPass / VkFramebuffer (直値)
+    - input_textures → 事前構築済 VkDescriptorSet (per-flight)
+    - filter_mask / sort_mode → 既に数値、 そのまま
+
+Per-frame (RenderPassScheduler::execute) — hot path に string / map lookup ゼロ:
+  for (const CompiledPass& cp : compiled_.passes) {
+      vkCmdBindDescriptorSets(... cp.input_sets[flight] ...);   // 事前 build
+      vkCmdBeginRenderPass(cmd, &cp.rp_begin_info[image_index], ...);
+      if (cp.pipeline != VK_NULL_HANDLE)
+          vkCmdBindPipeline(cmd, ..., cp.pipeline);
+      record_batches(cmd, cp.filter_mask, cp.sort_mode);
+      vkCmdEndRenderPass(cmd);
+  }
 ```
+
+**ノード化のオーバーヘッド方針** (`feedback_pictor_dod_layout` 準拠):
+- JSON の `render_passes[]` は宣言形式 (string 名で参照、可読性優先)
+- 起動時 `PipelineCompiler::compile()` で **CompiledGraph** (`std::vector<CompiledPass>`、 各エントリは VkHandle / index 直値のみ) へ畳み込む
+- `RenderPassScheduler::execute()` は **CompiledGraph をフラットイテレートするだけ**。 `unordered_map<string, ...>` / `std::string` / `find_by_name` は hot path に出ない
+- プロファイル切替・swapchain resize 時のみ `compile()` をやり直す (init 1 回方針)
+- `CompiledPass` は AoS 構造体だが、 主要 VkHandle 3 個 + bitmask 数個で 64-128 B 程度に収まる。 SIMD ではなく seq-iteration なので AoS のままキャッシュ効率が高い
 
 ## 3. データモデル (C++ 側)
 
@@ -165,12 +181,14 @@ public:
     void resize(VkExtent2D new_extent);
     void shutdown();
 
-    // SWAPCHAIN_COLOR は per-image だが、それ以外は per-flight (or 単一)
-    VkImageView view(const std::string& name, uint32_t frame_index) const;
-    VkImage     image(const std::string& name, uint32_t frame_index) const;
-    VkFormat    format(const std::string& name) const;
-    VkExtent2D  extent(const std::string& name) const;
-    const AttachmentDef* find(const std::string& name) const;
+    // init 時の名前解決にだけ使う。 hot path では呼ばない。
+    // 戻り値 0xFFFF = 未登録 (PipelineCompiler が fatal log)
+    uint16_t    index_of(std::string_view name) const;
+    VkImageView view(uint16_t index, uint32_t frame_index) const;
+    VkImage     image(uint16_t index, uint32_t frame_index) const;
+    VkFormat    format(uint16_t index) const;
+    VkExtent2D  extent(uint16_t index) const;
+    const AttachmentDef* find(uint16_t index) const;
 
     // ランタイムが swapchain image を inject
     void set_swapchain_images(std::span<const VkImage> images,
@@ -180,6 +198,7 @@ public:
 ```
 
 per-flight (flight_count = 2~3) で多重化、`resize()` で extent 追従。SWAPCHAIN_COLOR だけは swapchain 側からの inject に従う (`VulkanContext::recreate_swapchain` から呼ぶ)。
+**index 引きが正規** — `std::string` を hot path に出さないため、 lookup は init 時に 1 回だけ `index_of()` で `uint16_t` に解決して、 以降はその index を使い回す。
 
 ### 3.4 `RenderPassRegistry` / `FramebufferRegistry`
 
@@ -188,7 +207,8 @@ class RenderPassRegistry {
 public:
     void initialize(VkDevice device, const std::vector<RenderPassDef>& passes,
                     const AttachmentRegistry& attachments);
-    VkRenderPass get(const std::string& pass_name) const;
+    uint16_t     index_of(std::string_view pass_name) const;
+    VkRenderPass get(uint16_t index) const;
     void shutdown();
 };
 
@@ -200,12 +220,84 @@ public:
                     uint32_t flight_count, uint32_t swapchain_image_count);
     void resize(VkExtent2D new_extent);
     // swapchain attachment を含む pass は per-swapchain-image、それ以外は per-flight
-    VkFramebuffer get(const std::string& pass_name, uint32_t frame_or_image_index) const;
+    // PipelineCompiler が compile 時に per-pass で flat 配列を引き写すので
+    // hot path はこの get() も呼ばない設計
+    VkFramebuffer get(uint16_t pass_index, uint32_t frame_or_image_index) const;
     void shutdown();
 };
 ```
 
-両者は `AttachmentRegistry::resize()` 後に再構築。
+両者は `AttachmentRegistry::resize()` 後に再構築。 hot path から消すために `get()` は init 時にしか呼ばれない。
+
+### 3.5 `CompiledPass` / `CompiledGraph` — hot path 用 flat 構造
+
+`PipelineCompiler::compile()` が `profile.render_passes[]` を全 string 解決後の flat 配列へ畳み込む。 1 フレームの execute は **この配列を seq-iterate するだけ**。
+
+```cpp
+struct CompiledPass {
+    // ---- 描画コマンド側 (hot path で直値が必要) ----
+    VkRenderPass    render_pass;         // RenderPassRegistry から
+    // per-image / per-flight の framebuffer 配列。 swapchain attachment を
+    // 含む pass は per-swapchain-image (3 枚)、 含まない pass は per-flight
+    // (2~3 枚)。 indexing は image_index か flight_index のどちらか
+    // — is_swapchain で分岐 (枝予測は 1 種類しか出ない)
+    std::array<VkFramebuffer, 4> framebuffers;  // 0..framebuffer_count
+    std::array<VkDescriptorSet, 4> input_sets;  // 0..flight_count
+
+    // ---- clear 値 / extent も pre-resolve (BeginRenderPassInfo に渡す) ----
+    VkRect2D       render_area;
+    uint16_t       clear_count;
+    std::array<VkClearValue, 8> clear_values; // max 8 attachments per pass
+
+    // ---- pipeline override (NULL = scheduler が pass_type 既定を使う) ----
+    VkPipeline     pipeline;
+
+    // ---- バッチ抽出ヒント (uint で済む。 hot path で OK) ----
+    uint32_t       filter_mask;          // RenderBatch filter
+    uint8_t        sort_mode;            // FRONT_TO_BACK / BACK_TO_FRONT / NONE
+    uint8_t        pass_type;            // PassType enum を 1 byte で
+    uint8_t        framebuffer_count;    // 1=per-flight, 3=per-swapchain-image
+    uint8_t        is_swapchain : 1;
+    uint8_t        is_compute   : 1;
+    uint8_t        reserved     : 6;
+
+    // ---- 観測用 (Phase 2 §6.1 の GPU timestamp タグ) ----
+    uint16_t       timestamp_begin_query;
+    uint16_t       timestamp_end_query;
+    const char*    debug_name;           // string_view 化した名前 (static-lived)
+};
+static_assert(sizeof(CompiledPass) <= 192,
+              "CompiledPass should stay cache-line friendly");
+
+struct CompiledGraph {
+    std::vector<CompiledPass> passes;            // 実行順
+    // descriptor pool / input_set 配列の所有も graph がまとめて持つ
+    VkDescriptorPool descriptor_pool;
+    std::vector<VkDescriptorSet> descriptor_sets_storage;
+    // push constant データのバックストア (CompiledPass からは offset+size で参照)
+    std::vector<std::byte> push_constants_storage;
+};
+
+class PipelineCompiler {
+public:
+    static CompiledGraph compile(const PipelineProfileDef& profile,
+                                 const AttachmentRegistry&,
+                                 const RenderPassRegistry&,
+                                 const FramebufferRegistry&,
+                                 const ShaderRegistry&,
+                                 VkDevice device,
+                                 uint32_t flight_count,
+                                 uint32_t swapchain_image_count);
+};
+```
+
+**hot path 不変条件:**
+- `RenderPassScheduler::execute()` は `for (const auto& cp : graph.passes)` だけ。 `.find()` / `unordered_map` / `std::string` は 0 個
+- `CompiledPass` 内に解決済 VkHandle / index / push constant offset のみ。 attachment 名 / pass 名 / shader 名は文字列としては保持しない (debug_name は static literal の `const char*` のみ、 hot path で読まない)
+- `descriptor_sets_storage` は init 時に一括 allocate (pool フラグメント抑止)、 `input_sets` は span でなく 4 要素固定配列 (flight_count ≤ 4 を上限とする)
+- profile 切替 / swapchain resize 時のみ `compile()` を再実行 (init 1 回方針)
+
+これで `RenderPassScheduler::execute()` の per-frame 計算量は「pass 数 × 各 vkCmd* 呼出」 のみ、 余分な間接参照ゼロ ([[feedback_pictor_dod_layout]])。
 
 ## 4. C++ 側のリファクタリング順
 
@@ -226,17 +318,24 @@ public:
 
 検証: 既存 KS が無改変で起動できる。プロファイルに `render_passes[]` を書くと、その通りの順序で VkRenderPass が生成される。
 
-### 4.3 ステップ C: RenderPassScheduler::execute() を実描画化
+### 4.3 ステップ C: PipelineCompiler + RenderPassScheduler::execute() を実描画化
 
-- 各 case の中身を実装:
-  - `OPAQUE` / `TRANSPARENT` / `DEPTH_ONLY` / `SHADOW`: framebuffer + render pass 引いて `vkCmdBeginRenderPass` → batch を `vkCmdDraw*` (RenderBatch ベース)
-  - `POST_PROCESS`: 既存 `PostProcessPipeline::record` を chain ベースで呼ぶ (互換維持)
-  - `COMPUTE`: Phase 3 では `vkCmdDispatch` のみ、descriptor 系は Phase 4
-  - `CUSTOM`: 既存 `ICustomRenderPass::execute()` 呼出を維持
-- `input_textures[]` は descriptor set 0 の binding 0..N に sampled image として bind (固定 layout、Phase 4 で柔軟化)
-- `shader_override` が "none" 以外なら `ShaderRegistry::pipeline(handle)` を bind
+- `PipelineCompiler::compile()` を新設 (§3.5)。 起動時 / プロファイル切替 / swapchain resize で 1 回だけ呼ぶ。 `profile.render_passes[]` を全 string 解決して `CompiledGraph` (`std::vector<CompiledPass>`) へ畳み込む。
+- `RenderPassScheduler` は `CompiledGraph` を保持し、 `execute(cmd)` は **フラットイテレートのみ**:
+  - `vkCmdBindDescriptorSets(... cp.input_sets[flight] ...)` (pre-built set)
+  - `vkCmdBeginRenderPass(cmd, &cp.rp_begin[image_index|flight] ...)`
+  - `if (cp.pipeline) vkCmdBindPipeline(...)` (compile 時に NULL なら pass_type 既定パイプラインを scheduler が default として持つ)
+  - `vkCmdDispatch` or `record_batches(cmd, cp.filter_mask, cp.sort_mode)` を pass_type で分岐 (`switch` 1 個、 hot path で 1 fn ptr ジャンプ程度)
+  - `vkCmdEndRenderPass(cmd)`
+- pass_type ごとの記録経路:
+  - `OPAQUE` / `TRANSPARENT` / `DEPTH_ONLY` / `SHADOW`: `record_batches` が RenderBatch を `vkCmdDraw*` でフラッシュ
+  - `POST_PROCESS`: pass_type は CompiledPass にすでに反映済。 既存 `PostProcessPipeline` の chain 経路を CompiledPass.pipeline + framebuffer で駆動 (互換維持)
+  - `COMPUTE`: `vkCmdDispatch(cmd, group_x, group_y, group_z)`、 dispatch サイズは CompiledPass に pre-resolve
+  - `CUSTOM`: `ICustomRenderPass*` を CompiledPass に pre-resolve しておき `cp.custom->execute(cmd, frame_ctx)`
+- `input_textures[]` は compile 時に **per-flight VkDescriptorSet を一括 build**。 hot path は `cp.input_sets[flight]` を bind するだけ。 layout は 1 種類 (sampled image 0..N) を共有
+- `shader_override` は compile 時に `ShaderRegistry::pipeline(handle)` 解決 → `cp.pipeline` に直値
 
-検証: KS が無改変で起動でき、フレーム出力が従来と pixel-equivalent。`*.profile.json` で pass 順を入れ替えると実描画も追従する。
+検証: KS が無改変で起動でき、 フレーム出力が従来と pixel-equivalent。 プロファイル切替で compile が走り直して flat graph が差し替わる。 hot path に string lookup が 0 個であること (perfetto trace で `std::string`/`unordered_map` シンボルが per-frame に出ないことを確認)。
 
 ### 4.4 ステップ D: 既存呼び出し側の整理
 
@@ -267,14 +366,18 @@ public:
 - **統合**: 既存 `tests/unit_pipeline_profile_round_trip_test.cpp` に attachments[] + attachment_ops[] を含むケース追加
 - **ホスト**: KS が無改変で起動 + Custos でフレーム比較。プロファイル切替 ("standard" → "high" 等) で attachments 差分が反映されることを確認
 
-## 8. Ergo plugin 側の編集 UI 拡張
+## 8. Ergo plugin 側の編集 UI
 
-`tools/ergo/src/plugins/render_pipeline/` の Profile Editor を v2 スキーマに対応させる。詳細は Ergo 側 `spec/tool/render_pipeline.md` §「Profile Editor v2 (Phase 3)」を参照。
+Phase 3 では系統B (実 VkRenderPass チェーン) を解体し JSON 駆動にするため、 **Pictor のソースを静的 scan する意味が無くなる**。 Ergo の Scanner モード (Python regex + `scanner/render_pipeline.json`) は **削除**。 Profile が single source of truth。
 
-主な追加 UI:
-- Attachments タブ (現状の Scanner ビューの Attachments タブとは別に、Profile Editor 側にも attachments 編集を置く)
-- 各 RenderPass エントリに attachment_ops のグリッド (load/store/initial/final layout、render_targets と連動)
-- attachment 名のオートコンプリート (Profile 内宣言済の attachment 名 + 予約名 swapchain)
+Profile Editor / Timeline / DAG は **単一のグラフエディタ画面に統合**する:
+- ノード = `render_passes[]` の各 pass
+- ノード端子 = pass の `render_targets` (出力) / `input_textures` (入力)
+- エッジ = attachment 名で接続 (drag-to-connect で attachment 経由の依存を貼る)
+- timing (Phase 2 §6.1) は同グラフへ overlay 色 / バー (`{op:"timing"}` を受けたら各ノードを着色)
+- アニメーションは無効 (`physics: false` / `smooth: false`、 ノードは静的レイアウト)
+
+詳細は Ergo 側 `spec/tool/render_pipeline_system_b.md` を参照。
 
 ## 9. KS 側の対応
 
@@ -284,8 +387,8 @@ KS は本書の対象外だが、ステップ D で `data/render/kuzu.profile.js
 
 ## 10. 実装スコープ見積もり
 
-- Pictor 側: 新規ヘッダ 4 (`attachment_def.h` / `attachment_registry.h` / `render_pass_registry.h` / `framebuffer_registry.h`) + 実装 4 + 既存 `vulkan_context.cpp` / `render_pass_scheduler.cpp` / `pipeline_profile.h` / `pipeline_profile_serializer.cpp` の改修。新規 CTest 4 ファイル。
-- Ergo 側: `profile_schema.ts` を v2 化 (attachments[] + attachment_ops[]) + Profile Editor UI に Attachments タブ + 各 pass の attachment_ops グリッド。
+- Pictor 側: 新規ヘッダ 5 (`attachment_def.h` / `attachment_registry.h` / `render_pass_registry.h` / `framebuffer_registry.h` / `pipeline_compiler.h`) + 実装 5 + 既存 `vulkan_context.cpp` / `render_pass_scheduler.cpp` / `pipeline_profile.h` / `pipeline_profile_serializer.cpp` の改修。新規 CTest 5 ファイル (compiler の不変条件テスト含む — hot path に string 系シンボルが出ないことを check)。
+- Ergo 側: scanner 削除 (`scanner/render_pipeline_scan.py` / `scanner/render_pipeline.json`)、 plugin を「単一グラフエディタ」 に再構築 (`profile_schema.ts` を v2 化 + DAG ↔ ノード ↔ Profile の単一データ源)、 アニメ無効化。
 - KS 側: `data/render/kuzu.profile.json` の attachments[] 明示化 + `spec/rendering_overview.md` 追記 (別 PR)。
 
 ## 11. ブランチ + PR

--- a/spec/pipeline-system-b-config.md
+++ b/spec/pipeline-system-b-config.md
@@ -1,0 +1,295 @@
+# Pipeline System-B Configuration (scene-side, Phase 3)
+
+設計書 — 2026-05-23 起草。系統B (実 `VkRenderPass` / framebuffer / attachment / draw 記録) の scene 側ハードコードを解体し、`*.profile.json` から駆動できるようにする。`spec/rendering-extensibility-design.md` §6.4 後継のフェーズ 3。
+
+post-process 側の系統B は Phase 2 §6.3 (`feat/postprocess-chain`) で既に汎用チェーン化済み。本書の対象は **scene render pass + 中間 attachment + scheduler execute()**。
+
+## 1. スコープと非スコープ
+
+### 1.1 対象 (Phase 3 で配線するもの)
+
+| 項目 | 現状 (Phase 2 終了時点) | Phase 3 のゴール |
+|------|------------------------|------------------|
+| scene render pass | `vulkan_context.cpp` の `create_render_pass()` で固定の HDR color + depth attachment + load=CLEAR / store=STORE をハードコード | `RenderPassConfig` (JSON) から attachment 列・load/store op・サブパス・依存を構築 |
+| swapchain render pass | 同上、固定の swapchain color + load=LOAD で hardcoded | 同上、別 `RenderPassConfig` で表現 |
+| 中間 attachment (`scene_hdr_color` / `scene_depth` / `swapchain`) | `swapchain.cpp` で作成、名前は文字列定数 (scanner からは見えるが C++ は文字列を共有していない) | `AttachmentRegistry` (JSON で宣言 + C++ で作成) で名前→`VkImage`/`VkImageView`/format/extent を引ける |
+| framebuffer | `swapchain.cpp` が swapchain 用、`postprocess_pipeline.cpp` が中間用と 2 系統に分散 | `FramebufferRegistry` 一本化、render pass 名 + attachment 名で resolve |
+| `RenderPassScheduler::execute()` | 各 `PassType` の case がコメントスタブ | `pass_name` で `RenderPassConfig` を引き、設定された `render_targets` の framebuffer に `vkCmdBeginRenderPass`、`input_textures` を descriptor に bind |
+| `shader_override` | `RenderPassDef` に格納されるが scheduler 未消費 | `ShaderRegistry::pipeline(handle)` を resolve して `vkCmdBindPipeline` |
+
+### 1.2 非スコープ (Phase 3 で触らない)
+
+- post-process 側系統B (Phase 2 §6.3 で完了)
+- draw 記録の中身そのもの (どのメッシュをどの順に描くか — `RenderBatch` 構築は KS の責務、Pictor 側は順序保証だけ)
+- SPIR-V reflection / シェーダ自動 introspection (`layout(location=N)` 不一致は validation layer 任せ、Phase 2 §6.2 同様)
+- dynamic rendering (`VK_KHR_dynamic_rendering`) への移行 — 現実装は VkRenderPass + Framebuffer ベース。将来別タスク
+- TAA history (Phase 2 §6.3 の積み残しと同じ — フレーム間生存 attachment の汎用化)
+- compute pipeline (`PassType::COMPUTE` の中身配線) — Phase 4
+
+## 2. アーキテクチャ全体図
+
+```
+*.profile.json
+  └─ attachments[]      ← 名前付き attachment 宣言 (format/usage/clear)
+  └─ render_passes[]    ← 既存 RenderPassDef を拡張 (load/store op を追加)
+  └─ framebuffers[]     ← (任意) 明示宣言。省略時は render pass + attachment 名から自動
+
+C++ 起動順:
+  1. PipelineProfileBuilder が attachments[] を AttachmentRegistry へ
+  2. VulkanContext::create_swapchain() の中で AttachmentRegistry が swapchain 画像を attach
+  3. VulkanContext::create_render_passes() が render_passes[] を回り
+     RenderPassConfig 毎に VkRenderPass を生成し RenderPassRegistry へ登録
+  4. FramebufferRegistry が render_passes[].render_targets + AttachmentRegistry から
+     framebuffer を作成 (swapchain は per-image)
+
+Per-frame (RenderPassScheduler::execute):
+  for pass in profile.render_passes:
+    rp = RenderPassRegistry.get(pass.pass_name)
+    fb = FramebufferRegistry.get(pass.pass_name, frame_index)
+    bind input_textures → descriptor
+    vkCmdBeginRenderPass(rp, fb, ...)
+    if pass.shader_override != "none":
+        vkCmdBindPipeline(ShaderRegistry.pipeline(pass.shader_override))
+    record_batches(pass.filter_mask)
+    vkCmdEndRenderPass
+```
+
+## 3. データモデル (C++ 側)
+
+### 3.1 `AttachmentDef` (新規、`include/pictor/pipeline/attachment_def.h`)
+
+```cpp
+enum class AttachmentKind : uint8_t {
+    COLOR,             // 通常 color
+    DEPTH,             // depth or depth-stencil
+    SWAPCHAIN_COLOR,   // 特別: ランタイムが swapchain image を inject
+};
+
+enum class AttachmentSizing : uint8_t {
+    SWAPCHAIN_RELATIVE,  // extent = swapchain_extent * scale
+    ABSOLUTE,            // extent = (width, height) 固定
+};
+
+struct AttachmentDef {
+    std::string      name;            // unique 名 ("scene_hdr_color" / "scene_depth" / "swapchain")
+    AttachmentKind   kind;
+    VkFormat         format;          // VK_FORMAT_R16G16B16A16_SFLOAT 等
+    AttachmentSizing sizing;
+    float            scale;           // SWAPCHAIN_RELATIVE 用 (既定 1.0)
+    uint32_t         width, height;   // ABSOLUTE 用
+    VkImageUsageFlags usage;          // COLOR_ATTACHMENT_BIT | SAMPLED_BIT 等
+    VkClearValue     clear_value;     // load_op=CLEAR 時の値
+};
+```
+
+JSON 表現:
+```json
+"attachments": [
+  {
+    "name": "scene_hdr_color",
+    "kind": "COLOR",
+    "format": "R16G16B16A16_SFLOAT",
+    "sizing": "SWAPCHAIN_RELATIVE",
+    "scale": 1.0,
+    "usage": ["COLOR_ATTACHMENT", "SAMPLED"],
+    "clear_color": [0.0, 0.0, 0.0, 1.0]
+  },
+  {
+    "name": "scene_depth",
+    "kind": "DEPTH",
+    "format": "D32_SFLOAT",
+    "sizing": "SWAPCHAIN_RELATIVE",
+    "scale": 1.0,
+    "usage": ["DEPTH_STENCIL_ATTACHMENT"],
+    "clear_depth": 1.0
+  },
+  {
+    "name": "swapchain",
+    "kind": "SWAPCHAIN_COLOR",
+    "format": "B8G8R8A8_SRGB",
+    "sizing": "SWAPCHAIN_RELATIVE",
+    "scale": 1.0,
+    "usage": ["COLOR_ATTACHMENT"]
+  }
+]
+```
+
+予約名は `swapchain` のみ (`SWAPCHAIN_COLOR` kind と対応、ランタイムが per-frame image を差し込む)。
+
+### 3.2 `RenderPassDef` 拡張 (`include/pictor/pipeline/pipeline_profile.h`)
+
+既存フィールド (`pass_name` / `pass_type` / `shader_override` / `render_targets` / `input_textures` / ...) を維持しつつ、以下を追加:
+
+```cpp
+struct AttachmentOps {
+    std::string       attachment_name;
+    VkAttachmentLoadOp  load_op   = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    VkAttachmentStoreOp store_op  = VK_ATTACHMENT_STORE_OP_STORE;
+    VkImageLayout     initial_layout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VkImageLayout     final_layout   = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+};
+
+struct RenderPassDef {
+    /* 既存フィールド ... */
+    std::vector<AttachmentOps> attachment_ops;  // render_targets と同サイズが期待
+    // attachment_ops が空なら render_targets だけから既定 (CLEAR/STORE) を推論
+};
+```
+
+JSON 拡張:
+```json
+{
+  "pass_name": "Scene HDR",
+  "pass_type": "OPAQUE",
+  "render_targets": ["scene_hdr_color", "scene_depth"],
+  "attachment_ops": [
+    {"attachment": "scene_hdr_color", "load": "CLEAR", "store": "STORE",
+     "initial_layout": "UNDEFINED", "final_layout": "SHADER_READ_ONLY_OPTIMAL"},
+    {"attachment": "scene_depth", "load": "CLEAR", "store": "DONT_CARE",
+     "initial_layout": "UNDEFINED", "final_layout": "DEPTH_STENCIL_ATTACHMENT_OPTIMAL"}
+  ],
+  "input_textures": [],
+  "shader_override": "none"
+}
+```
+
+`attachment_ops` 省略時は既定値で `render_targets` から推論 (color は CLEAR/STORE、depth は CLEAR/DONT_CARE、最終レイアウトは color=SAMPLED、depth=DSV)。後方互換のため。
+
+### 3.3 `AttachmentRegistry` (新規、`include/pictor/pipeline/attachment_registry.h`)
+
+```cpp
+class AttachmentRegistry {
+public:
+    void initialize(VkDevice device, const std::vector<AttachmentDef>& defs,
+                    VkExtent2D swapchain_extent, uint32_t flight_count);
+    void resize(VkExtent2D new_extent);
+    void shutdown();
+
+    // SWAPCHAIN_COLOR は per-image だが、それ以外は per-flight (or 単一)
+    VkImageView view(const std::string& name, uint32_t frame_index) const;
+    VkImage     image(const std::string& name, uint32_t frame_index) const;
+    VkFormat    format(const std::string& name) const;
+    VkExtent2D  extent(const std::string& name) const;
+    const AttachmentDef* find(const std::string& name) const;
+
+    // ランタイムが swapchain image を inject
+    void set_swapchain_images(std::span<const VkImage> images,
+                              std::span<const VkImageView> views,
+                              VkFormat format, VkExtent2D extent);
+};
+```
+
+per-flight (flight_count = 2~3) で多重化、`resize()` で extent 追従。SWAPCHAIN_COLOR だけは swapchain 側からの inject に従う (`VulkanContext::recreate_swapchain` から呼ぶ)。
+
+### 3.4 `RenderPassRegistry` / `FramebufferRegistry`
+
+```cpp
+class RenderPassRegistry {
+public:
+    void initialize(VkDevice device, const std::vector<RenderPassDef>& passes,
+                    const AttachmentRegistry& attachments);
+    VkRenderPass get(const std::string& pass_name) const;
+    void shutdown();
+};
+
+class FramebufferRegistry {
+public:
+    void initialize(VkDevice device, const std::vector<RenderPassDef>& passes,
+                    const RenderPassRegistry& rps,
+                    const AttachmentRegistry& attachments,
+                    uint32_t flight_count, uint32_t swapchain_image_count);
+    void resize(VkExtent2D new_extent);
+    // swapchain attachment を含む pass は per-swapchain-image、それ以外は per-flight
+    VkFramebuffer get(const std::string& pass_name, uint32_t frame_or_image_index) const;
+    void shutdown();
+};
+```
+
+両者は `AttachmentRegistry::resize()` 後に再構築。
+
+## 4. C++ 側のリファクタリング順
+
+### 4.1 ステップ A: AttachmentRegistry を導入 (互換維持)
+
+- `AttachmentDef` / `AttachmentRegistry` を新設
+- `VulkanContext` に `AttachmentRegistry attachments_` を追加
+- 既存 `scene_render_pass_` は AttachmentRegistry が **空でも** 作成できるよう、profile に attachments がない場合は既定 (`scene_hdr_color` + `scene_depth` + `swapchain`) を C++ 側でハードコード fallback
+- `PipelineProfileBuilder` が `AttachmentDef[]` ビルダーを提供
+
+検証: 既存 KS が無改変で起動できる。`*.profile.json` に attachments を書かなくても従来通り動く。
+
+### 4.2 ステップ B: RenderPassRegistry / FramebufferRegistry を導入
+
+- 既存 `vulkan_context.cpp` の `create_render_pass()` を `RenderPassRegistry::initialize()` に移植
+- 既存 `create_framebuffers()` を `FramebufferRegistry::initialize()` に移植
+- profile に `render_passes[]` がない場合のフォールバックとして「Scene HDR」「Swapchain Composite」 2 件を C++ 側で自動生成
+
+検証: 既存 KS が無改変で起動できる。プロファイルに `render_passes[]` を書くと、その通りの順序で VkRenderPass が生成される。
+
+### 4.3 ステップ C: RenderPassScheduler::execute() を実描画化
+
+- 各 case の中身を実装:
+  - `OPAQUE` / `TRANSPARENT` / `DEPTH_ONLY` / `SHADOW`: framebuffer + render pass 引いて `vkCmdBeginRenderPass` → batch を `vkCmdDraw*` (RenderBatch ベース)
+  - `POST_PROCESS`: 既存 `PostProcessPipeline::record` を chain ベースで呼ぶ (互換維持)
+  - `COMPUTE`: Phase 3 では `vkCmdDispatch` のみ、descriptor 系は Phase 4
+  - `CUSTOM`: 既存 `ICustomRenderPass::execute()` 呼出を維持
+- `input_textures[]` は descriptor set 0 の binding 0..N に sampled image として bind (固定 layout、Phase 4 で柔軟化)
+- `shader_override` が "none" 以外なら `ShaderRegistry::pipeline(handle)` を bind
+
+検証: KS が無改変で起動でき、フレーム出力が従来と pixel-equivalent。`*.profile.json` で pass 順を入れ替えると実描画も追従する。
+
+### 4.4 ステップ D: 既存呼び出し側の整理
+
+- `FrameComposer` を `RenderPassScheduler::execute()` 経由に統合 (HUD レイヤーは pass として scheduler 内に置く / または "post-scheduler hook" として残す)
+- KS の `GameRenderer` / `SkinnedLayer` / `PostProcessLayer` / `HudLayer` を pass 単位に整理 (大改修になるので KS 側は別 PR に分ける可能性)
+
+検証: KS 起動 + プロファイル差し替えでフレーム構成が変わる。
+
+## 5. JSON スキーマバージョン
+
+現行 v1 → v2。`version: 2` 以降で attachments / attachment_ops を消費。`version: 1` プロファイル (Phase 2 までに作った 5 プリセット) は loader 側で既定 attachments を補完して動かす。
+
+スキーマ正本: 本書 + `spec/pipeline-profile-config.md` の §3 を v2 で更新。
+
+## 6. リスクとフォールバック
+
+| リスク | 検知 | フォールバック |
+|--------|------|----------------|
+| attachment 名typo で resolve 失敗 | `RenderPassRegistry::initialize()` で fatal log + 既定 attachments で起動継続 | "scene_hdr_color" / "scene_depth" / "swapchain" の 3 名を built-in 既定として保持 |
+| `attachment_ops` 不整合 (subpass dep 違反) | validation layer エラー | デフォルト推論 (CLEAR/STORE + SHADER_READ_ONLY 最終) にフォールバック |
+| ステップ C の draw 記録パスが従来と差分 | KS で目視 + screenshot 比較 (Custos 連携) | ステップ B で stop、`feat/pipeline-system-b` を merge せず差分原因特定 |
+| 既存プロファイル (v1, attachments 未宣言) の互換切れ | loader が version 検出して既定補完 | v1 互換シム (4.1, 4.2 のフォールバック) |
+| resize で attachment 取りこぼし | swapchain recreate 時に AttachmentRegistry::resize → 全 framebuffer rebuild | C++ assertion で resize 失敗時は古い framebuffer を破棄しない (フレーム skip) |
+
+## 7. テスト計画
+
+- **CTest 単体**: `tests/unit_attachment_registry_test.cpp` (alloc / resize / swapchain inject)、`tests/unit_render_pass_registry_test.cpp` (config から VkRenderPass 生成、load/store op 反映)、`tests/unit_framebuffer_registry_test.cpp`、`tests/unit_pipeline_profile_serializer_test.cpp` 拡張 (v2 round-trip + v1 後方互換)
+- **統合**: 既存 `tests/unit_pipeline_profile_round_trip_test.cpp` に attachments[] + attachment_ops[] を含むケース追加
+- **ホスト**: KS が無改変で起動 + Custos でフレーム比較。プロファイル切替 ("standard" → "high" 等) で attachments 差分が反映されることを確認
+
+## 8. Ergo plugin 側の編集 UI 拡張
+
+`tools/ergo/src/plugins/render_pipeline/` の Profile Editor を v2 スキーマに対応させる。詳細は Ergo 側 `spec/tool/render_pipeline.md` §「Profile Editor v2 (Phase 3)」を参照。
+
+主な追加 UI:
+- Attachments タブ (現状の Scanner ビューの Attachments タブとは別に、Profile Editor 側にも attachments 編集を置く)
+- 各 RenderPass エントリに attachment_ops のグリッド (load/store/initial/final layout、render_targets と連動)
+- attachment 名のオートコンプリート (Profile 内宣言済の attachment 名 + 予約名 swapchain)
+
+## 9. KS 側の対応
+
+KS は本書の対象外だが、ステップ D で `data/render/kuzu.profile.json` に attachments[] と attachment_ops[] を追加する PR を別建てする。Pictor 側のフォールバック (4.1 / 4.2) があるので KS 側 PR は Pictor merge の後追いで OK。
+
+`spec/rendering_overview.md` に「Phase 3: scene-side 系統B」を追記 (KS 側 PR の中で)。
+
+## 10. 実装スコープ見積もり
+
+- Pictor 側: 新規ヘッダ 4 (`attachment_def.h` / `attachment_registry.h` / `render_pass_registry.h` / `framebuffer_registry.h`) + 実装 4 + 既存 `vulkan_context.cpp` / `render_pass_scheduler.cpp` / `pipeline_profile.h` / `pipeline_profile_serializer.cpp` の改修。新規 CTest 4 ファイル。
+- Ergo 側: `profile_schema.ts` を v2 化 (attachments[] + attachment_ops[]) + Profile Editor UI に Attachments タブ + 各 pass の attachment_ops グリッド。
+- KS 側: `data/render/kuzu.profile.json` の attachments[] 明示化 + `spec/rendering_overview.md` 追記 (別 PR)。
+
+## 11. ブランチ + PR
+
+- Pictor: `feat/pipeline-system-b` (本書 + Phase 3 実装一式、1 PR)
+- Ergo: `feat/render-pipeline-system-b` (Profile Editor v2 + scanner v2 schema 認識、1 PR)
+- KS: 後追いで別 PR

--- a/src/pipeline/attachment_def.cpp
+++ b/src/pipeline/attachment_def.cpp
@@ -1,0 +1,245 @@
+#include "pictor/pipeline/attachment_def.h"
+
+#include <algorithm>
+
+namespace pictor {
+
+// ============================================================
+// to_string
+// ============================================================
+
+const char* to_string(AttachmentKind k) {
+    switch (k) {
+        case AttachmentKind::COLOR:           return "COLOR";
+        case AttachmentKind::DEPTH:           return "DEPTH";
+        case AttachmentKind::SWAPCHAIN_COLOR: return "SWAPCHAIN_COLOR";
+    }
+    return "COLOR";
+}
+
+const char* to_string(AttachmentSizing s) {
+    switch (s) {
+        case AttachmentSizing::SWAPCHAIN_RELATIVE: return "SWAPCHAIN_RELATIVE";
+        case AttachmentSizing::ABSOLUTE:           return "ABSOLUTE";
+    }
+    return "SWAPCHAIN_RELATIVE";
+}
+
+const char* to_string(AttachmentFormat f) {
+    switch (f) {
+        case AttachmentFormat::UNDEFINED:           return "UNDEFINED";
+        case AttachmentFormat::R8G8B8A8_UNORM:      return "R8G8B8A8_UNORM";
+        case AttachmentFormat::R8G8B8A8_SRGB:       return "R8G8B8A8_SRGB";
+        case AttachmentFormat::B8G8R8A8_UNORM:      return "B8G8R8A8_UNORM";
+        case AttachmentFormat::B8G8R8A8_SRGB:       return "B8G8R8A8_SRGB";
+        case AttachmentFormat::R16G16B16A16_SFLOAT: return "R16G16B16A16_SFLOAT";
+        case AttachmentFormat::R32G32B32A32_SFLOAT: return "R32G32B32A32_SFLOAT";
+        case AttachmentFormat::R11G11B10_UFLOAT:    return "R11G11B10_UFLOAT";
+        case AttachmentFormat::D16_UNORM:           return "D16_UNORM";
+        case AttachmentFormat::D24_UNORM_S8_UINT:   return "D24_UNORM_S8_UINT";
+        case AttachmentFormat::D32_SFLOAT:          return "D32_SFLOAT";
+        case AttachmentFormat::D32_SFLOAT_S8_UINT:  return "D32_SFLOAT_S8_UINT";
+    }
+    return "UNDEFINED";
+}
+
+const char* to_string(AttachmentLoadOp op) {
+    switch (op) {
+        case AttachmentLoadOp::LOAD:      return "LOAD";
+        case AttachmentLoadOp::CLEAR:     return "CLEAR";
+        case AttachmentLoadOp::DONT_CARE: return "DONT_CARE";
+        case AttachmentLoadOp::NONE:      return "NONE";
+    }
+    return "CLEAR";
+}
+
+const char* to_string(AttachmentStoreOp op) {
+    switch (op) {
+        case AttachmentStoreOp::STORE:     return "STORE";
+        case AttachmentStoreOp::DONT_CARE: return "DONT_CARE";
+        case AttachmentStoreOp::NONE:      return "NONE";
+    }
+    return "STORE";
+}
+
+const char* to_string(ImageLayout l) {
+    switch (l) {
+        case ImageLayout::UNDEFINED:                        return "UNDEFINED";
+        case ImageLayout::GENERAL:                          return "GENERAL";
+        case ImageLayout::COLOR_ATTACHMENT_OPTIMAL:         return "COLOR_ATTACHMENT_OPTIMAL";
+        case ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL: return "DEPTH_STENCIL_ATTACHMENT_OPTIMAL";
+        case ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL:  return "DEPTH_STENCIL_READ_ONLY_OPTIMAL";
+        case ImageLayout::SHADER_READ_ONLY_OPTIMAL:         return "SHADER_READ_ONLY_OPTIMAL";
+        case ImageLayout::TRANSFER_SRC_OPTIMAL:             return "TRANSFER_SRC_OPTIMAL";
+        case ImageLayout::TRANSFER_DST_OPTIMAL:             return "TRANSFER_DST_OPTIMAL";
+        case ImageLayout::PRESENT_SRC_KHR:                  return "PRESENT_SRC_KHR";
+    }
+    return "UNDEFINED";
+}
+
+// ============================================================
+// parse — case sensitive (canonical spelling only)
+// ============================================================
+
+namespace {
+bool eq(std::string_view s, const char* lit) {
+    return s == std::string_view(lit);
+}
+} // namespace
+
+bool parse_attachment_kind(std::string_view s, AttachmentKind& out) {
+    if (eq(s, "COLOR"))           { out = AttachmentKind::COLOR;           return true; }
+    if (eq(s, "DEPTH"))           { out = AttachmentKind::DEPTH;           return true; }
+    if (eq(s, "SWAPCHAIN_COLOR")) { out = AttachmentKind::SWAPCHAIN_COLOR; return true; }
+    return false;
+}
+
+bool parse_attachment_sizing(std::string_view s, AttachmentSizing& out) {
+    if (eq(s, "SWAPCHAIN_RELATIVE")) { out = AttachmentSizing::SWAPCHAIN_RELATIVE; return true; }
+    if (eq(s, "ABSOLUTE"))           { out = AttachmentSizing::ABSOLUTE;           return true; }
+    return false;
+}
+
+bool parse_attachment_format(std::string_view s, AttachmentFormat& out) {
+    if (eq(s, "UNDEFINED"))           { out = AttachmentFormat::UNDEFINED;           return true; }
+    if (eq(s, "R8G8B8A8_UNORM"))      { out = AttachmentFormat::R8G8B8A8_UNORM;      return true; }
+    if (eq(s, "R8G8B8A8_SRGB"))       { out = AttachmentFormat::R8G8B8A8_SRGB;       return true; }
+    if (eq(s, "B8G8R8A8_UNORM"))      { out = AttachmentFormat::B8G8R8A8_UNORM;      return true; }
+    if (eq(s, "B8G8R8A8_SRGB"))       { out = AttachmentFormat::B8G8R8A8_SRGB;       return true; }
+    if (eq(s, "R16G16B16A16_SFLOAT")) { out = AttachmentFormat::R16G16B16A16_SFLOAT; return true; }
+    if (eq(s, "R32G32B32A32_SFLOAT")) { out = AttachmentFormat::R32G32B32A32_SFLOAT; return true; }
+    if (eq(s, "R11G11B10_UFLOAT"))    { out = AttachmentFormat::R11G11B10_UFLOAT;    return true; }
+    if (eq(s, "D16_UNORM"))           { out = AttachmentFormat::D16_UNORM;           return true; }
+    if (eq(s, "D24_UNORM_S8_UINT"))   { out = AttachmentFormat::D24_UNORM_S8_UINT;   return true; }
+    if (eq(s, "D32_SFLOAT"))          { out = AttachmentFormat::D32_SFLOAT;          return true; }
+    if (eq(s, "D32_SFLOAT_S8_UINT"))  { out = AttachmentFormat::D32_SFLOAT_S8_UINT;  return true; }
+    return false;
+}
+
+bool parse_attachment_load_op(std::string_view s, AttachmentLoadOp& out) {
+    if (eq(s, "LOAD"))      { out = AttachmentLoadOp::LOAD;      return true; }
+    if (eq(s, "CLEAR"))     { out = AttachmentLoadOp::CLEAR;     return true; }
+    if (eq(s, "DONT_CARE")) { out = AttachmentLoadOp::DONT_CARE; return true; }
+    if (eq(s, "NONE"))      { out = AttachmentLoadOp::NONE;      return true; }
+    return false;
+}
+
+bool parse_attachment_store_op(std::string_view s, AttachmentStoreOp& out) {
+    if (eq(s, "STORE"))     { out = AttachmentStoreOp::STORE;     return true; }
+    if (eq(s, "DONT_CARE")) { out = AttachmentStoreOp::DONT_CARE; return true; }
+    if (eq(s, "NONE"))      { out = AttachmentStoreOp::NONE;      return true; }
+    return false;
+}
+
+bool parse_image_layout(std::string_view s, ImageLayout& out) {
+    if (eq(s, "UNDEFINED"))                        { out = ImageLayout::UNDEFINED;                        return true; }
+    if (eq(s, "GENERAL"))                          { out = ImageLayout::GENERAL;                          return true; }
+    if (eq(s, "COLOR_ATTACHMENT_OPTIMAL"))         { out = ImageLayout::COLOR_ATTACHMENT_OPTIMAL;         return true; }
+    if (eq(s, "DEPTH_STENCIL_ATTACHMENT_OPTIMAL")) { out = ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL; return true; }
+    if (eq(s, "DEPTH_STENCIL_READ_ONLY_OPTIMAL"))  { out = ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL;  return true; }
+    if (eq(s, "SHADER_READ_ONLY_OPTIMAL"))         { out = ImageLayout::SHADER_READ_ONLY_OPTIMAL;         return true; }
+    if (eq(s, "TRANSFER_SRC_OPTIMAL"))             { out = ImageLayout::TRANSFER_SRC_OPTIMAL;             return true; }
+    if (eq(s, "TRANSFER_DST_OPTIMAL"))             { out = ImageLayout::TRANSFER_DST_OPTIMAL;             return true; }
+    if (eq(s, "PRESENT_SRC_KHR"))                  { out = ImageLayout::PRESENT_SRC_KHR;                  return true; }
+    return false;
+}
+
+// ============================================================
+// Predicates
+// ============================================================
+
+bool is_depth_format(AttachmentFormat f) {
+    switch (f) {
+        case AttachmentFormat::D16_UNORM:
+        case AttachmentFormat::D24_UNORM_S8_UINT:
+        case AttachmentFormat::D32_SFLOAT:
+        case AttachmentFormat::D32_SFLOAT_S8_UINT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool is_valid_format(AttachmentFormat f) {
+    return f != AttachmentFormat::UNDEFINED;
+}
+
+// ============================================================
+// Default tables — kept in sync with Ergo `default_attachments.ts`
+// (any change here MUST be mirrored there).
+// ============================================================
+
+std::array<AttachmentDef, 3> default_attachments() {
+    AttachmentDef hdr_color;
+    hdr_color.name   = "scene_hdr_color";
+    hdr_color.kind   = AttachmentKind::COLOR;
+    hdr_color.format = AttachmentFormat::R16G16B16A16_SFLOAT;
+    hdr_color.sizing = AttachmentSizing::SWAPCHAIN_RELATIVE;
+    hdr_color.scale  = 1.0f;
+    hdr_color.usage  = USAGE_COLOR_ATTACHMENT | USAGE_SAMPLED;
+    hdr_color.clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+
+    AttachmentDef depth;
+    depth.name   = "scene_depth";
+    depth.kind   = AttachmentKind::DEPTH;
+    depth.format = AttachmentFormat::D32_SFLOAT;
+    depth.sizing = AttachmentSizing::SWAPCHAIN_RELATIVE;
+    depth.scale  = 1.0f;
+    depth.usage  = USAGE_DEPTH_STENCIL_ATTACHMENT;
+    depth.clear_depth   = 1.0f;
+    depth.clear_stencil = 0;
+
+    AttachmentDef swap;
+    swap.name   = "swapchain";
+    swap.kind   = AttachmentKind::SWAPCHAIN_COLOR;
+    swap.format = AttachmentFormat::B8G8R8A8_SRGB; // overwritten at runtime
+    swap.sizing = AttachmentSizing::SWAPCHAIN_RELATIVE;
+    swap.scale  = 1.0f;
+    swap.usage  = USAGE_COLOR_ATTACHMENT;
+    swap.clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
+
+    return { hdr_color, depth, swap };
+}
+
+std::vector<AttachmentOpsDef> default_attachment_ops(
+        const std::vector<std::string>& targets,
+        const std::vector<AttachmentDef>& attachments)
+{
+    std::vector<AttachmentOpsDef> ops;
+    ops.reserve(targets.size());
+
+    for (const auto& tgt : targets) {
+        AttachmentOpsDef op;
+        op.attachment_name = tgt;
+
+        // Look up the def to choose layout defaults.
+        const AttachmentDef* def = nullptr;
+        for (const auto& a : attachments) {
+            if (a.name == tgt) { def = &a; break; }
+        }
+
+        if (def && def->kind == AttachmentKind::DEPTH) {
+            op.load_op        = AttachmentLoadOp::CLEAR;
+            op.store_op       = AttachmentStoreOp::DONT_CARE;
+            op.initial_layout = ImageLayout::UNDEFINED;
+            op.final_layout   = ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        } else if (def && def->kind == AttachmentKind::SWAPCHAIN_COLOR) {
+            op.load_op        = AttachmentLoadOp::CLEAR;
+            op.store_op       = AttachmentStoreOp::STORE;
+            op.initial_layout = ImageLayout::UNDEFINED;
+            op.final_layout   = ImageLayout::PRESENT_SRC_KHR;
+        } else {
+            // COLOR (or unknown — treat as color)
+            op.load_op        = AttachmentLoadOp::CLEAR;
+            op.store_op       = AttachmentStoreOp::STORE;
+            op.initial_layout = ImageLayout::UNDEFINED;
+            op.final_layout   = ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+        }
+
+        ops.push_back(std::move(op));
+    }
+
+    return ops;
+}
+
+} // namespace pictor

--- a/src/pipeline/attachment_registry.cpp
+++ b/src/pipeline/attachment_registry.cpp
@@ -1,0 +1,353 @@
+#include "pictor/pipeline/attachment_registry.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace pictor {
+
+// ============================================================
+// Vulkan-free portion (always built)
+// ============================================================
+
+AttachmentRegistry::AttachmentRegistry() = default;
+
+AttachmentRegistry::~AttachmentRegistry() {
+#ifdef PICTOR_HAS_VULKAN
+    shutdown_vulkan();
+#endif
+}
+
+void AttachmentRegistry::set_defs(std::span<const AttachmentDef> defs) {
+    defs_.assign(defs.begin(), defs.end());
+#ifdef PICTOR_HAS_VULKAN
+    // Resources are stale — must call initialize_vulkan() again before use.
+    if (!resources_.empty()) {
+        shutdown_vulkan();
+    }
+#endif
+}
+
+uint16_t AttachmentRegistry::index_of(std::string_view name) const {
+    for (size_t i = 0; i < defs_.size(); ++i) {
+        if (defs_[i].name == name) {
+            return static_cast<uint16_t>(i);
+        }
+    }
+    return INVALID_INDEX;
+}
+
+#ifdef PICTOR_HAS_VULKAN
+
+// ============================================================
+// Vulkan format / layout / op translation
+// ============================================================
+
+VkFormat to_vk_format(AttachmentFormat f) {
+    switch (f) {
+        case AttachmentFormat::UNDEFINED:           return VK_FORMAT_UNDEFINED;
+        case AttachmentFormat::R8G8B8A8_UNORM:      return VK_FORMAT_R8G8B8A8_UNORM;
+        case AttachmentFormat::R8G8B8A8_SRGB:       return VK_FORMAT_R8G8B8A8_SRGB;
+        case AttachmentFormat::B8G8R8A8_UNORM:      return VK_FORMAT_B8G8R8A8_UNORM;
+        case AttachmentFormat::B8G8R8A8_SRGB:       return VK_FORMAT_B8G8R8A8_SRGB;
+        case AttachmentFormat::R16G16B16A16_SFLOAT: return VK_FORMAT_R16G16B16A16_SFLOAT;
+        case AttachmentFormat::R32G32B32A32_SFLOAT: return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case AttachmentFormat::R11G11B10_UFLOAT:    return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+        case AttachmentFormat::D16_UNORM:           return VK_FORMAT_D16_UNORM;
+        case AttachmentFormat::D24_UNORM_S8_UINT:   return VK_FORMAT_D24_UNORM_S8_UINT;
+        case AttachmentFormat::D32_SFLOAT:          return VK_FORMAT_D32_SFLOAT;
+        case AttachmentFormat::D32_SFLOAT_S8_UINT:  return VK_FORMAT_D32_SFLOAT_S8_UINT;
+    }
+    return VK_FORMAT_UNDEFINED;
+}
+
+VkImageUsageFlags to_vk_usage(uint32_t mask) {
+    VkImageUsageFlags v = 0;
+    if (mask & USAGE_TRANSFER_SRC)              v |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    if (mask & USAGE_TRANSFER_DST)              v |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    if (mask & USAGE_SAMPLED)                   v |= VK_IMAGE_USAGE_SAMPLED_BIT;
+    if (mask & USAGE_STORAGE)                   v |= VK_IMAGE_USAGE_STORAGE_BIT;
+    if (mask & USAGE_COLOR_ATTACHMENT)          v |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    if (mask & USAGE_DEPTH_STENCIL_ATTACHMENT)  v |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    if (mask & USAGE_TRANSIENT_ATTACHMENT)      v |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+    if (mask & USAGE_INPUT_ATTACHMENT)          v |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+    return v;
+}
+
+VkAttachmentLoadOp to_vk_load_op(AttachmentLoadOp op) {
+    switch (op) {
+        case AttachmentLoadOp::LOAD:      return VK_ATTACHMENT_LOAD_OP_LOAD;
+        case AttachmentLoadOp::CLEAR:     return VK_ATTACHMENT_LOAD_OP_CLEAR;
+        case AttachmentLoadOp::DONT_CARE: return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        case AttachmentLoadOp::NONE:      return VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    }
+    return VK_ATTACHMENT_LOAD_OP_CLEAR;
+}
+
+VkAttachmentStoreOp to_vk_store_op(AttachmentStoreOp op) {
+    switch (op) {
+        case AttachmentStoreOp::STORE:     return VK_ATTACHMENT_STORE_OP_STORE;
+        case AttachmentStoreOp::DONT_CARE: return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        case AttachmentStoreOp::NONE:      return VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    }
+    return VK_ATTACHMENT_STORE_OP_STORE;
+}
+
+VkImageLayout to_vk_layout(ImageLayout l) {
+    switch (l) {
+        case ImageLayout::UNDEFINED:                        return VK_IMAGE_LAYOUT_UNDEFINED;
+        case ImageLayout::GENERAL:                          return VK_IMAGE_LAYOUT_GENERAL;
+        case ImageLayout::COLOR_ATTACHMENT_OPTIMAL:         return VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        case ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL: return VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+        case ImageLayout::DEPTH_STENCIL_READ_ONLY_OPTIMAL:  return VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+        case ImageLayout::SHADER_READ_ONLY_OPTIMAL:         return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+        case ImageLayout::TRANSFER_SRC_OPTIMAL:             return VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        case ImageLayout::TRANSFER_DST_OPTIMAL:             return VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        case ImageLayout::PRESENT_SRC_KHR:                  return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    }
+    return VK_IMAGE_LAYOUT_UNDEFINED;
+}
+
+// ============================================================
+// GPU resource lifecycle
+// ============================================================
+
+namespace {
+
+uint32_t find_memory_type(VkPhysicalDevice phys, uint32_t type_bits,
+                          VkMemoryPropertyFlags want) {
+    VkPhysicalDeviceMemoryProperties mp{};
+    vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+    for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+        if ((type_bits & (1u << i)) &&
+            (mp.memoryTypes[i].propertyFlags & want) == want) {
+            return i;
+        }
+    }
+    return UINT32_MAX;
+}
+
+VkExtent2D resolve_extent(const AttachmentDef& d, VkExtent2D swap) {
+    if (d.sizing == AttachmentSizing::SWAPCHAIN_RELATIVE) {
+        VkExtent2D e;
+        e.width  = static_cast<uint32_t>(static_cast<float>(swap.width)  * d.scale);
+        e.height = static_cast<uint32_t>(static_cast<float>(swap.height) * d.scale);
+        if (e.width  == 0) e.width  = 1;
+        if (e.height == 0) e.height = 1;
+        return e;
+    }
+    return { d.width, d.height };
+}
+
+VkImageAspectFlags aspect_of(const AttachmentDef& d) {
+    if (is_depth_format(d.format)) {
+        VkImageAspectFlags a = VK_IMAGE_ASPECT_DEPTH_BIT;
+        if (d.format == AttachmentFormat::D24_UNORM_S8_UINT ||
+            d.format == AttachmentFormat::D32_SFLOAT_S8_UINT) {
+            a |= VK_IMAGE_ASPECT_STENCIL_BIT;
+        }
+        return a;
+    }
+    return VK_IMAGE_ASPECT_COLOR_BIT;
+}
+
+} // anon
+
+bool AttachmentRegistry::create_one_(uint16_t index, VkExtent2D swap_extent) {
+    const AttachmentDef& d = defs_[index];
+    Resource& r = resources_[index];
+
+    if (d.kind == AttachmentKind::SWAPCHAIN_COLOR) {
+        // Owned by VulkanContext — populated via set_swapchain_images().
+        r.is_swapchain = true;
+        r.vk_format    = to_vk_format(d.format);
+        r.extent       = swap_extent;
+        return true;
+    }
+
+    r.is_swapchain = false;
+    r.vk_format    = to_vk_format(d.format);
+    r.extent       = resolve_extent(d, swap_extent);
+
+    const uint32_t slots = flight_count_;
+    r.images.assign(slots, VK_NULL_HANDLE);
+    r.views.assign(slots, VK_NULL_HANDLE);
+    r.memories.assign(slots, VK_NULL_HANDLE);
+
+    for (uint32_t i = 0; i < slots; ++i) {
+        VkImageCreateInfo ic{};
+        ic.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+        ic.imageType     = VK_IMAGE_TYPE_2D;
+        ic.format        = r.vk_format;
+        ic.extent        = { r.extent.width, r.extent.height, 1 };
+        ic.mipLevels     = 1;
+        ic.arrayLayers   = 1;
+        ic.samples       = VK_SAMPLE_COUNT_1_BIT;
+        ic.tiling        = VK_IMAGE_TILING_OPTIMAL;
+        ic.usage         = to_vk_usage(d.usage);
+        ic.sharingMode   = VK_SHARING_MODE_EXCLUSIVE;
+        ic.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+        if (vkCreateImage(device_, &ic, nullptr, &r.images[i]) != VK_SUCCESS) {
+            std::fprintf(stderr, "[AttachmentRegistry] vkCreateImage failed (%s slot %u)\n",
+                         d.name.c_str(), i);
+            return false;
+        }
+
+        VkMemoryRequirements mreq{};
+        vkGetImageMemoryRequirements(device_, r.images[i], &mreq);
+        VkMemoryAllocateInfo ai{};
+        ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        ai.allocationSize  = mreq.size;
+        ai.memoryTypeIndex = find_memory_type(physical_device_, mreq.memoryTypeBits,
+                                              VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        if (ai.memoryTypeIndex == UINT32_MAX) {
+            std::fprintf(stderr, "[AttachmentRegistry] no device-local memory type\n");
+            return false;
+        }
+        if (vkAllocateMemory(device_, &ai, nullptr, &r.memories[i]) != VK_SUCCESS) {
+            std::fprintf(stderr, "[AttachmentRegistry] vkAllocateMemory failed\n");
+            return false;
+        }
+        vkBindImageMemory(device_, r.images[i], r.memories[i], 0);
+
+        VkImageViewCreateInfo iv{};
+        iv.sType                           = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        iv.image                           = r.images[i];
+        iv.viewType                        = VK_IMAGE_VIEW_TYPE_2D;
+        iv.format                          = r.vk_format;
+        iv.subresourceRange.aspectMask     = aspect_of(d);
+        iv.subresourceRange.baseMipLevel   = 0;
+        iv.subresourceRange.levelCount     = 1;
+        iv.subresourceRange.baseArrayLayer = 0;
+        iv.subresourceRange.layerCount     = 1;
+
+        if (vkCreateImageView(device_, &iv, nullptr, &r.views[i]) != VK_SUCCESS) {
+            std::fprintf(stderr, "[AttachmentRegistry] vkCreateImageView failed\n");
+            return false;
+        }
+    }
+    return true;
+}
+
+void AttachmentRegistry::destroy_one_(Resource& r) {
+    if (r.is_swapchain) {
+        // Not owned — VulkanContext owns swapchain images/views.
+        r.images.clear();
+        r.views.clear();
+        r.memories.clear();
+        return;
+    }
+    for (size_t i = 0; i < r.views.size(); ++i) {
+        if (r.views[i]) vkDestroyImageView(device_, r.views[i], nullptr);
+    }
+    for (size_t i = 0; i < r.images.size(); ++i) {
+        if (r.images[i]) vkDestroyImage(device_, r.images[i], nullptr);
+    }
+    for (size_t i = 0; i < r.memories.size(); ++i) {
+        if (r.memories[i]) vkFreeMemory(device_, r.memories[i], nullptr);
+    }
+    r.views.clear();
+    r.images.clear();
+    r.memories.clear();
+}
+
+bool AttachmentRegistry::initialize_vulkan(VkPhysicalDevice physical_device,
+                                           VkDevice         device,
+                                           VkExtent2D       swapchain_extent,
+                                           uint32_t         flight_count)
+{
+    physical_device_  = physical_device;
+    device_           = device;
+    current_extent_   = swapchain_extent;
+    flight_count_     = std::min(flight_count, MAX_FLIGHTS);
+    swapchain_image_count_ = 0; // populated by set_swapchain_images()
+
+    resources_.clear();
+    resources_.resize(defs_.size());
+
+    for (uint16_t i = 0; i < static_cast<uint16_t>(defs_.size()); ++i) {
+        if (!create_one_(i, swapchain_extent)) return false;
+    }
+    return true;
+}
+
+bool AttachmentRegistry::resize(VkExtent2D new_extent) {
+    if (!device_) return false;
+    if (new_extent.width == current_extent_.width && new_extent.height == current_extent_.height) {
+        return true;
+    }
+
+    // Destroy all non-swapchain images and recreate at new extent.
+    for (size_t i = 0; i < resources_.size(); ++i) {
+        if (!resources_[i].is_swapchain) {
+            destroy_one_(resources_[i]);
+        }
+    }
+    current_extent_ = new_extent;
+    for (uint16_t i = 0; i < static_cast<uint16_t>(defs_.size()); ++i) {
+        if (!resources_[i].is_swapchain) {
+            if (!create_one_(i, new_extent)) return false;
+        } else {
+            // Swapchain entries: clear handles, host re-injects.
+            resources_[i].images.clear();
+            resources_[i].views.clear();
+            resources_[i].extent = new_extent;
+        }
+    }
+    return true;
+}
+
+void AttachmentRegistry::set_swapchain_images(std::span<const VkImage>     images,
+                                              std::span<const VkImageView> views,
+                                              VkFormat                     format,
+                                              VkExtent2D                   extent)
+{
+    swapchain_image_count_ = static_cast<uint32_t>(images.size());
+    for (size_t i = 0; i < resources_.size(); ++i) {
+        if (!resources_[i].is_swapchain) continue;
+        resources_[i].images.assign(images.begin(), images.end());
+        resources_[i].views.assign(views.begin(), views.end());
+        resources_[i].vk_format = format;
+        resources_[i].extent    = extent;
+    }
+}
+
+void AttachmentRegistry::shutdown_vulkan() {
+    if (!device_) {
+        resources_.clear();
+        return;
+    }
+    for (auto& r : resources_) destroy_one_(r);
+    resources_.clear();
+    device_ = VK_NULL_HANDLE;
+    physical_device_ = VK_NULL_HANDLE;
+}
+
+VkImageView AttachmentRegistry::view(uint16_t att_index, uint32_t slot) const {
+    const Resource& r = resources_[att_index];
+    if (slot >= r.views.size()) return VK_NULL_HANDLE;
+    return r.views[slot];
+}
+
+VkImage AttachmentRegistry::image(uint16_t att_index, uint32_t slot) const {
+    const Resource& r = resources_[att_index];
+    if (slot >= r.images.size()) return VK_NULL_HANDLE;
+    return r.images[slot];
+}
+
+VkFormat AttachmentRegistry::vk_format(uint16_t att_index) const {
+    return resources_[att_index].vk_format;
+}
+
+VkExtent2D AttachmentRegistry::extent(uint16_t att_index) const {
+    return resources_[att_index].extent;
+}
+
+uint32_t AttachmentRegistry::slot_count(uint16_t att_index) const {
+    return static_cast<uint32_t>(resources_[att_index].images.size());
+}
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/src/pipeline/framebuffer_registry.cpp
+++ b/src/pipeline/framebuffer_registry.cpp
@@ -1,0 +1,178 @@
+#include "pictor/pipeline/framebuffer_registry.h"
+#include "pictor/pipeline/attachment_registry.h"
+#include "pictor/pipeline/render_pass_registry.h"
+
+#include <cstdio>
+
+namespace pictor {
+
+FramebufferRegistry::FramebufferRegistry() = default;
+
+FramebufferRegistry::~FramebufferRegistry() {
+#ifdef PICTOR_HAS_VULKAN
+    shutdown_vulkan();
+#endif
+}
+
+#ifdef PICTOR_HAS_VULKAN
+
+bool FramebufferRegistry::build_one_(uint16_t pass_index,
+                                      const AttachmentRegistry& atts,
+                                      const RenderPassRegistry& rps)
+{
+    const RenderPassDef& pd = rps.pass(pass_index);
+    PassEntry& e = entries_[pass_index];
+
+    // Look up attachment indices once.
+    std::vector<uint16_t> att_indices;
+    att_indices.reserve(pd.render_targets.size());
+    bool has_swapchain = false;
+    VkExtent2D pass_extent = {0, 0};
+
+    for (const std::string& tgt : pd.render_targets) {
+        uint16_t idx = atts.index_of(tgt);
+        if (idx == AttachmentRegistry::INVALID_INDEX) {
+            std::fprintf(stderr, "[FramebufferRegistry] pass '%s' refs unknown attachment '%s'\n",
+                         pd.pass_name.c_str(), tgt.c_str());
+            return false;
+        }
+        att_indices.push_back(idx);
+
+        const AttachmentDef& d = atts.def(idx);
+        if (d.kind == AttachmentKind::SWAPCHAIN_COLOR) has_swapchain = true;
+
+        VkExtent2D e2 = atts.extent(idx);
+        if (pass_extent.width == 0)  pass_extent.width  = e2.width;
+        if (pass_extent.height == 0) pass_extent.height = e2.height;
+    }
+
+    e.is_swapchain = has_swapchain;
+    e.extent       = pass_extent;
+    const uint32_t slots = has_swapchain ? swap_ : flight_;
+    e.framebuffers.assign(slots, VK_NULL_HANDLE);
+
+    VkRenderPass rp = rps.get(pass_index);
+    if (rp == VK_NULL_HANDLE) {
+        std::fprintf(stderr, "[FramebufferRegistry] pass '%s' has no VkRenderPass\n",
+                     pd.pass_name.c_str());
+        return false;
+    }
+
+    std::vector<VkImageView> views(att_indices.size(), VK_NULL_HANDLE);
+
+    for (uint32_t slot = 0; slot < slots; ++slot) {
+        for (size_t i = 0; i < att_indices.size(); ++i) {
+            const AttachmentDef& d = atts.def(att_indices[i]);
+            // Per-swapchain-image attachment indexes by `slot` (swap image idx).
+            // Per-flight attachment indexes by `slot` when whole pass is
+            // per-flight; per-swapchain pass uses slot for swapchain attachment
+            // but a single per-flight resource for non-swapchain attachments —
+            // for simplicity, use slot for everything and rely on min-slot wrap.
+            uint32_t att_slot = slot;
+            if (d.kind != AttachmentKind::SWAPCHAIN_COLOR) {
+                // wrap into the attachment's slot range (flight_count)
+                uint32_t avail = atts.slot_count(att_indices[i]);
+                if (avail == 0) {
+                    std::fprintf(stderr, "[FramebufferRegistry] att '%s' has 0 slots\n",
+                                 d.name.c_str());
+                    return false;
+                }
+                att_slot = slot % avail;
+            }
+            views[i] = atts.view(att_indices[i], att_slot);
+            if (views[i] == VK_NULL_HANDLE) {
+                std::fprintf(stderr, "[FramebufferRegistry] missing view for '%s' slot %u\n",
+                             d.name.c_str(), att_slot);
+                return false;
+            }
+        }
+
+        VkFramebufferCreateInfo fb{};
+        fb.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        fb.renderPass      = rp;
+        fb.attachmentCount = static_cast<uint32_t>(views.size());
+        fb.pAttachments    = views.data();
+        fb.width           = pass_extent.width  ? pass_extent.width  : 1;
+        fb.height          = pass_extent.height ? pass_extent.height : 1;
+        fb.layers          = 1;
+
+        if (vkCreateFramebuffer(device_, &fb, nullptr, &e.framebuffers[slot]) != VK_SUCCESS) {
+            std::fprintf(stderr, "[FramebufferRegistry] vkCreateFramebuffer failed (pass '%s' slot %u)\n",
+                         pd.pass_name.c_str(), slot);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool FramebufferRegistry::initialize_vulkan(VkDevice                   device,
+                                             const AttachmentRegistry&  attachments,
+                                             const RenderPassRegistry&  render_passes,
+                                             uint32_t                   flight_count,
+                                             uint32_t                   swapchain_image_count)
+{
+    device_         = device;
+    flight_         = flight_count;
+    swap_           = swapchain_image_count;
+    attachments_    = &attachments;
+    render_passes_  = &render_passes;
+    entries_.assign(render_passes.count(), {});
+
+    for (uint16_t i = 0; i < render_passes.count(); ++i) {
+        if (!build_one_(i, attachments, render_passes)) return false;
+    }
+    return true;
+}
+
+bool FramebufferRegistry::resize(uint32_t flight_count, uint32_t swapchain_image_count) {
+    if (!device_ || !attachments_ || !render_passes_) return false;
+
+    // Destroy all framebuffers.
+    for (auto& e : entries_) {
+        for (VkFramebuffer fb : e.framebuffers) {
+            if (fb) vkDestroyFramebuffer(device_, fb, nullptr);
+        }
+        e.framebuffers.clear();
+    }
+
+    flight_ = flight_count;
+    swap_   = swapchain_image_count;
+
+    for (uint16_t i = 0; i < render_passes_->count(); ++i) {
+        if (!build_one_(i, *attachments_, *render_passes_)) return false;
+    }
+    return true;
+}
+
+void FramebufferRegistry::shutdown_vulkan() {
+    if (!device_) {
+        entries_.clear();
+        return;
+    }
+    for (auto& e : entries_) {
+        for (VkFramebuffer fb : e.framebuffers) {
+            if (fb) vkDestroyFramebuffer(device_, fb, nullptr);
+        }
+        e.framebuffers.clear();
+    }
+    entries_.clear();
+    device_         = VK_NULL_HANDLE;
+    attachments_    = nullptr;
+    render_passes_  = nullptr;
+}
+
+VkFramebuffer FramebufferRegistry::get(uint16_t pass_index, uint32_t slot) const {
+    if (pass_index >= entries_.size()) return VK_NULL_HANDLE;
+    const PassEntry& e = entries_[pass_index];
+    if (slot >= e.framebuffers.size()) return VK_NULL_HANDLE;
+    return e.framebuffers[slot];
+}
+
+bool FramebufferRegistry::is_swapchain_pass(uint16_t pass_index) const {
+    if (pass_index >= entries_.size()) return false;
+    return entries_[pass_index].is_swapchain;
+}
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/src/pipeline/pipeline_profile_serializer.cpp
+++ b/src/pipeline/pipeline_profile_serializer.cpp
@@ -234,6 +234,62 @@ void emit_string_array(std::string& out, const std::vector<std::string>& arr) {
 
 void pad(std::string& out, int n) { out.append(static_cast<size_t>(n) * 2, ' '); }
 
+// Emit a string array of usage flag names from a `AttachmentUsageBits` mask.
+void emit_attachment_usage(std::string& out, uint32_t mask) {
+    out.push_back('[');
+    bool first = true;
+    auto add = [&](const char* name) {
+        if (!first) out += ", ";
+        quote(out, name);
+        first = false;
+    };
+    if (mask & USAGE_TRANSFER_SRC)              add("TRANSFER_SRC");
+    if (mask & USAGE_TRANSFER_DST)              add("TRANSFER_DST");
+    if (mask & USAGE_SAMPLED)                   add("SAMPLED");
+    if (mask & USAGE_STORAGE)                   add("STORAGE");
+    if (mask & USAGE_COLOR_ATTACHMENT)          add("COLOR_ATTACHMENT");
+    if (mask & USAGE_DEPTH_STENCIL_ATTACHMENT)  add("DEPTH_STENCIL_ATTACHMENT");
+    if (mask & USAGE_TRANSIENT_ATTACHMENT)      add("TRANSIENT_ATTACHMENT");
+    if (mask & USAGE_INPUT_ATTACHMENT)          add("INPUT_ATTACHMENT");
+    out.push_back(']');
+}
+
+void emit_attachment_def(std::string& out, const AttachmentDef& a, int indent) {
+    pad(out, indent); out += "{\n";
+    pad(out, indent+1); out += "\"name\":         "; quote(out, a.name); out += ",\n";
+    pad(out, indent+1); out += "\"kind\":         "; quote(out, to_string(a.kind)); out += ",\n";
+    pad(out, indent+1); out += "\"format\":       "; quote(out, to_string(a.format)); out += ",\n";
+    pad(out, indent+1); out += "\"sizing\":       "; quote(out, to_string(a.sizing)); out += ",\n";
+    if (a.sizing == AttachmentSizing::SWAPCHAIN_RELATIVE) {
+        pad(out, indent+1); out += "\"scale\":        "; emit_float(out, a.scale); out += ",\n";
+    } else {
+        pad(out, indent+1); out += "\"width\":        "; emit_uint(out, a.width);  out += ",\n";
+        pad(out, indent+1); out += "\"height\":       "; emit_uint(out, a.height); out += ",\n";
+    }
+    pad(out, indent+1); out += "\"usage\":        "; emit_attachment_usage(out, a.usage); out += ",\n";
+    if (a.kind == AttachmentKind::DEPTH) {
+        pad(out, indent+1); out += "\"clear_depth\":  "; emit_float(out, a.clear_depth);   out += ",\n";
+        pad(out, indent+1); out += "\"clear_stencil\":"; emit_uint(out, a.clear_stencil);  out += "\n";
+    } else {
+        pad(out, indent+1); out += "\"clear_color\":  [";
+        emit_float(out, a.clear_color[0]); out += ", ";
+        emit_float(out, a.clear_color[1]); out += ", ";
+        emit_float(out, a.clear_color[2]); out += ", ";
+        emit_float(out, a.clear_color[3]); out += "]\n";
+    }
+    pad(out, indent); out += "}";
+}
+
+void emit_attachment_ops(std::string& out, const AttachmentOpsDef& o, int indent) {
+    pad(out, indent); out += "{";
+    out += "\"attachment\": ";     quote(out, o.attachment_name);
+    out += ", \"load\": ";         quote(out, to_string(o.load_op));
+    out += ", \"store\": ";        quote(out, to_string(o.store_op));
+    out += ", \"initial_layout\":"; quote(out, to_string(o.initial_layout));
+    out += ", \"final_layout\": "; quote(out, to_string(o.final_layout));
+    out += "}";
+}
+
 // ---- parser ---------------------------------------------------------------
 
 struct Parser {
@@ -399,6 +455,32 @@ struct Parser {
         }
     }
 
+    // Parse a JSON array of 4 numbers into a float4-like {x,y,z,w}.
+    // Missing tail elements stay at their current value.
+    bool parse_float4(float& x, float& y, float& z, float& w) {
+        if (!expect('[')) return false;
+        double v;
+        skip_ws();
+        if (consume(']')) return true;
+        if (!parse_number(v)) return false; x = static_cast<float>(v);
+        if (consume(']')) return true;
+        if (!expect(',')) return false;
+        if (!parse_number(v)) return false; y = static_cast<float>(v);
+        if (consume(']')) return true;
+        if (!expect(',')) return false;
+        if (!parse_number(v)) return false; z = static_cast<float>(v);
+        if (consume(']')) return true;
+        if (!expect(',')) return false;
+        if (!parse_number(v)) return false; w = static_cast<float>(v);
+        if (consume(']')) return true;
+        while (true) {
+            if (!skip_value()) return false;
+            if (consume(',')) continue;
+            if (consume(']')) return true;
+            return fail("expected , or ]");
+        }
+    }
+
     // Parse a JSON array of 3 numbers into a float3-like {x,y,z}.
     bool parse_float3(float& x, float& y, float& z) {
         if (!expect('[')) return false;
@@ -443,6 +525,98 @@ bool parse_object(Parser& pr, Fn&& on_key) {
 
 // ---- nested object parsers ------------------------------------------------
 
+// ============================================================
+// Phase 3 (schema v2): attachments[] と RenderPassDef::attachment_ops[]
+// ============================================================
+
+bool parse_attachment_def(Parser& pr, AttachmentDef& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "name") {
+            return p.parse_string(out.name);
+        } else if (key == "kind") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_attachment_kind(s, out.kind);
+            return true;
+        } else if (key == "format") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_attachment_format(s, out.format);
+            return true;
+        } else if (key == "sizing") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_attachment_sizing(s, out.sizing);
+            return true;
+        } else if (key == "scale") {
+            return p.parse_float_field(out.scale);
+        } else if (key == "width") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.width = static_cast<uint32_t>(v); return true;
+        } else if (key == "height") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.height = static_cast<uint32_t>(v); return true;
+        } else if (key == "usage") {
+            // Either a uint bitmask OR a string array of flag names.
+            std::vector<std::string> names;
+            // Try string array first; if it fails, fall back to uint.
+            // The Parser doesn't speculate, so probe by peeking the first
+            // non-ws char.
+            // (Simple approach: try array, on failure parse number.)
+            uint64_t mask = 0;
+            if (p.parse_string_array(names)) {
+                for (const auto& n : names) {
+                    if      (n == "TRANSFER_SRC")              mask |= USAGE_TRANSFER_SRC;
+                    else if (n == "TRANSFER_DST")              mask |= USAGE_TRANSFER_DST;
+                    else if (n == "SAMPLED")                   mask |= USAGE_SAMPLED;
+                    else if (n == "STORAGE")                   mask |= USAGE_STORAGE;
+                    else if (n == "COLOR_ATTACHMENT")          mask |= USAGE_COLOR_ATTACHMENT;
+                    else if (n == "DEPTH_STENCIL_ATTACHMENT")  mask |= USAGE_DEPTH_STENCIL_ATTACHMENT;
+                    else if (n == "TRANSIENT_ATTACHMENT")      mask |= USAGE_TRANSIENT_ATTACHMENT;
+                    else if (n == "INPUT_ATTACHMENT")          mask |= USAGE_INPUT_ATTACHMENT;
+                }
+                out.usage = static_cast<uint32_t>(mask);
+                return true;
+            }
+            // Fallback path: raw integer.
+            if (!p.parse_uint_field(mask)) return false;
+            out.usage = static_cast<uint32_t>(mask);
+            return true;
+        } else if (key == "clear_color") {
+            return p.parse_float4(out.clear_color[0], out.clear_color[1],
+                                  out.clear_color[2], out.clear_color[3]);
+        } else if (key == "clear_depth") {
+            return p.parse_float_field(out.clear_depth);
+        } else if (key == "clear_stencil") {
+            uint64_t v; if (!p.parse_uint_field(v)) return false;
+            out.clear_stencil = static_cast<uint32_t>(v); return true;
+        }
+        return p.skip_value();
+    });
+}
+
+bool parse_attachment_ops_def(Parser& pr, AttachmentOpsDef& out) {
+    return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
+        if (key == "attachment") {
+            return p.parse_string(out.attachment_name);
+        } else if (key == "load") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_attachment_load_op(s, out.load_op);
+            return true;
+        } else if (key == "store") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_attachment_store_op(s, out.store_op);
+            return true;
+        } else if (key == "initial_layout") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_image_layout(s, out.initial_layout);
+            return true;
+        } else if (key == "final_layout") {
+            std::string s; if (!p.parse_string(s)) return false;
+            (void)parse_image_layout(s, out.final_layout);
+            return true;
+        }
+        return p.skip_value();
+    });
+}
+
 bool parse_render_pass(Parser& pr, RenderPassDef& out) {
     return parse_object(pr, [&](Parser& p, const std::string& key) -> bool {
         if (key == "pass_name") {
@@ -475,6 +649,20 @@ bool parse_render_pass(Parser& pr, RenderPassDef& out) {
             return p.parse_bool(out.gpu_driven_pass);
         } else if (key == "required_streams") {
             return p.parse_string_array(out.required_streams);
+        } else if (key == "attachment_ops") {
+            // Phase 3 (schema v2): per-attachment load/store/layout overrides.
+            if (!p.expect('[')) return false;
+            out.attachment_ops.clear();
+            p.skip_ws();
+            if (p.consume(']')) return true;
+            while (true) {
+                AttachmentOpsDef ops;
+                if (!parse_attachment_ops_def(p, ops)) return false;
+                out.attachment_ops.push_back(std::move(ops));
+                if (p.consume(',')) continue;
+                if (p.consume(']')) return true;
+                return false;
+            }
         }
         return p.skip_value();
     });
@@ -817,6 +1005,21 @@ bool decode(const std::string& json, PipelineProfileDef& out, std::string* error
             ok = pr.parse_bool(out.gpu_driven_enabled);
         } else if (key == "compute_update_enabled") {
             ok = pr.parse_bool(out.compute_update_enabled);
+        } else if (key == "attachments") {
+            // Phase 3 (schema v2): named attachments used by render_passes.
+            if (!pr.expect('[')) return fail("expected array");
+            out.attachments.clear();
+            pr.skip_ws();
+            if (!pr.consume(']')) {
+                while (true) {
+                    AttachmentDef att;
+                    if (!parse_attachment_def(pr, att)) return fail("bad attachment");
+                    out.attachments.push_back(std::move(att));
+                    if (pr.consume(',')) continue;
+                    if (pr.consume(']')) break;
+                    return fail("expected , or ]");
+                }
+            }
         } else if (key == "render_passes") {
             if (!pr.expect('[')) return fail("expected array");
             out.render_passes.clear();
@@ -880,13 +1083,26 @@ std::string to_pipeline_profile_json(const PipelineProfileDef& def) {
     out.reserve(4096);
 
     out += "{\n";
-    out += "  \"version\": 1,\n";
+    out += "  \"version\": 2,\n";
     out += "  \"profile_name\": "; quote(out, def.profile_name); out += ",\n";
     out += "  \"rendering_path\": "; quote(out, rendering_path_to_str(def.rendering_path)); out += ",\n";
     out += "  \"max_lights\": "; emit_uint(out, def.max_lights); out += ",\n";
     out += "  \"msaa_samples\": "; emit_uint(out, def.msaa_samples); out += ",\n";
     out += "  \"gpu_driven_enabled\": "; emit_bool(out, def.gpu_driven_enabled); out += ",\n";
     out += "  \"compute_update_enabled\": "; emit_bool(out, def.compute_update_enabled); out += ",\n";
+
+    // attachments (Phase 3, schema v2)
+    out += "  \"attachments\": [";
+    if (!def.attachments.empty()) {
+        out += "\n";
+        for (size_t i = 0; i < def.attachments.size(); ++i) {
+            emit_attachment_def(out, def.attachments[i], 2);
+            if (i + 1 < def.attachments.size()) out += ",";
+            out += "\n";
+        }
+        pad(out, 1);
+    }
+    out += "],\n";
 
     // render_passes
     out += "  \"render_passes\": [";
@@ -903,7 +1119,19 @@ std::string to_pipeline_profile_json(const PipelineProfileDef& def) {
             pad(out, 3); out += "\"sort_mode\":        "; quote(out, sort_mode_to_str(rp.sort_mode)); out += ",\n";
             pad(out, 3); out += "\"filter_mask\":      "; emit_uint(out, rp.filter_mask); out += ",\n";
             pad(out, 3); out += "\"gpu_driven_pass\":  "; emit_bool(out, rp.gpu_driven_pass); out += ",\n";
-            pad(out, 3); out += "\"required_streams\": "; emit_string_array(out, rp.required_streams); out += "\n";
+            pad(out, 3); out += "\"required_streams\": "; emit_string_array(out, rp.required_streams);
+            if (!rp.attachment_ops.empty()) {
+                out += ",\n";
+                pad(out, 3); out += "\"attachment_ops\": [\n";
+                for (size_t j = 0; j < rp.attachment_ops.size(); ++j) {
+                    emit_attachment_ops(out, rp.attachment_ops[j], 4);
+                    if (j + 1 < rp.attachment_ops.size()) out += ",";
+                    out += "\n";
+                }
+                pad(out, 3); out += "]\n";
+            } else {
+                out += "\n";
+            }
             pad(out, 2); out += "}";
             if (i + 1 < def.render_passes.size()) out += ",";
             out += "\n";

--- a/src/pipeline/render_pass_registry.cpp
+++ b/src/pipeline/render_pass_registry.cpp
@@ -1,0 +1,178 @@
+#include "pictor/pipeline/render_pass_registry.h"
+#include "pictor/pipeline/attachment_registry.h"
+
+#include <cstdio>
+
+namespace pictor {
+
+RenderPassRegistry::RenderPassRegistry() = default;
+
+RenderPassRegistry::~RenderPassRegistry() {
+#ifdef PICTOR_HAS_VULKAN
+    shutdown_vulkan();
+#endif
+}
+
+void RenderPassRegistry::set_passes(std::span<const RenderPassDef> passes) {
+    passes_.assign(passes.begin(), passes.end());
+#ifdef PICTOR_HAS_VULKAN
+    if (!passes_render_passes_.empty()) {
+        shutdown_vulkan();
+    }
+#endif
+}
+
+uint16_t RenderPassRegistry::index_of(std::string_view pass_name) const {
+    for (size_t i = 0; i < passes_.size(); ++i) {
+        if (passes_[i].pass_name == pass_name) return static_cast<uint16_t>(i);
+    }
+    return INVALID_INDEX;
+}
+
+#ifdef PICTOR_HAS_VULKAN
+
+namespace {
+
+// Default ops if `RenderPassDef::attachment_ops` is empty.
+AttachmentOpsDef infer_op(const std::string& target, const AttachmentRegistry& atts) {
+    uint16_t idx = atts.index_of(target);
+    AttachmentOpsDef op;
+    op.attachment_name = target;
+    if (idx == AttachmentRegistry::INVALID_INDEX) {
+        // Unknown — keep CLEAR/STORE/UNDEFINED→SHADER_READ_ONLY.
+        return op;
+    }
+    const AttachmentDef& d = atts.def(idx);
+    if (d.kind == AttachmentKind::DEPTH) {
+        op.load_op        = AttachmentLoadOp::CLEAR;
+        op.store_op       = AttachmentStoreOp::DONT_CARE;
+        op.initial_layout = ImageLayout::UNDEFINED;
+        op.final_layout   = ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    } else if (d.kind == AttachmentKind::SWAPCHAIN_COLOR) {
+        op.load_op        = AttachmentLoadOp::CLEAR;
+        op.store_op       = AttachmentStoreOp::STORE;
+        op.initial_layout = ImageLayout::UNDEFINED;
+        op.final_layout   = ImageLayout::PRESENT_SRC_KHR;
+    }
+    return op;
+}
+
+} // anon
+
+bool RenderPassRegistry::build_one_(uint16_t index, const AttachmentRegistry& atts) {
+    const RenderPassDef& pd = passes_[index];
+
+    // Compute view (attachment_ops, in render_targets order).
+    std::vector<AttachmentOpsDef> resolved;
+    resolved.reserve(pd.render_targets.size());
+    for (size_t t = 0; t < pd.render_targets.size(); ++t) {
+        const std::string& tgt = pd.render_targets[t];
+
+        // Look up explicit ops for this attachment, otherwise infer default.
+        const AttachmentOpsDef* explicit_op = nullptr;
+        for (const auto& o : pd.attachment_ops) {
+            if (o.attachment_name == tgt) { explicit_op = &o; break; }
+        }
+        resolved.push_back(explicit_op ? *explicit_op : infer_op(tgt, atts));
+    }
+
+    // VkAttachmentDescription + VkAttachmentReference (single subpass).
+    std::vector<VkAttachmentDescription> ads;
+    std::vector<VkAttachmentReference>   color_refs;
+    VkAttachmentReference                depth_ref{};
+    bool has_depth = false;
+
+    ads.reserve(resolved.size());
+    color_refs.reserve(resolved.size());
+
+    for (size_t i = 0; i < resolved.size(); ++i) {
+        uint16_t att_idx = atts.index_of(resolved[i].attachment_name);
+        if (att_idx == AttachmentRegistry::INVALID_INDEX) {
+            std::fprintf(stderr, "[RenderPassRegistry] pass '%s' references unknown attachment '%s'\n",
+                         pd.pass_name.c_str(), resolved[i].attachment_name.c_str());
+            return false;
+        }
+        const AttachmentDef& d = atts.def(att_idx);
+
+        VkAttachmentDescription ad{};
+        ad.format         = atts.vk_format(att_idx);
+        ad.samples        = VK_SAMPLE_COUNT_1_BIT;
+        ad.loadOp         = to_vk_load_op(resolved[i].load_op);
+        ad.storeOp        = to_vk_store_op(resolved[i].store_op);
+        ad.stencilLoadOp  = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        ad.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        ad.initialLayout  = to_vk_layout(resolved[i].initial_layout);
+        ad.finalLayout    = to_vk_layout(resolved[i].final_layout);
+        ads.push_back(ad);
+
+        VkAttachmentReference ref{};
+        ref.attachment = static_cast<uint32_t>(i);
+        if (d.kind == AttachmentKind::DEPTH) {
+            ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+            depth_ref  = ref;
+            has_depth  = true;
+        } else {
+            ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+            color_refs.push_back(ref);
+        }
+    }
+
+    VkSubpassDescription sub{};
+    sub.pipelineBindPoint       = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    sub.colorAttachmentCount    = static_cast<uint32_t>(color_refs.size());
+    sub.pColorAttachments       = color_refs.empty() ? nullptr : color_refs.data();
+    sub.pDepthStencilAttachment = has_depth ? &depth_ref : nullptr;
+
+    // Standard external→subpass dependency for present / shader read sequences.
+    VkSubpassDependency dep{};
+    dep.srcSubpass    = VK_SUBPASS_EXTERNAL;
+    dep.dstSubpass    = 0;
+    dep.srcStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                        VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    dep.dstStageMask  = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                        VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    dep.srcAccessMask = 0;
+    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo ci{};
+    ci.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    ci.attachmentCount = static_cast<uint32_t>(ads.size());
+    ci.pAttachments    = ads.empty() ? nullptr : ads.data();
+    ci.subpassCount    = 1;
+    ci.pSubpasses      = &sub;
+    ci.dependencyCount = 1;
+    ci.pDependencies   = &dep;
+
+    if (vkCreateRenderPass(device_, &ci, nullptr, &passes_render_passes_[index]) != VK_SUCCESS) {
+        std::fprintf(stderr, "[RenderPassRegistry] vkCreateRenderPass failed for '%s'\n",
+                     pd.pass_name.c_str());
+        return false;
+    }
+    return true;
+}
+
+bool RenderPassRegistry::initialize_vulkan(VkDevice device, const AttachmentRegistry& atts) {
+    device_ = device;
+    passes_render_passes_.assign(passes_.size(), VK_NULL_HANDLE);
+    for (uint16_t i = 0; i < static_cast<uint16_t>(passes_.size()); ++i) {
+        if (!build_one_(i, atts)) return false;
+    }
+    return true;
+}
+
+void RenderPassRegistry::shutdown_vulkan() {
+    if (!device_) {
+        passes_render_passes_.clear();
+        return;
+    }
+    for (VkRenderPass rp : passes_render_passes_) {
+        if (rp) vkDestroyRenderPass(device_, rp, nullptr);
+    }
+    passes_render_passes_.clear();
+    device_ = VK_NULL_HANDLE;
+}
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PICTOR_TESTS
     unit_shader_registry_test
     unit_pipeline_profile_serializer_test
     unit_postprocess_chain_test
+    unit_attachment_def_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(PICTOR_TESTS
     unit_pipeline_profile_serializer_test
     unit_postprocess_chain_test
     unit_attachment_def_test
+    unit_pipeline_registries_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_attachment_def_test.cpp
+++ b/tests/unit_attachment_def_test.cpp
@@ -1,0 +1,164 @@
+// unit_attachment_def_test — Phase 3 schema v2 の基礎確認。
+//
+// 1. AttachmentDef / AttachmentOpsDef の to_string / parse_* が round-trip
+// 2. default_attachments() が 3 件 (scene_hdr_color / scene_depth / swapchain)
+//    を期待順で返す
+// 3. default_attachment_ops() が kind に応じて load/store/layout を選ぶ
+// 4. PipelineProfileDef に v2 構造 (attachments + render_passes.attachment_ops)
+//    を入れて to_pipeline_profile_json -> from_pipeline_profile_json が
+//    バイト単位ではないが意味単位で同値 (round-trip)
+
+#include "pictor/pipeline/attachment_def.h"
+#include "pictor/pipeline/pipeline_profile.h"
+#include "pictor/pipeline/pipeline_profile_serializer.h"
+#include "test_common.h"
+
+#include <string>
+
+using namespace pictor;
+using pictor_test::g_failures;
+
+namespace {
+
+void test_enum_round_trip() {
+    AttachmentKind k;
+    PT_ASSERT(parse_attachment_kind("COLOR", k) && k == AttachmentKind::COLOR, "COLOR");
+    PT_ASSERT(parse_attachment_kind("DEPTH", k) && k == AttachmentKind::DEPTH, "DEPTH");
+    PT_ASSERT(parse_attachment_kind("SWAPCHAIN_COLOR", k) && k == AttachmentKind::SWAPCHAIN_COLOR, "SWAPCHAIN");
+    PT_ASSERT(!parse_attachment_kind("BOGUS", k), "rejects unknown");
+
+    AttachmentFormat f;
+    PT_ASSERT(parse_attachment_format("R16G16B16A16_SFLOAT", f)
+              && f == AttachmentFormat::R16G16B16A16_SFLOAT, "HDR");
+    PT_ASSERT(parse_attachment_format("D32_SFLOAT", f)
+              && f == AttachmentFormat::D32_SFLOAT, "D32");
+
+    AttachmentLoadOp lo;
+    PT_ASSERT(parse_attachment_load_op("CLEAR", lo) && lo == AttachmentLoadOp::CLEAR, "load CLEAR");
+    AttachmentStoreOp so;
+    PT_ASSERT(parse_attachment_store_op("STORE", so) && so == AttachmentStoreOp::STORE, "store STORE");
+
+    ImageLayout l;
+    PT_ASSERT(parse_image_layout("PRESENT_SRC_KHR", l) && l == ImageLayout::PRESENT_SRC_KHR, "PRESENT");
+    PT_ASSERT(parse_image_layout("UNDEFINED", l) && l == ImageLayout::UNDEFINED, "UNDEFINED");
+
+    PT_ASSERT(std::string(to_string(AttachmentFormat::B8G8R8A8_SRGB)) == "B8G8R8A8_SRGB", "BGRA SRGB");
+}
+
+void test_is_depth_format() {
+    PT_ASSERT(is_depth_format(AttachmentFormat::D32_SFLOAT), "D32 is depth");
+    PT_ASSERT(is_depth_format(AttachmentFormat::D24_UNORM_S8_UINT), "D24S8 is depth");
+    PT_ASSERT(!is_depth_format(AttachmentFormat::R16G16B16A16_SFLOAT), "HDR not depth");
+    PT_ASSERT(!is_depth_format(AttachmentFormat::UNDEFINED), "UNDEFINED not depth");
+}
+
+void test_default_attachments() {
+    auto defs = default_attachments();
+    PT_ASSERT(defs.size() == 3, "3 defaults");
+    PT_ASSERT(defs[0].name == "scene_hdr_color", "[0] hdr");
+    PT_ASSERT(defs[0].kind == AttachmentKind::COLOR, "[0] COLOR kind");
+    PT_ASSERT(defs[0].format == AttachmentFormat::R16G16B16A16_SFLOAT, "[0] HDR fmt");
+    PT_ASSERT(defs[1].name == "scene_depth", "[1] depth");
+    PT_ASSERT(defs[1].kind == AttachmentKind::DEPTH, "[1] DEPTH kind");
+    PT_ASSERT(defs[2].name == "swapchain", "[2] swapchain");
+    PT_ASSERT(defs[2].kind == AttachmentKind::SWAPCHAIN_COLOR, "[2] SWAPCHAIN kind");
+}
+
+void test_default_attachment_ops() {
+    auto defs = default_attachments();
+    std::vector<AttachmentDef> vec(defs.begin(), defs.end());
+
+    // Color target -> CLEAR / STORE / SHADER_READ_ONLY_OPTIMAL
+    auto ops_color = default_attachment_ops({"scene_hdr_color"}, vec);
+    PT_ASSERT(ops_color.size() == 1, "color: 1 entry");
+    PT_ASSERT(ops_color[0].load_op  == AttachmentLoadOp::CLEAR, "color CLEAR");
+    PT_ASSERT(ops_color[0].store_op == AttachmentStoreOp::STORE, "color STORE");
+    PT_ASSERT(ops_color[0].final_layout == ImageLayout::SHADER_READ_ONLY_OPTIMAL, "color SHADER_READ");
+
+    // Depth target -> CLEAR / DONT_CARE / DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+    auto ops_depth = default_attachment_ops({"scene_depth"}, vec);
+    PT_ASSERT(ops_depth.size() == 1, "depth: 1 entry");
+    PT_ASSERT(ops_depth[0].load_op  == AttachmentLoadOp::CLEAR, "depth CLEAR");
+    PT_ASSERT(ops_depth[0].store_op == AttachmentStoreOp::DONT_CARE, "depth DONT_CARE");
+    PT_ASSERT(ops_depth[0].final_layout == ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL, "depth DSV");
+
+    // Swapchain -> CLEAR / STORE / PRESENT_SRC_KHR
+    auto ops_swap = default_attachment_ops({"swapchain"}, vec);
+    PT_ASSERT(ops_swap.size() == 1, "swap: 1 entry");
+    PT_ASSERT(ops_swap[0].load_op  == AttachmentLoadOp::CLEAR, "swap CLEAR");
+    PT_ASSERT(ops_swap[0].store_op == AttachmentStoreOp::STORE, "swap STORE");
+    PT_ASSERT(ops_swap[0].final_layout == ImageLayout::PRESENT_SRC_KHR, "swap PRESENT");
+}
+
+void test_profile_v2_round_trip() {
+    PipelineProfileDef in;
+    in.profile_name = "Phase3Test";
+    {
+        auto defs = default_attachments();
+        in.attachments.assign(defs.begin(), defs.end());
+    }
+    RenderPassDef rp;
+    rp.pass_name      = "Scene HDR";
+    rp.pass_type      = PassType::OPAQUE;
+    rp.render_targets = {"scene_hdr_color", "scene_depth"};
+    rp.attachment_ops = default_attachment_ops(rp.render_targets, in.attachments);
+    in.render_passes.push_back(rp);
+
+    std::string json = to_pipeline_profile_json(in);
+    PT_ASSERT(json.find("\"version\": 2") != std::string::npos, "emits v2");
+    PT_ASSERT(json.find("\"attachments\"") != std::string::npos, "emits attachments key");
+    PT_ASSERT(json.find("\"scene_hdr_color\"") != std::string::npos, "hdr name present");
+    PT_ASSERT(json.find("\"attachment_ops\"") != std::string::npos, "emits attachment_ops");
+
+    PipelineProfileDef out;
+    std::string err;
+    bool ok = from_pipeline_profile_json(json, out, &err);
+    PT_ASSERT(ok, err.c_str());
+    PT_ASSERT(out.profile_name == "Phase3Test", "name kept");
+    PT_ASSERT(out.attachments.size() == 3, "3 attachments parsed");
+    PT_ASSERT(out.attachments[0].name == "scene_hdr_color", "name[0]");
+    PT_ASSERT(out.attachments[0].format == AttachmentFormat::R16G16B16A16_SFLOAT, "fmt[0]");
+    PT_ASSERT(out.attachments[1].kind == AttachmentKind::DEPTH, "kind[1]");
+    PT_ASSERT(out.attachments[2].kind == AttachmentKind::SWAPCHAIN_COLOR, "kind[2]");
+
+    PT_ASSERT(out.render_passes.size() == 1, "1 pass");
+    PT_ASSERT(out.render_passes[0].attachment_ops.size() == 2, "2 ops");
+    PT_ASSERT(out.render_passes[0].attachment_ops[0].attachment_name == "scene_hdr_color", "ops[0] att");
+    PT_ASSERT(out.render_passes[0].attachment_ops[0].load_op == AttachmentLoadOp::CLEAR, "ops[0] CLEAR");
+    PT_ASSERT(out.render_passes[0].attachment_ops[1].store_op == AttachmentStoreOp::DONT_CARE,
+              "depth STORE DONT_CARE");
+}
+
+void test_v1_backward_compat() {
+    // v1 profile (no attachments[], no attachment_ops[]) — must parse with
+    // empty attachments / empty attachment_ops.
+    const char* json =
+        "{\n"
+        "  \"version\": 1,\n"
+        "  \"profile_name\": \"Legacy\",\n"
+        "  \"render_passes\": [ { \"pass_name\": \"Opaque\",\n"
+        "                          \"pass_type\": \"OPAQUE\",\n"
+        "                          \"render_targets\": [\"scene_hdr_color\"]\n"
+        "                        } ]\n"
+        "}";
+    PipelineProfileDef out;
+    std::string err;
+    bool ok = from_pipeline_profile_json(json, out, &err);
+    PT_ASSERT(ok, err.c_str());
+    PT_ASSERT(out.profile_name == "Legacy", "v1 name");
+    PT_ASSERT(out.attachments.empty(), "v1 attachments empty");
+    PT_ASSERT(out.render_passes.size() == 1, "1 pass");
+    PT_ASSERT(out.render_passes[0].attachment_ops.empty(), "v1 ops empty");
+}
+
+} // anon
+
+int main() {
+    test_enum_round_trip();
+    test_is_depth_format();
+    test_default_attachments();
+    test_default_attachment_ops();
+    test_profile_v2_round_trip();
+    test_v1_backward_compat();
+    return pictor_test::report("unit_attachment_def_test");
+}

--- a/tests/unit_pipeline_registries_test.cpp
+++ b/tests/unit_pipeline_registries_test.cpp
@@ -1,0 +1,128 @@
+// unit_pipeline_registries_test — Phase 3 Step B の Vulkan 非依存部分を確認。
+//
+// Vulkan の VkImage / VkRenderPass / VkFramebuffer 生成は実 GPU が要るため
+// 単体テストでは対象外 (KS / Custos の統合テストでカバー)。 ここでは:
+//
+// 1. AttachmentRegistry::set_defs / index_of / count / def / defs が
+//    名前→index 解決と def 配列保持を正しく行う
+// 2. RenderPassRegistry::set_passes / index_of / count / pass / passes が
+//    パス名→index 解決を行う
+// 3. INVALID_INDEX 戻り値が未登録名で返る
+
+// `pipeline_profile.h` (and the core enums it pulls in) must be processed
+// before `vulkan.h` on Windows — vulkan.h transitively brings <windows.h>
+// which `#define OPAQUE` collides with `PassType::OPAQUE`. Same pattern as
+// `postprocess_pipeline.h` / `gpu_timer.h`.
+#include "pictor/pipeline/attachment_def.h"
+#include "pictor/pipeline/pipeline_profile.h"
+
+#include "pictor/pipeline/attachment_registry.h"
+#include "pictor/pipeline/render_pass_registry.h"
+#include "test_common.h"
+
+#include <string>
+#include <vector>
+
+using namespace pictor;
+using pictor_test::g_failures;
+
+namespace {
+
+void test_attachment_registry_index_resolution() {
+    AttachmentRegistry reg;
+
+    auto defs = default_attachments();
+    std::vector<AttachmentDef> vec(defs.begin(), defs.end());
+    reg.set_defs(vec);
+
+    PT_ASSERT(reg.count() == 3, "count 3");
+    PT_ASSERT(reg.index_of("scene_hdr_color") == 0, "hdr->0");
+    PT_ASSERT(reg.index_of("scene_depth") == 1, "depth->1");
+    PT_ASSERT(reg.index_of("swapchain") == 2, "swap->2");
+    PT_ASSERT(reg.index_of("bogus") == AttachmentRegistry::INVALID_INDEX, "miss->INVALID");
+
+    PT_ASSERT(reg.def(0).kind == AttachmentKind::COLOR, "def(0) kind");
+    PT_ASSERT(reg.def(1).kind == AttachmentKind::DEPTH, "def(1) kind");
+    PT_ASSERT(reg.def(2).kind == AttachmentKind::SWAPCHAIN_COLOR, "def(2) kind");
+
+    PT_ASSERT(reg.defs().size() == 3, "defs() size");
+}
+
+void test_attachment_registry_set_defs_replaces() {
+    AttachmentRegistry reg;
+    auto defs = default_attachments();
+    std::vector<AttachmentDef> vec(defs.begin(), defs.end());
+    reg.set_defs(vec);
+    PT_ASSERT(reg.count() == 3, "first 3");
+
+    // Replace with a single def.
+    AttachmentDef only;
+    only.name   = "shadow_atlas";
+    only.kind   = AttachmentKind::DEPTH;
+    only.format = AttachmentFormat::D32_SFLOAT;
+    std::vector<AttachmentDef> one = {only};
+    reg.set_defs(one);
+    PT_ASSERT(reg.count() == 1, "now 1");
+    PT_ASSERT(reg.index_of("scene_hdr_color") == AttachmentRegistry::INVALID_INDEX, "old gone");
+    PT_ASSERT(reg.index_of("shadow_atlas") == 0, "new present");
+}
+
+void test_render_pass_registry_index_resolution() {
+    RenderPassRegistry reg;
+
+    RenderPassDef a;
+    a.pass_name = "Scene HDR";
+    a.pass_type = PassType::OPAQUE;
+    a.render_targets = {"scene_hdr_color", "scene_depth"};
+
+    RenderPassDef b;
+    b.pass_name = "Swapchain Composite";
+    b.pass_type = PassType::POST_PROCESS;
+    b.render_targets = {"swapchain"};
+
+    std::vector<RenderPassDef> passes = {a, b};
+    reg.set_passes(passes);
+
+    PT_ASSERT(reg.count() == 2, "2 passes");
+    PT_ASSERT(reg.index_of("Scene HDR") == 0, "Scene HDR -> 0");
+    PT_ASSERT(reg.index_of("Swapchain Composite") == 1, "Composite -> 1");
+    PT_ASSERT(reg.index_of("bogus") == RenderPassRegistry::INVALID_INDEX, "miss -> INVALID");
+
+    PT_ASSERT(reg.pass(0).render_targets.size() == 2, "pass 0 has 2 targets");
+    PT_ASSERT(reg.pass(1).pass_type == PassType::POST_PROCESS, "pass 1 type");
+
+    PT_ASSERT(reg.passes().size() == 2, "passes() size");
+}
+
+void test_render_pass_attachment_ops_round_trip() {
+    // RenderPassDef::attachment_ops is preserved by set_passes.
+    AttachmentRegistry atts;
+    auto defs = default_attachments();
+    std::vector<AttachmentDef> vec(defs.begin(), defs.end());
+    atts.set_defs(vec);
+
+    RenderPassDef pd;
+    pd.pass_name      = "Scene HDR";
+    pd.render_targets = {"scene_hdr_color", "scene_depth"};
+    pd.attachment_ops = default_attachment_ops(pd.render_targets, vec);
+
+    RenderPassRegistry reg;
+    std::vector<RenderPassDef> passes = {pd};
+    reg.set_passes(passes);
+
+    const RenderPassDef& p = reg.pass(0);
+    PT_ASSERT(p.attachment_ops.size() == 2, "ops 2");
+    PT_ASSERT(p.attachment_ops[0].attachment_name == "scene_hdr_color", "ops[0] name");
+    PT_ASSERT(p.attachment_ops[0].load_op == AttachmentLoadOp::CLEAR, "ops[0] CLEAR");
+    PT_ASSERT(p.attachment_ops[1].store_op == AttachmentStoreOp::DONT_CARE, "depth DONT_CARE");
+}
+
+} // anon
+
+int main() {
+    test_attachment_registry_index_resolution();
+    test_attachment_registry_set_defs_replaces();
+    test_render_pass_registry_index_resolution();
+    test_render_pass_attachment_ops_round_trip();
+    return pictor_test::report("unit_pipeline_registries_test");
+}


### PR DESCRIPTION
Phase 3 (`spec/pipeline-system-b-config.md`) の前半。 vulkan_context / render_pass_scheduler の本体改修 (Step C) は本 PR の **対象外**、 後続 PR で配線する。 本 PR は **追加のみ・既存挙動に影響なし**。

## 含まれる commit

- `docs(spec): pipeline system-B (Phase 3) 設計書`
- `docs(spec): system-B 設計を CompiledGraph + 単一グラフ UI 方針に更新` — ユーザ feedback (アニメ無効 / オーバーヘッドゼロのノード化 / 統一UI / scanner撤去) を反映
- `feat(pipeline): Step A — AttachmentDef + schema v2 attachments/attachment_ops` — Vulkan 非依存 enum + serializer v2 (v1 後方互換)
- `feat(pipeline): Step B — Attachment/RenderPass/Framebuffer Registries` — name → `uint16_t` index 解決 + Vulkan リソース管理 (`PICTOR_HAS_VULKAN` ガード)

## 残り (Step C / 後続 PR)

- `pipeline_compiler.{h,cpp}` 新設 (CompiledGraph 生成)
- `render_pass_scheduler.cpp` を flat seq-iterate に書き換え
- `vulkan_context.cpp` のハードコード VkRenderPass / VkFramebuffer 生成を registry 経由へ
- KS 側 `data/render/kuzu.profile.json` の attachments[] 追加 (KS リポ別 PR)

## 検証

- 全 12 CTest green (`unit_attachment_def_test` 6 / `unit_pipeline_registries_test` 4 / 既存 10)
- 既存 KS exe は本 PR で挙動変化なし (registry を呼ぶ箇所がまだ無いため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)