### PR TITLE
feat(animation): AnimationSystem::get_instance_mutable

### DIFF
--- a/include/pictor/animation/animation_system.h
+++ b/include/pictor/animation/animation_system.h
@@ -202,6 +202,15 @@ public:
     const AnimationClip* get_clip(AnimationClipHandle handle) const;
     const AnimationInstance* get_instance(AnimationStateHandle handle) const;
 
+    /// Mutable accessor — `play()` 直後の最後尾 layer に
+    /// `AnimationPlayback::channel_remap` を差し込む等、 host が layer
+    /// メタデータを直接書き換える必要があるケース向け。 host が同じ instance を
+    /// 同時並行で書き換えないこと (single-thread per state を期待)。
+    /// 互換: 既存の `get_instance()` を `const_cast<AnimationInstance*>(get_instance(h))`
+    /// で代用していたコード (MontagePlayer, KS LocomotionBlend) は本 API に
+    /// 段階的に移行する。
+    AnimationInstance* get_instance_mutable(AnimationStateHandle handle);
+
     uint32_t active_instance_count() const { return active_instance_count_; }
     const AnimationSystemConfig& config() const { return config_; }
 

--- a/src/animation/animation_system.cpp
+++ b/src/animation/animation_system.cpp
@@ -388,6 +388,11 @@ const AnimationInstance* AnimationSystem::get_instance(AnimationStateHandle hand
     return (it != instances_.end()) ? it->second.get() : nullptr;
 }
 
+AnimationInstance* AnimationSystem::get_instance_mutable(AnimationStateHandle handle) {
+    auto it = instances_.find(handle);
+    return (it != instances_.end()) ? it->second.get() : nullptr;
+}
+
 // ============================================================
 // 2D / Rive / Lottie / Vector Factories
 // ============================================================

--- a/src/animation/montage.cpp
+++ b/src/animation/montage.cpp
@@ -67,7 +67,7 @@ void MontagePlayer::play(AnimationStateHandle inst, MontageHandle m,
     // (locomotion ブレンド等) と同一 instance で共存しうるので、 layer 0 を
     // 決め打ちせず実 index を使う。 同時に remap テーブルを最後尾 layer へ差し込む。
     uint32_t layer_index = 0;
-    if (auto* inst_data = const_cast<AnimationInstance*>(sys_.get_instance(inst))) {
+    if (auto* inst_data = sys_.get_instance_mutable(inst)) {
         if (!inst_data->layers.empty()) {
             layer_index = static_cast<uint32_t>(inst_data->layers.size() - 1);
             const auto* remap = get_bone_remap(d.clip, skel);


### PR DESCRIPTION
post-play layer メタデータ (AnimationPlayback::channel_remap 等) を host が書き換えるための mutable accessor を追加。 これまで MontagePlayer / KS LocomotionBlend は `const_cast<AnimationInstance*>(get_instance(h))` で代用しており、 const 違反扱いだった。

## 変更
- `get_instance(const)` と並列で `get_instance_mutable()` を追加
- `montage.cpp`: 既存の const_cast trick を新 API に置換

## 検証
CTest 12/12 PASS

## 関連
- LUDIARS/Pictor #63 #64 (Phase 4 wiring 系)
- MELPOT/KuzuSurvivors #12 (LocomotionBlend remap — 移行は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)