### PR TITLE
feat(vulkan): opt-out for built-in default render pass

### DIFF
--- a/include/pictor/surface/vulkan_context.h
+++ b/include/pictor/surface/vulkan_context.h
@@ -17,6 +17,16 @@ struct VulkanContextConfig {
     const char* app_name    = "Pictor";
     uint32_t    app_version = 1;
     bool        validation  = false;  // VK_LAYER_KHRONOS_validation
+    /// 既定: true — VulkanContext が組み込みの swapchain default render pass
+    /// + framebuffers を自動生成する (simple_renderer / ui_overlay_pipeline /
+    /// bitmap_text_renderer 等の easy-mode consumer 向け)。
+    ///
+    /// false にすると create_render_pass / framebuffers を skip し、 host が
+    /// RenderPassRegistry + FramebufferRegistry 経由で profile-driven に作る
+    /// 前提になる (KS Phase 4 step 4 など `default_render_pass()` を使わない
+    /// パス専用)。 default_render_pass() / framebuffers() は VK_NULL_HANDLE を
+    /// 返すので、 これらに依存するコンポーネントは同居できない。
+    bool        create_default_render_pass = true;
 };
 
 /// Manages the Vulkan instance, physical/logical device, queue,
@@ -127,6 +137,10 @@ private:
 
     VkRenderPass             render_pass_        = VK_NULL_HANDLE;
     std::vector<VkFramebuffer> framebuffers_;
+    /// initialize 時の cfg を保存する (recreate_swapchain で再利用)。
+    /// `create_default_render_pass=false` で起動した host は recreate でも
+    /// default RP を作らない方が一貫する。
+    bool                     create_default_rp_on_init_ = true;
 
     VkCommandPool            command_pool_       = VK_NULL_HANDLE;
     std::vector<VkCommandBuffer> command_buffers_;

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -37,14 +37,22 @@ bool VulkanContext::initialize(ISurfaceProvider* provider,
     if (!provider) return false;
     provider_ = provider;
 
+    create_default_rp_on_init_ = cfg.create_default_render_pass;
+
     if (!create_instance(cfg))              return false;
     if (!create_surface())                  return false;
     if (!pick_physical_device())            return false;
     if (!create_logical_device())           return false;
     if (!create_swapchain())                return false;
     if (!create_image_views())              return false;
-    if (!create_render_pass())              return false;
-    if (!create_framebuffers())             return false;
+    // Phase 4 step 4: host が profile-driven (RenderPassRegistry +
+    // FramebufferRegistry) で自前 RP/FB を作るなら、 ここをスキップする。
+    // default_render_pass() / framebuffers() は VK_NULL_HANDLE / 空 vector を
+    // 返すので、 旧 easy-mode consumer はリンク時に NULL チェック必要。
+    if (create_default_rp_on_init_) {
+        if (!create_render_pass())              return false;
+        if (!create_framebuffers())             return false;
+    }
     if (!create_command_pool_and_buffers()) return false;
     if (!create_sync_objects())             return false;
 
@@ -87,8 +95,10 @@ bool VulkanContext::recreate_swapchain() {
 
     if (!create_swapchain())    return false;
     if (!create_image_views())  return false;
-    if (!create_render_pass())  return false;
-    if (!create_framebuffers()) return false;
+    if (create_default_rp_on_init_) {
+        if (!create_render_pass())  return false;
+        if (!create_framebuffers()) return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
Phase 4 step 4 (`spec/pipeline-system-b-config.md` §4.4) 段階的解消の一手。 `VulkanContextConfig::create_default_render_pass` (default true) を追加。 profile-driven host (RenderPassRegistry + FramebufferRegistry を自前で回す KS Phase 4 等) は false にしてビルトイン default RP を回避できる。

## 後方互換
default true。 KS / AdventureCube / Pictor demo は無変更で従来通り動く。

## false の意味
- VulkanContext::create_render_pass / create_framebuffers を skip
- `default_render_pass()` は VK_NULL_HANDLE / `framebuffers()` は空 vector
- 依存する easy-mode consumer (simple_renderer / ui_overlay_pipeline / bitmap_text_renderer / decal_system pipeline init) は同居不可

## 関連
- Issue [#13](https://github.com/MELPOT/KuzuSurvivors/issues/13) — Phase 4 step 4
- KS 統合 PR は本 PR merge 後に出す

🤖 Generated with [Claude Code](https://claude.com/claude-code)