### PR TITLE
fix(pipeline): skip framebuffer build for host_recorded passes

### DIFF
--- a/src/pipeline/framebuffer_registry.cpp
+++ b/src/pipeline/framebuffer_registry.cpp
@@ -23,6 +23,20 @@ bool FramebufferRegistry::build_one_(uint16_t pass_index,
     const RenderPassDef& pd = rps.pass(pass_index);
     PassEntry& e = entries_[pass_index];
 
+    // host_recorded passes: host (アプリ) が内部で Begin/End / Pipeline bind を
+    // 自前管理するため、 framework 側で framebuffer を作る必要は無い。
+    // RenderPassRegistry も同様に VkRenderPass を生成しない (空 handle のまま)
+    // ので、 ここで build を試みると「has no VkRenderPass」 で必ず失敗する。
+    // KS の PostProcess / DecalCompose のように、 内部で複数 sub-render-pass を
+    // 持つチェーンを CompiledGraph entry として 1 つで表現するための逃げ口
+    // (Phase 4 step 3 / Pictor PR #66 と対)。
+    if (pd.host_recorded) {
+        e.is_swapchain = false;
+        e.extent       = {0, 0};
+        e.framebuffers.clear();
+        return true;
+    }
+
     // Look up attachment indices once.
     std::vector<uint16_t> att_indices;
     att_indices.reserve(pd.render_targets.size());


### PR DESCRIPTION
## Summary
- `FramebufferRegistry::build_one_` が `host_recorded=true` のパスでも framebuffer を作ろうとして、 RenderPassRegistry が host_recorded に VkRenderPass を生成しない仕様 (PR #66) と噛み合わずに必ず失敗していた問題を修正
- 冒頭で `pd.host_recorded` を見て PassEntry を空のまま early-return

## 実害
KS の Phase 4 step 3 (#17) で DecalCompose / PostProcess を host_recorded にした直後から:
```
[FramebufferRegistry] pass 'DecalCompose' has no VkRenderPass
[phase3] FramebufferRegistry::initialize_vulkan failed
[render] Phase 3 配線 init 失敗 — 既存パスで続行
```
→ scheduler が install されない → scene 描画スキップ → **真っ黒な画面 + 最小 HUD のみ** という状態。

## 修正後
```
[phase3] OK — profile='KuzuSurvivors' attachments=3 passes=3 (graph passes=3)
[render] Phase 4 scheduler installed (KUZU_PHASE4_EXEC=1)
```

## Test plan
- [x] KS Release ビルド通過
- [x] KS smoke で Phase 3 init 成功ログ確認
- [ ] 視覚確認: KS でゲーム画面が見えるか (ユーザ実機)

## 関連
- Pictor #66 host_recorded flag
- KS #17 Phase 4 step 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)