### PR TITLE
chore(framebuffer-registry): host-recorded コメントから KS 固有参照を外す

### DIFF
--- a/src/pipeline/framebuffer_registry.cpp
+++ b/src/pipeline/framebuffer_registry.cpp
@@ -23,13 +23,13 @@ bool FramebufferRegistry::build_one_(uint16_t pass_index,
     const RenderPassDef& pd = rps.pass(pass_index);
     PassEntry& e = entries_[pass_index];
 
-    // host_recorded passes: host (アプリ) が内部で Begin/End / Pipeline bind を
-    // 自前管理するため、 framework 側で framebuffer を作る必要は無い。
-    // RenderPassRegistry も同様に VkRenderPass を生成しない (空 handle のまま)
-    // ので、 ここで build を試みると「has no VkRenderPass」 で必ず失敗する。
-    // KS の PostProcess / DecalCompose のように、 内部で複数 sub-render-pass を
-    // 持つチェーンを CompiledGraph entry として 1 つで表現するための逃げ口
-    // (Phase 4 step 3 / Pictor PR #66 と対)。
+    // Host-managed multi-pass chains: host (application) が内部で
+    // Begin/End / Pipeline bind を自前管理するため、 framework 側で
+    // framebuffer を作る必要は無い。 RenderPassRegistry も同様に
+    // VkRenderPass を生成しない (空 handle のまま) ので、 ここで build を
+    // 試みると「has no VkRenderPass」 で必ず失敗する。
+    // 内部で複数 sub-render-pass を持つチェーンを CompiledGraph entry として
+    // 1 つで表現するための逃げ口 (Pictor PR #66 で導入)。
     if (pd.host_recorded) {
         e.is_swapchain = false;
         e.extent       = {0, 0};


### PR DESCRIPTION
## Summary

`FramebufferRegistry::build_one_()` 冒頭の host_recorded ガード (PR #68) の
コメントが \"KS の PostProcess / DecalCompose のように...\" と consumer 固有の
ゲーム名を含んでいた。 Pictor は下層 library なので、 library 単体での可読性を
保つため \"Host-managed multi-pass chains\" の汎用表現に置き換えた。

ロジックは変更なし (コメント変更のみ)。

ludiars-review-daily 2026-05-25 (Pictor) の bounded fix 候補
(REVIEW_QUALITY.md §3 / REVIEW_MISSING_FEATURES.md §1)。

## Test plan

- [ ] ビルドが通る (KuzuSurvivors Release / Pictor unit tests)
- [ ] `git diff` で論理変更がコメントのみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code) — ludiars-review-daily 2026-05-25