### PR TITLE
docs(README): セットアップガイドへの導線を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Pictorは、描画オブジェクトの一元管理と最適な描画パイプ�
 
 ## セットアップ
 
+> 用途別のビルド設定は [`spec/setup/`](spec/setup/) にまとめてある:
+> [ビルド手順](spec/setup/build.md) / [ビルドオプション](spec/setup/build-options.md) / [consumer への組み込み](spec/setup/integration.md)。
+
 ### 必要要件
 
 | 項目 | 要件 |


### PR DESCRIPTION
README に [`spec/setup/`](spec/setup/) 用途別セットアップガイドへの導線セクションを追加 (先行マージ済みのガイド本体への索引)。README 本文は最小追記のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)