### PR TITLE
feat(pipeline): host_recorded pass flag (Phase 4 step 3 前提)

### DIFF
--- a/include/pictor/pipeline/compiled_graph.h
+++ b/include/pictor/pipeline/compiled_graph.h
@@ -67,11 +67,19 @@ struct CompiledPass {
     /// ポインタ)。 hot path では読まない。
     const char*                    debug_name = nullptr;
 
-    static constexpr uint8_t FLAG_IS_SWAPCHAIN = 1u << 0;
-    static constexpr uint8_t FLAG_IS_COMPUTE   = 1u << 1;
+    static constexpr uint8_t FLAG_IS_SWAPCHAIN    = 1u << 0;
+    static constexpr uint8_t FLAG_IS_COMPUTE      = 1u << 1;
+    /// host_recorded: execute_compiled は Begin/End render pass / pipeline bind を
+    /// 一切発行せず、 PassRecordFn 内で host が完全に command 記録を行う。
+    /// PostProcessPipeline のように内部で複数 sub-render-pass を持つ chain を
+    /// 単一 CompiledGraph entry として表現するための逃げ口。 KS の
+    /// `kuzu.profile.json` PostProcess pass で使う。 compute pass と類似
+    /// (Begin/End 不要)、 ただし graphics queue で動く点が違うので別 flag。
+    static constexpr uint8_t FLAG_IS_HOST_RECORDED = 1u << 2;
 
-    bool is_swapchain() const { return (flags & FLAG_IS_SWAPCHAIN) != 0; }
-    bool is_compute()   const { return (flags & FLAG_IS_COMPUTE) != 0; }
+    bool is_swapchain()     const { return (flags & FLAG_IS_SWAPCHAIN) != 0; }
+    bool is_compute()       const { return (flags & FLAG_IS_COMPUTE) != 0; }
+    bool is_host_recorded() const { return (flags & FLAG_IS_HOST_RECORDED) != 0; }
 };
 static_assert(sizeof(CompiledPass) <= 256,
               "CompiledPass should stay cache-friendly (≤256B target)");

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -88,6 +88,16 @@ struct RenderPassDef {
     /// CLEAR/STORE for color, CLEAR/DONT_CARE for depth, PRESENT_SRC_KHR
     /// for swapchain. See `spec/pipeline-system-b-config.md` §3.2.
     std::vector<AttachmentOpsDef> attachment_ops;
+
+    /// host_recorded: `RenderPassScheduler::execute_compiled` は本 pass の
+    /// Begin/End render pass / pipeline bind を一切発行せず、 PassRecordFn
+    /// 内で host が完全に command 記録する。 `PostProcessPipeline::composite`
+    /// のように内部で複数 sub-render-pass を持つチェーンを単一 CompiledGraph
+    /// entry として表現したいとき使う (Phase 4 step 3)。 当該 pass の
+    /// `render_targets` / `attachment_ops` は framebuffer / VkRenderPass 生成
+    /// にも使われないので空でよい (CompiledPass.render_pass / framebuffers は
+    /// VK_NULL_HANDLE)。
+    bool                    host_recorded    = false;
 };
 
 /// Profiler configuration (§8.2)

--- a/src/pipeline/pipeline_compiler.cpp
+++ b/src/pipeline/pipeline_compiler.cpp
@@ -164,6 +164,10 @@ CompiledGraph PipelineCompiler::compile(const PipelineProfileDef&  profile,
         const bool is_swap = pass_has_swapchain_target(pd, atts);
         if (is_swap) cp.flags |= CompiledPass::FLAG_IS_SWAPCHAIN;
         if (pd.pass_type == PassType::COMPUTE) cp.flags |= CompiledPass::FLAG_IS_COMPUTE;
+        // host_recorded フラグは pass def から伝播。 execute_compiled は
+        // Begin/End render pass / pipeline bind を一切発行せず host record に
+        // 完全委譲する (Phase 4 step 3 / PostProcessPipeline 等の chain pass)。
+        if (pd.host_recorded) cp.flags |= CompiledPass::FLAG_IS_HOST_RECORDED;
 
         const uint32_t slot_count = is_swap ? swapchain_image_count : flight_count;
         const uint32_t copy_count = std::min<uint32_t>(slot_count, static_cast<uint32_t>(cp.framebuffers.size()));

--- a/src/pipeline/pipeline_profile_serializer.cpp
+++ b/src/pipeline/pipeline_profile_serializer.cpp
@@ -647,6 +647,10 @@ bool parse_render_pass(Parser& pr, RenderPassDef& out) {
             return true;
         } else if (key == "gpu_driven_pass") {
             return p.parse_bool(out.gpu_driven_pass);
+        } else if (key == "host_recorded") {
+            // Phase 4 step 3: host_recorded — execute_compiled が Begin/End
+            // render pass / pipeline bind を発行せず host record に委譲する。
+            return p.parse_bool(out.host_recorded);
         } else if (key == "required_streams") {
             return p.parse_string_array(out.required_streams);
         } else if (key == "attachment_ops") {
@@ -1119,6 +1123,9 @@ std::string to_pipeline_profile_json(const PipelineProfileDef& def) {
             pad(out, 3); out += "\"sort_mode\":        "; quote(out, sort_mode_to_str(rp.sort_mode)); out += ",\n";
             pad(out, 3); out += "\"filter_mask\":      "; emit_uint(out, rp.filter_mask); out += ",\n";
             pad(out, 3); out += "\"gpu_driven_pass\":  "; emit_bool(out, rp.gpu_driven_pass); out += ",\n";
+            if (rp.host_recorded) {
+                pad(out, 3); out += "\"host_recorded\":    "; emit_bool(out, rp.host_recorded); out += ",\n";
+            }
             pad(out, 3); out += "\"required_streams\": "; emit_string_array(out, rp.required_streams);
             if (!rp.attachment_ops.empty()) {
                 out += ",\n";

--- a/src/pipeline/render_pass_registry.cpp
+++ b/src/pipeline/render_pass_registry.cpp
@@ -62,6 +62,15 @@ AttachmentOpsDef infer_op(const std::string& target, const AttachmentRegistry& a
 bool RenderPassRegistry::build_one_(uint16_t index, const AttachmentRegistry& atts) {
     const RenderPassDef& pd = passes_[index];
 
+    // host_recorded passes は host が内部で sub-render-pass を自前管理する
+    // (PostProcessPipeline chain 等)。 RenderPassRegistry は VkRenderPass を
+    // 生成しない (空 handle のまま)。 execute_compiled の host_recorded 分岐
+    // で Begin/End は完全に skip される。
+    if (pd.host_recorded) {
+        passes_render_passes_[index] = VK_NULL_HANDLE;
+        return true;
+    }
+
     // Compute view (attachment_ops, in render_targets order).
     std::vector<AttachmentOpsDef> resolved;
     resolved.reserve(pd.render_targets.size());

--- a/src/pipeline/render_pass_scheduler.cpp
+++ b/src/pipeline/render_pass_scheduler.cpp
@@ -132,6 +132,14 @@ void RenderPassScheduler::execute_compiled(VkCommandBuffer cmd,
             continue;
         }
 
+        if (cp.is_host_recorded()) {
+            // host_recorded: PostProcess chain 等、 内部で複数 sub-render-pass
+            // を持つ pass。 execute_compiled は Begin/End / BindPipeline を
+            // 一切発行せず、 host の record callback に command 記録を委ねる。
+            if (record) record(cmd, cp, flight_index, image_index);
+            continue;
+        }
+
         if (cp.render_pass == VK_NULL_HANDLE || fb == VK_NULL_HANDLE) {
             // Missing GPU resources — host record can still observe the
             // pass (e.g. for tagging) but BeginRenderPass would assert.


### PR DESCRIPTION
PostProcessPipeline のように内部で複数 sub-render-pass を持つチェーンを、 単一 CompiledGraph entry として表現するための逃げ口。 KS Phase 4 step 3 で PostProcess を CompiledGraph に乗せるための前提改修。

## 変更
- `CompiledPass::FLAG_IS_HOST_RECORDED` (bit2) + `is_host_recorded()`
- `RenderPassDef::host_recorded` フィールド (default false、 後方互換)
- PipelineCompiler / RenderPassRegistry / execute_compiled が新 flag を尊重
- 単一 pass の Begin/End / BindPipeline を完全 skip、 PassRecordFn に委譲
- JSON serializer の parse + emit

## 意味論
- compute pass との違い: graphics queue で動く + host が内部で複数 sub-pass を持ちうる
- attachment_ops / render_targets は host_recorded 時 PipelineCompiler から無視
- CompiledPass.render_pass / framebuffers は VK_NULL_HANDLE のまま

## KS 側利用 (後続 PR)
profile に `{"pass_name": "PostProcess", "host_recorded": true}` を追加し、 PassRecordFn で `pp_layer_.composite()` を呼ぶ。

## 検証
CTest 12/12 PASS。 既存 host_recorded=false で完全後方互換。

## 関連
- Issue [#13](https://github.com/MELPOT/KuzuSurvivors/issues/13) — Phase 4 step 3+
- Pictor PR #63 #64 #65 (Phase 4 wiring 系)

🤖 Generated with [Claude Code](https://claude.com/claude-code)