### PR TITLE
docs: spec/setup に用途別セットアップガイドを追加

### DIFF
--- a/spec/setup/README.md
+++ b/spec/setup/README.md
@@ -1,0 +1,51 @@
+# Pictor セットアップガイド (用途別)
+
+> Pictor (LUDIARS 短縮コード **Pc**) は最下層のレンダリングパイプラインモジュール。
+> Pictor 自体は **ライブラリ** (`libpictor` 静的ライブラリ) であり、実行確認は consumer 側の責務 ([[feedback_pictor_no_run]])。
+> 本ガイドは **「ビルドと統合」** にフォーカスする。
+
+このフォルダは「○○するためにどうビルドするか」を用途別に引ける索引。
+詳細はリンク先に置き、ここでは要点と最短手順だけを示す (DRY。`../../README.md` / `../../CLAUDE.md` の丸写しはしない)。
+
+## 前提
+
+| 項目 | 要件 | 根拠 |
+|---|---|---|
+| ビルドシステム | **CMake** (3.20 以上) のみ。premake は Pictor 本体では使わない (Rive を prebuilt 消費するだけ) | `../../CMakeLists.txt:1` |
+| C++ | C++20 対応コンパイラ (GCC / Clang / MSVC) | `../../CMakeLists.txt:4` |
+| CPU | x86/x64 では AVX2 を使用 (ARM64 は `PICTOR_IS_X86` ガードで自動回避) | `../../CMakeLists.txt:271-285` |
+| Vulkan SDK | GPU 機能に必要。未検出時は `find_package(Vulkan QUIET)` でスキップされ、headless デモ/テストのみビルド | `../../CMakeLists.txt:46-49` |
+| GLFW 3.4 | デスクトップのみ。システム未検出時は FetchContent で自動取得 | `../../CMakeLists.txt:51-72` |
+
+## 最短ビルド (ライブラリのみ)
+
+```bash
+cmake -B build -DPICTOR_BUILD_DEMO=OFF
+cmake --build build --config Release --target pictor
+```
+
+- consumer に組み込むだけなら通常 `add_subdirectory` で取り込むので、単体ビルドは不要 → [`integration.md`](integration.md)。
+- **Release 必須の事情** (prebuilt rive_yoga.lib の CRT) は Rive を有効化したときのみ → [`build.md`](build.md) §Release/Debug。
+
+## 用途別インデックス
+
+| 用途 | 設定 | 参照 |
+|---|---|---|
+| 標準ビルド (generate→build、Debug/Release、依存) | `cmake -B build` → `cmake --build build` | [`build.md`](build.md) |
+| ライブラリだけ欲しい (デモ・テスト不要) | `-DPICTOR_BUILD_DEMO=OFF -DPICTOR_BUILD_TESTS=OFF` | [`build-options.md`](build-options.md) |
+| ベクター/Rive アニメを使いたい | `-DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=<path>` (要 prebuilt rive-runtime) | [`build-options.md`](build-options.md) §Rive / [`build.md`](build.md) |
+| プロファイラを切りたい | `-DPICTOR_ENABLE_PROFILER=OFF` | [`build-options.md`](build-options.md) |
+| ラージページ確保を試したい | `-DPICTOR_USE_LARGE_PAGES=ON` | [`build-options.md`](build-options.md) |
+| WebGL2 (ブラウザ) バックエンド | `-DPICTOR_BUILD_WEBGL=ON` (Emscripten) | [`build-options.md`](build-options.md) §WebGL |
+| 開発者ツール (feature-selector) を開きたい | `-DPICTOR_BUILD_TOOLS=ON` | [`build-options.md`](build-options.md) |
+| ヘッドレステストを回したい | `-DPICTOR_BUILD_TESTS=ON` (既定) → `ctest` | [`build.md`](build.md) §テスト |
+| consumer (KS 等) に組み込みたい | `add_subdirectory(Pictor)` + `target_link_libraries(... pictor)` | [`integration.md`](integration.md) |
+| Android NDK / iOS でクロスビルド | `PICTOR_MOBILE` 分岐 (GLFW 無効化、NDK Vulkan) | [`../../docs/android-build.md`](../../docs/android-build.md) |
+
+## 関連設計
+
+- ビルドオプション一覧の正本: `../../README.md` の「ビルドオプション」表 + `../../CMakeLists.txt`。
+- Rive 統合設計: [[project_pictor_rive]] / `../../cmake/FindRive.cmake`。
+- レンダリング拡張 (Visus / カスタムシェーダ): [`../rendering-extensibility-design.md`](../rendering-extensibility-design.md)。
+- WebGL2 バックエンド設計: `../../docs/design/webgl_backend.md`。
+- モバイル: `../../docs/android-build.md`。

--- a/spec/setup/build-options.md
+++ b/spec/setup/build-options.md
@@ -1,0 +1,71 @@
+# ビルドオプション / define / 環境変数
+
+`../../CMakeLists.txt` で実在を確認したものだけを列挙する。手順は [`build.md`](build.md)、索引は [`README.md`](README.md)。
+
+## CMake option (`-D<NAME>=ON/OFF`)
+
+| オプション | 既定 | 効果 | 例 / 根拠 |
+|---|---|---|---|
+| `PICTOR_BUILD_DEMO` | `ON` | デモ + ベンチマーク群をビルド。ウィンドウデモは Vulkan + GLFW 必須 | `-DPICTOR_BUILD_DEMO=OFF` / `:8` |
+| `PICTOR_BUILD_TOOLS` | `OFF` | 開発者ツール target (feature-selector 等) を有効化。`pictor` ライブラリサイズには影響しない | `-DPICTOR_BUILD_TOOLS=ON` / `:9,573` |
+| `PICTOR_BUILD_TESTS` | `ON` | headless テストスイート (CTest) をビルド (非モバイルのみ) | `-DPICTOR_BUILD_TESTS=OFF` / `:10,557` |
+| `PICTOR_ENABLE_PROFILER` | `ON` | 組込みプロファイラを有効化 → define `PICTOR_PROFILER_ENABLED=1` | `-DPICTOR_ENABLE_PROFILER=OFF` / `:11,246` |
+| `PICTOR_USE_LARGE_PAGES` | `OFF` | ラージページ確保を有効化 → define `PICTOR_LARGE_PAGES=1` (PRIVATE) | `-DPICTOR_USE_LARGE_PAGES=ON` / `:12,250` |
+| `PICTOR_BUILD_WEBGL` | `OFF` | WebGL2 バックエンド (別ライブラリ `pictor_webgl`) をビルド。Emscripten 前提 | `-DPICTOR_BUILD_WEBGL=ON` / `:13,390` |
+| `PICTOR_ENABLE_RIVE` | `OFF` | Rive Renderer 統合。prebuilt rive-runtime が必要 (下記 §Rive) | `-DPICTOR_ENABLE_RIVE=ON` / `:14,260` |
+
+> 注: `../../README.md` には `PICTOR_BUILD_C_API` (C ABI エクスポート) が列挙されているが、現行 `../../CMakeLists.txt` には対応する `option()` もターゲット定義も無く、ビルドフラグとしては未配線。`include/pictor/c_api.h` / `src/c_api/c_api.cpp` のソースは存在するが、現状このフラグを渡しても効果は無い。同様に consumer (KS) や CI が渡す `PICTOR_BUILD_BENCHMARK` も Pictor 側では未配線で、無害なキャッシュ変数として無視される。本ガイドでは未実装のため操作対象に含めない。
+
+## Rive 統合の入力 (§Rive)
+
+`PICTOR_ENABLE_RIVE=ON` のとき `find_package(Rive REQUIRED)` が走り、`Rive::Rive` をリンクして `PICTOR_HAS_RIVE=1` を define する (`../../CMakeLists.txt:260-265`)。`cmake/FindRive.cmake` が参照する入力:
+
+| 変数 | 既定 | 効果 | 根拠 |
+|---|---|---|---|
+| `PICTOR_RIVE_DIR` | (未設定) | rive-runtime チェックアウトのルート。`renderer/out/<config>/` に compiled static lib がある想定。未設定なら `Rive_FOUND=FALSE` | `../../cmake/FindRive.cmake:11-14,36-39` |
+| `PICTOR_RIVE_CONFIG` | `release` | シングルコンフィグ生成系での構成フォールバック (`release` / `debug`)。マルチコンフィグ生成系では両方を探索し per-config マッピング | `../../cmake/FindRive.cmake:15-22,41-43` |
+
+prebuilt のビルド手順は [`build.md`](build.md) §4 を参照。**Rive 有効時は Release 必須** (rive_yoga.lib が Release 専用 CRT、Debug は LNK2038/LNK1319) ([[feedback_ks_release_build_required]])。
+
+## コンパイル define (Pictor が立てるもの)
+
+option やプラットフォーム検出から自動で立つ define。consumer が手で渡すものではないが、条件付きコードを読むときの参照用。
+
+| define | 立つ条件 | スコープ | 根拠 |
+|---|---|---|---|
+| `PICTOR_HAS_VULKAN=1` | `Vulkan_FOUND` | PUBLIC | `:220` |
+| `PICTOR_PROFILER_ENABLED=1` | `PICTOR_ENABLE_PROFILER=ON` | PUBLIC | `:247` |
+| `PICTOR_LARGE_PAGES=1` | `PICTOR_USE_LARGE_PAGES=ON` | PRIVATE | `:251` |
+| `PICTOR_HAS_RIVE=1` | `PICTOR_ENABLE_RIVE=ON` | PUBLIC | `:263` |
+| `PICTOR_HAS_WEBGL=1` | `pictor_webgl` ビルド時 | PUBLIC (pictor_webgl) | `:404` |
+| `VK_USE_PLATFORM_WIN32_KHR=1` / `NOMINMAX` | Win32 + Vulkan | PUBLIC | `:237` |
+| `VK_USE_PLATFORM_XLIB_KHR=1` | Linux + Vulkan | PUBLIC | `:239` |
+| `VK_USE_PLATFORM_MACOS_MVK=1` | macOS + Vulkan | PUBLIC | `:241` |
+| `VK_USE_PLATFORM_ANDROID_KHR=1` | Android | PUBLIC | `:224` |
+| `VK_USE_PLATFORM_METAL_EXT=1` | iOS (MoltenVK) | PUBLIC | `:233` |
+
+PUBLIC define は `pictor` をリンクした consumer にも伝播する。
+
+## コンパイルオプション (コンパイラ別)
+
+| 環境 | 付与されるフラグ | 条件 | 根拠 |
+|---|---|---|---|
+| GCC / Clang | `-Wall -Wextra` | 常時 | `:276` |
+| GCC / Clang | `-mavx2` | x86/x64 かつ非モバイル | `:277-279` |
+| MSVC | `/W4 /utf-8` | 常時 (`pictor` への PRIVATE) | `:281` |
+| MSVC | `/arch:AVX2` | x86/x64 | `:282-284` |
+
+### MSVC `/utf-8` は伝播しない (重要)
+
+`/utf-8` は `pictor` への **PRIVATE** 指定なので、consumer / テストターゲットには伝播しない。日本語コメントを含む Pictor の header を取り込む側 (テスト / consumer) は **自前で `/utf-8` を付ける**必要がある ([[feedback_msvc_utf8_test_targets]])。テスト側の実例は `../../tests/CMakeLists.txt:30-33`、consumer 側の付け方は [`integration.md`](integration.md) を参照。
+
+## WebGL2 バックエンド (§WebGL)
+
+`PICTOR_BUILD_WEBGL=ON` または `EMSCRIPTEN` のとき、別ライブラリ `pictor_webgl` をビルドする (`../../CMakeLists.txt:390-409`)。
+
+- Emscripten 環境では `-sUSE_WEBGL2=1` / `-sFULL_ES3=1` が付与される (`:407-408`)。
+- 設計の詳細: `../../docs/design/webgl_backend.md`。
+
+## モバイル (Android / iOS)
+
+`ANDROID` / `IOS` 検出で `PICTOR_MOBILE=ON` となり、GLFW FetchContent とデスクトップ surface provider をスキップ、NDK 同梱 Vulkan / MoltenVK を直接指す (`../../CMakeLists.txt:28-44,206-212`)。AVX2 フラグは `PICTOR_IS_X86` ガードで ARM64 では付かない (`:271-285`)。詳細は `../../docs/android-build.md`。

--- a/spec/setup/build.md
+++ b/spec/setup/build.md
@@ -1,0 +1,97 @@
+# 標準ビルド手順
+
+Pictor は CMake プロジェクト (`../../CMakeLists.txt`)。出力は静的ライブラリ `libpictor` (`add_library(pictor STATIC ...)`、`../../CMakeLists.txt:74`) と、オプションのデモ群。
+
+オプション一覧は [`build-options.md`](build-options.md)、consumer 組込みは [`integration.md`](integration.md) を参照。
+
+## 1. generate → build
+
+```bash
+# generate (構成生成)
+cmake -B build
+
+# build (Release を明示)
+cmake --build build --config Release
+```
+
+- 既定で `PICTOR_BUILD_DEMO=ON` / `PICTOR_BUILD_TESTS=ON` / `PICTOR_ENABLE_PROFILER=ON` (`../../CMakeLists.txt:8-11`)。
+- ライブラリだけ欲しいときは `cmake -B build -DPICTOR_BUILD_DEMO=OFF` 後に `--target pictor`。
+- マルチコンフィグ生成系 (Visual Studio) は `--config` で、シングルコンフィグ生成系 (Ninja / Unix Makefiles) は generate 時に `-DCMAKE_BUILD_TYPE=Release` で構成を指定する。
+
+### CI と同じ最小構成 (参考)
+
+CI (`../../.github/workflows/build.yml`) は Ninja + Release で `pictor` ターゲットのみをビルドする:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DPICTOR_BUILD_DEMO=OFF
+cmake --build build --target pictor --parallel
+```
+
+## 2. 前提依存
+
+| 依存 | 必須/任意 | 挙動 |
+|---|---|---|
+| Vulkan SDK | 任意 | あれば `PICTOR_HAS_VULKAN=1` が立ち GPU 機能とウィンドウデモが有効。無ければ headless デモ/テストのみ (`../../CMakeLists.txt:46-49,219-244`) |
+| GLFW 3.4 | 任意 (デスクトップ) | システム未検出時は FetchContent で `3.4` を自動取得 (`../../CMakeLists.txt:51-72`) |
+| glslc (Vulkan SDK 同梱) | デモ時のみ | `PICTOR_BUILD_DEMO` かつ `Vulkan_GLSLC_EXECUTABLE` 検出時に SPIR-V を焼く (`../../CMakeLists.txt:437`) |
+
+ウィンドウを開くデモ (`pictor_demo` / `pictor_graphics_demo` 等) は **Vulkan + GLFW が両方揃ったときだけ** add_executable される (`../../CMakeLists.txt:335,344`)。揃わない場合は `pictor_benchmark` などの headless デモのみ。
+
+## 3. Release / Debug の別
+
+| 構成 | 使いどころ | 注意 |
+|---|---|---|
+| Debug | 普段の確認の既定。診断ログは Debug でしか出ない ([[feedback_pictor_debug_default]]) | Rive 有効時は後述の制約あり |
+| Release | CI / 配布 / **Rive 有効時** | — |
+
+### Rive 有効時は Release ビルド必須
+
+`PICTOR_ENABLE_RIVE=ON` で消費する **prebuilt `rive_yoga.lib` (および rive-runtime の各 static lib) は Release 専用 CRT** でビルドされている。そのため Pictor 側を Debug でリンクすると CRT 不一致で **LNK2038 / LNK1319** になる ([[feedback_ks_release_build_required]])。
+
+- Rive を使うときは **Release でビルドする**。
+- Debug でリンクしたい場合は、rive-runtime 側を debug CRT で別途ビルドして与える必要がある。`FindRive.cmake` はマルチコンフィグ生成系向けに debug/release 両方を探索し per-config でマッピングするので、両構成を用意できるなら Visual Studio 生成系で両対応できる (`../../cmake/FindRive.cmake:19-34,182-207`)。
+- 注意: コンパイル自体は通ってしまい **リンク段階で初めて失敗する** ため、「ビルドが進んでいるのに最後で落ちる」症状になりやすい。
+
+> Rive を使わない (`PICTOR_ENABLE_RIVE=OFF`、既定) ならこの制約は無く、Debug/Release どちらでもビルドできる。
+
+## 4. prebuilt 連携 (Rive)
+
+Rive Renderer は premake5 ベースの独自ビルドを持つため、Pictor は **prebuilt static library として外部消費**する (`../../cmake/FindRive.cmake:1-9`)。手順:
+
+```bash
+git clone https://github.com/rive-app/rive-runtime
+cd rive-runtime/renderer
+# Windows (Git Bash) — Release / Debug を必要に応じて
+../build/build_rive.bat release --with_vulkan --toolset=msc --windows_runtime=dynamic_release
+../build/build_rive.bat debug   --with_vulkan --toolset=msc --windows_runtime=dynamic_debug
+```
+
+その後 Pictor を:
+
+```bash
+cmake -B build -DPICTOR_ENABLE_RIVE=ON -DPICTOR_RIVE_DIR=/path/to/rive-runtime
+cmake --build build --config Release
+```
+
+`FindRive.cmake` は `renderer/out/<config>/` (または `out/<config>/`) の static lib を探索し、`Rive::Rive` imported target として `rive_renderer` / `rive` / `rive_decoders` / harfbuzz / sheenbidi / yoga / 画像ライブラリをリンク順込みで束ねる (`../../cmake/FindRive.cmake:48-55,116-125,158-172`)。詳細フラグは [`build-options.md`](build-options.md) §Rive。
+
+## 5. テスト
+
+ヘッドレステスト (CTest) は `PICTOR_BUILD_TESTS=ON` (既定) かつ非モバイルで有効 (`../../CMakeLists.txt:557`)。
+
+```bash
+cmake -B build            # PICTOR_BUILD_TESTS は既定 ON
+cmake --build build
+ctest --test-dir build
+```
+
+- テストは GLFW / Vulkan ウィンドウ不要の headless で、`pictor` 静的ライブラリのみに依存する (`../../tests/CMakeLists.txt:1-9`)。
+- **MSVC では各テストターゲットに `/utf-8` が個別付与される** (`../../tests/CMakeLists.txt:30-33`)。`target_compile_options(pictor PRIVATE /utf-8)` は consumer/テストへ伝播しないため、日本語コメントを含む header を Shift-JIS 誤読させない措置 ([[feedback_msvc_utf8_test_targets]])。
+
+## 6. 出力物
+
+- `libpictor` — 静的ライブラリ (consumer がリンクする本体)。
+- `pictor_benchmark` / `pictor_fbx_demo` / `pictor_mobile_demo` / `pictor_text_effects_demo` / `pictor_material_serializer_demo` — headless デモ (Vulkan/GLFW 不要、`PICTOR_BUILD_DEMO=ON` 時、`../../CMakeLists.txt:298-322`)。
+- `pictor_demo` / `pictor_graphics_demo` / `pictor_ocean_demo` / `pictor_text_demo` / `pictor_postprocess_demo` / `pictor_rive_demo` / `pictor_texture2d_demo` / `pictor_fbx_viewer` — Vulkan + GLFW 必須のデモ (`../../CMakeLists.txt:335-380`)。
+
+> Pictor の方針として、本リポでの作業は **ビルドまで**。`.exe` の起動・実行確認は consumer/ユーザー側 ([[feedback_pictor_no_run]])。

--- a/spec/setup/integration.md
+++ b/spec/setup/integration.md
@@ -1,0 +1,73 @@
+# consumer への組み込み
+
+Pictor を上位アプリ (KuzuSurvivors 等) に組み込むための CMake / インクルード / define 設定。
+オプションの意味は [`build-options.md`](build-options.md)、ビルド手順は [`build.md`](build.md)。
+
+> **レイヤ方向の原則**: Pictor は **最下層**。consumer は Pictor の抽象 API に依存し、Vulkan handle / GLFW を直叩きしない ([[feedback_pictor_no_upper_dep]] / `../../CLAUDE.md` SOLID D)。逆向き (Ergo / AdventureCube / ergo_custos 等の上位を Pictor に取り込む) は禁止 — 本書も「Pictor を下に敷く」方向のみを扱う。
+
+## 1. CMake で取り込む
+
+最小形 (`../../README.md` の「プロジェクトへの組み込み」と同じ):
+
+```cmake
+add_subdirectory(Pictor)
+target_link_libraries(your_app PRIVATE pictor)
+```
+
+`pictor` は include ディレクトリを PUBLIC で公開する (`../../CMakeLists.txt:214-217`) ので、リンクすれば自動でヘッダパスが通る。
+
+### sibling clone を取り込む実例 (KuzuSurvivors)
+
+別ディレクトリにある Pictor を `add_subdirectory` で取り込み、オプションを consumer 側で固定する実パターン (`../../../KuzuSurvivors/CMakeLists.txt`):
+
+```cmake
+set(KUZU_PICTOR_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../Pictor" CACHE PATH "Path to Pictor source")
+
+# consumer 側で Pictor のオプションを固定 (FORCE で上書き)
+set(PICTOR_BUILD_DEMO      OFF CACHE BOOL "" FORCE)
+set(PICTOR_ENABLE_PROFILER ON  CACHE BOOL "" FORCE)
+set(PICTOR_ENABLE_RIVE     ON  CACHE BOOL "Rive Renderer 統合")
+set(PICTOR_RIVE_DIR        "${CMAKE_CURRENT_SOURCE_DIR}/../rive-runtime" CACHE PATH "rive-runtime のクローンパス")
+
+add_subdirectory(${KUZU_PICTOR_DIR} ${CMAKE_BINARY_DIR}/_pictor)
+target_link_libraries(your_app PRIVATE pictor)
+```
+
+ポイント:
+- consumer の `CMakeLists.txt` で `set(PICTOR_* ... CACHE BOOL "" FORCE)` してから `add_subdirectory` すると、Pictor の `option()` 既定を上書きできる。
+- ビルドツリーを分けるため `add_subdirectory(<src> <bin>)` の第 2 引数 (例 `${CMAKE_BINARY_DIR}/_pictor`) を渡す。
+- CI など rive-runtime が無い環境では `-DPICTOR_ENABLE_RIVE=OFF` でビルドできるようにしておく。
+
+## 2. インクルード
+
+```cpp
+#include <pictor/pictor.h>          // 集約ヘッダ
+```
+
+個別ヘッダも `include/pictor/<module>/` 配下で利用できる (例 `#include <pictor/shader/shader_registry.h>`、`#include <pictor/visus/visus.h>`)。
+
+## 3. 必要な define / リンク設定
+
+`pictor` の **PUBLIC** define は consumer に自動伝播する (`../../CMakeLists.txt`)。consumer 側で改めて立てる必要は基本無いが、Vulkan を使う consumer 自身のソースが Vulkan プラットフォームマクロを必要とする場合は併せて指定する。KS の実例では consumer ターゲットにも `PICTOR_HAS_VULKAN` を付けている (`../../../KuzuSurvivors/CMakeLists.txt:288`)。
+
+| 項目 | 必要なとき | 対応 |
+|---|---|---|
+| `PICTOR_HAS_VULKAN` | consumer 自身が Vulkan API を直接触る | `pictor` から PUBLIC 伝播 (`../../CMakeLists.txt:220`)。consumer ソース側で必要なら明示付与 |
+| Rive 統合 | ベクター/Rive を使う | `PICTOR_ENABLE_RIVE=ON` + `PICTOR_RIVE_DIR` (§1 / [`build-options.md`](build-options.md) §Rive)。`Rive::Rive` の `RIVE_VULKAN;WITH_RIVE_TEXT;WITH_RIVE_LAYOUT` define は `pictor` 経由で伝播 (`../../cmake/FindRive.cmake:191`) |
+| **MSVC `/utf-8`** | MSVC で Pictor の日本語コメント入り header を取り込む | **consumer ターゲットに `/utf-8` を個別付与**。`pictor` の `/utf-8` は PRIVATE で伝播しない ([[feedback_msvc_utf8_test_targets]]) |
+
+MSVC consumer の例:
+
+```cmake
+if(MSVC)
+    target_compile_options(your_app PRIVATE /utf-8)
+endif()
+```
+
+## 4. Release 必須 (Rive 有効時)
+
+`PICTOR_ENABLE_RIVE=ON` の consumer は **Release でビルド・リンクする**。prebuilt `rive_yoga.lib` 等が Release 専用 CRT のため、Debug リンクは LNK2038 / LNK1319 になる ([[feedback_ks_release_build_required]])。コンパイルは通りリンク段で初めて落ちる点に注意。詳細は [`build.md`](build.md) §3。
+
+## 5. シェーダ / アセットの扱い
+
+Pictor のデモシェーダや postprocess シェーダを consumer が流用する場合、consumer 側で SPIR-V を焼く。KS は `${KUZU_PICTOR_DIR}/demo/shaders/` や `${KUZU_PICTOR_DIR}/shaders/postprocess/` を参照してコンパイルする (`../../../KuzuSurvivors/CMakeLists.txt:334-356`)。`PICTOR_BUILD_DEMO=OFF` で取り込んでいても、ソースツリー上のシェーダファイル自体は参照できる。


### PR DESCRIPTION
「○○するための設定」を `spec/setup/` に用途別でまとめたセットアップガイド (Di の spec/setup と同形式)。

- 各設定キー / ビルドフラグは実装・README・CMake から**実在確認**し、根拠ファイル:行を本文に併記
- 推測キーは排除。未配線フラグ・死にキー・ドキュメント誤記はその旨を注記
- DRY: 既存 README/CLAUDE/spec へのリンク参照で重複を回避

LUDIARS 横断のセットアップガイド整備の一環 (Mm/Concordia/Cr/Pictor/Ergo、Di は先行実装済)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)