### PR TITLE
feat(pipeline): RenderPassRegistry::set_external_render_pass

### DIFF
--- a/include/pictor/pipeline/render_pass_registry.h
+++ b/include/pictor/pipeline/render_pass_registry.h
@@ -59,6 +59,16 @@ public:
     /// `attachments.index_of()`. Missing names → fatal log + skip.
     bool initialize_vulkan(VkDevice device, const AttachmentRegistry& attachments);
 
+    /// Replace a pass's VkRenderPass with a caller-owned external handle.
+    /// 既に build_one_ で確保済みだった内部 VkRenderPass は解放してから
+    /// external に差替える。 KS の Phase 4 で `PostProcessPipeline` 内部の
+    /// scene_render_pass を CompiledGraph に reuse させるために使う。
+    ///
+    /// 必ず `initialize_vulkan()` の **後** に呼ぶこと (内部 handle の
+    /// destroy が必要なため)。 戻り値 false: name 未登録 / index 不整合。
+    /// 以後 `shutdown_vulkan()` では destroy されない (caller 所有)。
+    bool set_external_render_pass(std::string_view name, VkRenderPass rp);
+
     void shutdown_vulkan();
 
     VkRenderPass get(uint16_t index) const {
@@ -76,6 +86,7 @@ private:
 
     VkDevice                  device_ = VK_NULL_HANDLE;
     std::vector<VkRenderPass> passes_render_passes_;
+    std::vector<uint8_t>      passes_is_external_;  // 1 = caller-owned, do not destroy
 #endif
 };
 

--- a/src/pipeline/render_pass_registry.cpp
+++ b/src/pipeline/render_pass_registry.cpp
@@ -155,21 +155,44 @@ bool RenderPassRegistry::build_one_(uint16_t index, const AttachmentRegistry& at
 bool RenderPassRegistry::initialize_vulkan(VkDevice device, const AttachmentRegistry& atts) {
     device_ = device;
     passes_render_passes_.assign(passes_.size(), VK_NULL_HANDLE);
+    passes_is_external_.assign(passes_.size(), 0);
     for (uint16_t i = 0; i < static_cast<uint16_t>(passes_.size()); ++i) {
         if (!build_one_(i, atts)) return false;
     }
     return true;
 }
 
+bool RenderPassRegistry::set_external_render_pass(std::string_view name, VkRenderPass rp) {
+    uint16_t idx = index_of(name);
+    if (idx == INVALID_INDEX) return false;
+    if (idx >= passes_render_passes_.size()) return false;  // initialize_vulkan 未呼出
+    // 既に内部 build 済の VkRenderPass があれば解放 (external なら skip)。
+    const bool was_external = (idx < passes_is_external_.size()) && passes_is_external_[idx];
+    if (!was_external && passes_render_passes_[idx] && device_) {
+        vkDestroyRenderPass(device_, passes_render_passes_[idx], nullptr);
+    }
+    passes_render_passes_[idx] = rp;
+    if (passes_is_external_.size() <= idx) {
+        passes_is_external_.resize(static_cast<size_t>(idx) + 1u, 0);
+    }
+    passes_is_external_[idx] = 1;
+    return true;
+}
+
 void RenderPassRegistry::shutdown_vulkan() {
     if (!device_) {
         passes_render_passes_.clear();
+        passes_is_external_.clear();
         return;
     }
-    for (VkRenderPass rp : passes_render_passes_) {
-        if (rp) vkDestroyRenderPass(device_, rp, nullptr);
+    for (size_t i = 0; i < passes_render_passes_.size(); ++i) {
+        const bool external = (i < passes_is_external_.size()) && passes_is_external_[i];
+        if (!external && passes_render_passes_[i]) {
+            vkDestroyRenderPass(device_, passes_render_passes_[i], nullptr);
+        }
     }
     passes_render_passes_.clear();
+    passes_is_external_.clear();
     device_ = VK_NULL_HANDLE;
 }
 


### PR DESCRIPTION
caller-owned VkRenderPass を register できる API を追加。 KS Phase 4 step 2 で \`PostProcessPipeline\` 内部の \`scene_render_pass\` を CompiledGraph の OpaquePass に reuse させるための前提改修。

## 変更

- \`RenderPassRegistry::Resource\` 相当 \`passes_is_external_\` (uint8_t bitvec) 追加
- \`set_external_render_pass(name, VkRenderPass)\` 追加 (initialize_vulkan の **後** に呼ぶ)
- shutdown_vulkan: external なら destroy skip

## 互換性

\`FramebufferRegistry::build_one_\` は \`rps.get(idx)\` を引くだけなので、 external が set されていれば自動的にそれを使って framebuffer を build する。 PP の \`scene_render_pass\` と AttachmentRegistry の \`scene_hdr_color\` / \`scene_depth\` は format + sample count が一致するため Vulkan render pass compatibility 要件を満たす (load/store/layout の差異は許容)。

## 検証

CTest 12/12 PASS。 KS 統合は後続 PR で。

## 関連

- LUDIARS/Pictor #63 (merged) — set_external_attachment / scene_color_image getter
- MELPOT/KuzuSurvivors #8 (merged) — Phase 4 step 1 infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)