### PR TITLE
feat(pipeline): AttachmentRegistry::set_external_attachment

### DIFF
--- a/include/pictor/pipeline/attachment_registry.h
+++ b/include/pictor/pipeline/attachment_registry.h
@@ -85,6 +85,27 @@ public:
                               VkFormat                     format,
                               VkExtent2D                   extent);
 
+    /// Replace an attachment with caller-owned VkImage/VkImageView handles.
+    ///
+    /// Use when the host already owns the GPU resources (e.g. KS の
+    /// `PostProcessLayer` が `PostProcessPipeline` 内部で先に作った
+    /// `scene_hdr_color`) と Phase 4 で AttachmentRegistry に参照させたい
+    /// 場合。 `name` で attachment を引き、 内部で作成済みだった
+    /// VkImage/View/Memory を破棄して caller-owned handles を割り当てる。
+    ///
+    /// `images.size() == views.size() == flight_count_` を期待 (per-flight)。
+    /// 以後 `image()` / `view()` は提供された handle を返し、 `shutdown_vulkan()`
+    /// では destroy しない (caller の所有権)。 `resize()` も触らない
+    /// (host が swapchain recreate 後に同 API で再 inject する)。
+    ///
+    /// 戻り値 false: 該当 name が未登録、 もしくは登録済みだが SWAPCHAIN_COLOR
+    /// (こちらは set_swapchain_images を使うこと)。
+    bool set_external_attachment(std::string_view             name,
+                                 std::span<const VkImage>     images,
+                                 std::span<const VkImageView> views,
+                                 VkFormat                     format,
+                                 VkExtent2D                   extent);
+
     /// Free all Vulkan resources owned by the registry.
     void shutdown_vulkan();
 
@@ -108,14 +129,16 @@ private:
 
 #ifdef PICTOR_HAS_VULKAN
     struct Resource {
-        // Non-swapchain: per-flight image+view+memory
-        // Swapchain    : per-image image+view (memory not owned)
+        // Non-swapchain non-external: per-flight image+view+memory (owned)
+        // Swapchain                 : per-image image+view (memory not owned)
+        // External                  : per-flight image+view (memory not owned)
         std::vector<VkImage>        images;        // flight_count or swapchain_image_count
         std::vector<VkImageView>    views;
-        std::vector<VkDeviceMemory> memories;      // empty for swapchain (not owned)
+        std::vector<VkDeviceMemory> memories;      // empty for swapchain/external (not owned)
         VkFormat                    vk_format = VK_FORMAT_UNDEFINED;
         VkExtent2D                  extent    = {0, 0};
         bool                        is_swapchain = false;
+        bool                        is_external  = false;  // caller-owned, do not destroy
     };
 
     bool create_one_(uint16_t index, VkExtent2D extent);

--- a/include/pictor/postprocess/postprocess_pipeline.h
+++ b/include/pictor/postprocess/postprocess_pipeline.h
@@ -104,6 +104,12 @@ public:
     VkImageView   scene_color_view() const;
     /// シーンの深度ビュー (D32_SFLOAT)。 DecalSystem 等が read する。
     VkImageView   scene_depth_view() const;
+    /// シーンカラー HDR の VkImage (RGBA16F)。 KS の Phase 4 wiring が
+    /// `AttachmentRegistry::set_external_attachment` で external attachment
+    /// として再 expose する用。
+    VkImage       scene_color_image() const;
+    /// シーン深度の VkImage (D32_SFLOAT)。 同上。
+    VkImage       scene_depth_image() const;
 
     /// Record the post-process chain into `output_views[output_index]`.
     /// The output image is left in COLOR_ATTACHMENT_OPTIMAL so the host can

--- a/include/pictor/vector/rive_renderer.h
+++ b/include/pictor/vector/rive_renderer.h
@@ -84,7 +84,13 @@ public:
     /// Create the Rive RenderContext bound to the given Vulkan context.
     /// Returns false if Rive is not compiled in (PICTOR_HAS_RIVE undefined)
     /// or if Rive initialisation fails.
-    bool initialize(VulkanContext& vk_ctx, const Options& opts = {});
+    ///
+    /// gcc (Pictor の test 環境では gcc 13) は inline default argument `= {}` を
+    /// `const Options&` に解決できない (`<brace-enclosed initializer list>` の
+    /// 変換失敗エラー) ため、 オーバーロード 2 段にして default は明示的に
+    /// `Options{}` を渡す。 MSVC は両形式 OK。
+    bool initialize(VulkanContext& vk_ctx);
+    bool initialize(VulkanContext& vk_ctx, const Options& opts);
 
     void shutdown();
 

--- a/src/pipeline/attachment_registry.cpp
+++ b/src/pipeline/attachment_registry.cpp
@@ -231,8 +231,9 @@ bool AttachmentRegistry::create_one_(uint16_t index, VkExtent2D swap_extent) {
 }
 
 void AttachmentRegistry::destroy_one_(Resource& r) {
-    if (r.is_swapchain) {
-        // Not owned — VulkanContext owns swapchain images/views.
+    if (r.is_swapchain || r.is_external) {
+        // Not owned — caller (VulkanContext for swapchain, host for external)
+        // owns the images/views.
         r.images.clear();
         r.views.clear();
         r.memories.clear();
@@ -278,21 +279,26 @@ bool AttachmentRegistry::resize(VkExtent2D new_extent) {
         return true;
     }
 
-    // Destroy all non-swapchain images and recreate at new extent.
+    // Destroy all owned (non-swapchain, non-external) images and recreate at new extent.
     for (size_t i = 0; i < resources_.size(); ++i) {
-        if (!resources_[i].is_swapchain) {
+        if (!resources_[i].is_swapchain && !resources_[i].is_external) {
             destroy_one_(resources_[i]);
         }
     }
     current_extent_ = new_extent;
     for (uint16_t i = 0; i < static_cast<uint16_t>(defs_.size()); ++i) {
-        if (!resources_[i].is_swapchain) {
-            if (!create_one_(i, new_extent)) return false;
-        } else {
+        if (resources_[i].is_swapchain) {
             // Swapchain entries: clear handles, host re-injects.
             resources_[i].images.clear();
             resources_[i].views.clear();
             resources_[i].extent = new_extent;
+        } else if (resources_[i].is_external) {
+            // External entries: keep handles untouched. Host re-injects via
+            // set_external_attachment after swapchain recreate if the
+            // underlying GPU image needs a new size.
+            resources_[i].extent = new_extent;
+        } else {
+            if (!create_one_(i, new_extent)) return false;
         }
     }
     return true;
@@ -311,6 +317,35 @@ void AttachmentRegistry::set_swapchain_images(std::span<const VkImage>     image
         resources_[i].vk_format = format;
         resources_[i].extent    = extent;
     }
+}
+
+bool AttachmentRegistry::set_external_attachment(std::string_view             name,
+                                                 std::span<const VkImage>     images,
+                                                 std::span<const VkImageView> views,
+                                                 VkFormat                     format,
+                                                 VkExtent2D                   extent)
+{
+    uint16_t idx = index_of(name);
+    if (idx == INVALID_INDEX) return false;
+    if (idx >= resources_.size())  return false;  // initialize_vulkan 未呼出
+
+    auto& r = resources_[idx];
+    if (r.is_swapchain) return false;  // swapchain は set_swapchain_images を使う
+
+    // 既に owned で確保済みなら先に解放 (is_external=false の状態で destroy)。
+    if (!r.is_external) {
+        destroy_one_(r);
+    } else {
+        r.images.clear();
+        r.views.clear();
+        r.memories.clear();
+    }
+    r.is_external = true;
+    r.images.assign(images.begin(), images.end());
+    r.views.assign(views.begin(), views.end());
+    r.vk_format = format;
+    r.extent    = extent;
+    return true;
 }
 
 void AttachmentRegistry::shutdown_vulkan() {

--- a/src/postprocess/postprocess_pipeline.cpp
+++ b/src/postprocess/postprocess_pipeline.cpp
@@ -50,6 +50,16 @@ VkImageView PostProcessPipeline::scene_depth_view() const {
     return targets_[static_cast<size_t>(scene_index_)].depth_view;
 }
 
+VkImage PostProcessPipeline::scene_color_image() const {
+    if (scene_index_ < 0) return VK_NULL_HANDLE;
+    return targets_[static_cast<size_t>(scene_index_)].image;
+}
+
+VkImage PostProcessPipeline::scene_depth_image() const {
+    if (scene_index_ < 0) return VK_NULL_HANDLE;
+    return targets_[static_cast<size_t>(scene_index_)].depth_image;
+}
+
 uint32_t PostProcessPipeline::find_memory_type_(uint32_t filter,
                                                 VkMemoryPropertyFlags props) const {
     VkPhysicalDeviceMemoryProperties mp{};

--- a/src/vector/rive_renderer.cpp
+++ b/src/vector/rive_renderer.cpp
@@ -121,6 +121,10 @@ bool RiveRenderer::is_initialized() const {
 
 // ─── initialize / shutdown ───────────────────────────────────
 
+bool RiveRenderer::initialize(VulkanContext& vk_ctx) {
+    return initialize(vk_ctx, Options{});
+}
+
 bool RiveRenderer::initialize(VulkanContext& vk_ctx, const Options& opts) {
     (void)vk_ctx; (void)opts;
 #if !defined(PICTOR_HAS_RIVE)


### PR DESCRIPTION
caller-owned VkImage / VkImageView を attachment として register できる API を追加。 KS の Phase 4 wiring (FrameComposer → \`execute_compiled\`) で、 既存 \`PostProcessLayer\` 内部の \`scene_hdr_color\` (PostProcessPipeline 所有) を AttachmentRegistry 経由で CompiledGraph に渡せるようにするための前提改修。

## 変更

- \`AttachmentRegistry::Resource\` に \`is_external\` フラグ追加 (caller-owned, destroy しない)
- \`AttachmentRegistry::set_external_attachment(name, images, views, format, extent)\` 追加
  - 既存 owned resource があれば解放して caller-owned に差替え
  - swapchain attachment には使えない (\`set_swapchain_images\` を使うこと)
- \`destroy_one_\`: \`is_external\` も \`is_swapchain\` 同様 skip
- \`resize\`: \`is_external\` も skip (host が再 inject)

## 検証

- CTest 12/12 PASS (既存 unit test 全 green)
- Vulkan device を要する set_external_attachment 自体の round-trip は KS 統合 PR で検証

## 関連

- KS 側 PR (Phase 4 wiring) はこの PR merge 後に出す予定。 spec \`pipeline-system-b-config.md\` §4.4 のステップ D

🤖 Generated with [Claude Code](https://claude.com/claude-code)