### PR TITLE
feat(tools): add WebGL level editor prototype

### DIFF
--- a/tools/level-editor/README.md
+++ b/tools/level-editor/README.md
@@ -1,0 +1,54 @@
+# Pictor Level Editor
+
+Browser-based level editing prototype for Pictor scenes.
+
+It provides a local WebGL2 viewport, hierarchy tree, asset palette, transform inspector, and JSON import/export for level data. The current renderer uses Pictor-style mesh descriptors with built-in preview meshes; the boundary is isolated in `webgl_model_viewer.js` so native Pictor model data can replace the preview mesh registry later.
+
+## Run
+
+```powershell
+cd tools\level-editor
+node .\serve.mjs
+```
+
+Open `http://localhost:8781/`.
+
+## Level JSON
+
+The exported format is intentionally simple:
+
+```json
+{
+  "version": 1,
+  "name": "sample_level",
+  "assets": [
+    {
+      "id": "cover_block",
+      "name": "Cover Block",
+      "model": "models/cover_block.glb",
+      "previewMesh": "cube",
+      "color": [0.62, 0.72, 0.46, 1]
+    }
+  ],
+  "nodes": [
+    {
+      "id": "cover_01",
+      "parentId": "root",
+      "name": "Cover Block",
+      "kind": "model",
+      "assetId": "cover_block",
+      "transform": {
+        "position": [3, 1, 2],
+        "rotation": [0, 28, 0],
+        "scale": [1.4, 1, 1]
+      }
+    }
+  ]
+}
+```
+
+## Integration Notes
+
+- `webgl_model_viewer.js` owns WebGL buffer creation, shaders, camera, and mesh registry.
+- `app.js` owns editor state, hierarchy, inspector, asset placement, import/export, and JSON preview.
+- Asset entries already carry a `model` path so the next step can add GLB/native Pictor mesh loading without changing the editor data model.

--- a/tools/level-editor/app.js
+++ b/tools/level-editor/app.js
@@ -1,0 +1,334 @@
+import { WebGLModelViewer, defaultAssetCatalog } from "./webgl_model_viewer.js";
+
+const $ = (id) => document.getElementById(id);
+
+const defaultTransform = () => ({
+  position: [0, 0, 0],
+  rotation: [0, 0, 0],
+  scale: [1, 1, 1],
+});
+
+const state = {
+  selectedId: "root",
+  tool: "select",
+  level: {
+    version: 1,
+    name: "sample_level",
+    assets: defaultAssetCatalog(),
+    nodes: [
+      { id: "root", parentId: null, name: "Level", kind: "group", transform: defaultTransform() },
+      { id: "floor_01", parentId: "root", name: "Stage Floor", kind: "model", assetId: "stage_floor", transform: { position: [0, 0, 0], rotation: [0, 0, 0], scale: [12, 1, 12] } },
+      { id: "spawn_01", parentId: "root", name: "Player Spawn", kind: "model", assetId: "spawn_marker", transform: { position: [0, 0.25, 0], rotation: [0, 0, 0], scale: [0.45, 0.45, 0.45] } },
+      { id: "enemy_01", parentId: "root", name: "Enemy Anchor A", kind: "model", assetId: "enemy_anchor", transform: { position: [-4, 0.65, -2], rotation: [0, 0, 0], scale: [0.65, 0.65, 0.65] } },
+      { id: "cover_01", parentId: "root", name: "Cover Block", kind: "model", assetId: "cover_block", transform: { position: [3, 1, 2], rotation: [0, 28, 0], scale: [1.4, 1, 1] } },
+    ],
+  },
+};
+
+const viewer = new WebGLModelViewer($("viewport"));
+
+function uid(prefix) {
+  return `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function selectedNode() {
+  return state.level.nodes.find((node) => node.id === state.selectedId) || null;
+}
+
+function childrenOf(parentId) {
+  return state.level.nodes.filter((node) => node.parentId === parentId);
+}
+
+function setStatus(text, tone = "") {
+  const status = $("status");
+  status.textContent = text;
+  status.className = `status ${tone}`.trim();
+}
+
+function serializeLevel() {
+  return JSON.stringify(state.level, null, 2);
+}
+
+function renderHierarchy() {
+  const tree = $("hierarchy");
+  tree.innerHTML = "";
+  const walk = (parentId, depth) => {
+    for (const node of childrenOf(parentId)) {
+      const row = document.createElement("div");
+      row.className = `treeNode${node.id === state.selectedId ? " selected" : ""}`;
+      row.style.setProperty("--indent", `${depth * 14}px`);
+      row.role = "treeitem";
+      row.innerHTML = `<span class="nodeIcon">${node.kind === "group" ? "◆" : "●"}</span><span class="nodeName"><span class="treeIndent"></span>${node.name}</span>`;
+      row.addEventListener("click", () => {
+        state.selectedId = node.id;
+        renderAll();
+      });
+      tree.appendChild(row);
+      walk(node.id, depth + 1);
+    }
+  };
+  walk(null, 0);
+}
+
+function renderAssets() {
+  $("assetCount").textContent = String(state.level.assets.length);
+  const list = $("assetList");
+  list.innerHTML = "";
+  for (const asset of state.level.assets) {
+    const item = document.createElement("div");
+    item.className = "assetItem";
+    item.innerHTML = `
+      <div class="swatch" style="background: rgba(${asset.color.slice(0, 3).map((v) => Math.round(v * 255)).join(",")},1)"></div>
+      <div>
+        <div class="assetName">${asset.name}</div>
+        <div class="assetMeta">${asset.previewMesh} · ${asset.model}</div>
+      </div>`;
+    item.addEventListener("click", () => addAssetNode(asset));
+    list.appendChild(item);
+  }
+}
+
+function field(label, input) {
+  const row = document.createElement("div");
+  row.className = "field";
+  const l = document.createElement("label");
+  l.textContent = label;
+  row.append(l, input);
+  return row;
+}
+
+function textInput(value, onInput) {
+  const input = document.createElement("input");
+  input.type = "text";
+  input.value = value ?? "";
+  input.addEventListener("input", () => onInput(input.value));
+  return input;
+}
+
+function selectInput(value, options, onInput) {
+  const select = document.createElement("select");
+  for (const option of options) {
+    const el = document.createElement("option");
+    el.value = option.value;
+    el.textContent = option.label;
+    select.appendChild(el);
+  }
+  select.value = value ?? "";
+  select.addEventListener("change", () => onInput(select.value));
+  return select;
+}
+
+function vectorInput(values, onInput) {
+  const wrap = document.createElement("div");
+  wrap.className = "triple";
+  values.forEach((value, index) => {
+    const input = document.createElement("input");
+    input.type = "number";
+    input.step = "0.1";
+    input.value = Number(value).toFixed(2);
+    input.addEventListener("input", () => {
+      const next = [...values];
+      const parsed = parseFloat(input.value);
+      next[index] = Number.isFinite(parsed) ? parsed : 0;
+      onInput(next);
+    });
+    wrap.appendChild(input);
+  });
+  return wrap;
+}
+
+function renderInspector() {
+  const panel = $("inspector");
+  panel.innerHTML = "";
+  const node = selectedNode();
+  $("selectedType").textContent = node ? node.kind : "none";
+  if (!node) {
+    panel.appendChild(Object.assign(document.createElement("div"), { className: "emptyState", textContent: "No node selected" }));
+    return;
+  }
+
+  panel.appendChild(field("Name", textInput(node.name, (value) => {
+    node.name = value || node.id;
+    renderAll();
+  })));
+  panel.appendChild(field("Kind", selectInput(node.kind, [
+    { value: "group", label: "Group" },
+    { value: "model", label: "Model" },
+  ], (value) => {
+    node.kind = value;
+    if (value === "model" && !node.assetId) node.assetId = state.level.assets[0]?.id;
+    renderAll();
+  })));
+  if (node.kind === "model") {
+    panel.appendChild(field("Asset", selectInput(node.assetId, state.level.assets.map((asset) => ({
+      value: asset.id,
+      label: asset.name,
+    })), (value) => {
+      node.assetId = value;
+      renderAll();
+    })));
+  }
+  panel.appendChild(field("Position", vectorInput(node.transform.position, (next) => {
+    node.transform.position = next;
+    renderAll();
+  })));
+  panel.appendChild(field("Rotation", vectorInput(node.transform.rotation, (next) => {
+    node.transform.rotation = next;
+    renderAll();
+  })));
+  panel.appendChild(field("Scale", vectorInput(node.transform.scale, (next) => {
+    node.transform.scale = next.map((v) => Math.max(0.01, v));
+    renderAll();
+  })));
+}
+
+function addAssetNode(asset) {
+  const parent = selectedNode();
+  const parentId = parent?.kind === "group" ? parent.id : (parent?.parentId ?? "root");
+  const node = {
+    id: uid(asset.id),
+    parentId,
+    name: asset.name,
+    kind: "model",
+    assetId: asset.id,
+    transform: defaultTransform(),
+  };
+  const siblings = childrenOf(parentId).length;
+  node.transform.position = [(siblings % 5 - 2) * 1.8, asset.previewMesh === "plane" ? 0 : 0.8, Math.floor(siblings / 5) * 1.8];
+  if (asset.previewMesh === "plane") node.transform.scale = [4, 1, 4];
+  state.level.nodes.push(node);
+  state.selectedId = node.id;
+  renderAll();
+  setStatus(`added ${asset.name}`, "ok");
+}
+
+function addGroup() {
+  const node = {
+    id: uid("group"),
+    parentId: selectedNode()?.kind === "group" ? state.selectedId : "root",
+    name: "Group",
+    kind: "group",
+    transform: defaultTransform(),
+  };
+  state.level.nodes.push(node);
+  state.selectedId = node.id;
+  renderAll();
+}
+
+function duplicateSelected() {
+  const node = selectedNode();
+  if (!node || node.id === "root") return;
+  const copy = structuredClone(node);
+  copy.id = uid(node.id);
+  copy.name = `${node.name} Copy`;
+  copy.transform.position = [
+    copy.transform.position[0] + 1,
+    copy.transform.position[1],
+    copy.transform.position[2] + 1,
+  ];
+  state.level.nodes.push(copy);
+  state.selectedId = copy.id;
+  renderAll();
+}
+
+function deleteSelected() {
+  const node = selectedNode();
+  if (!node || node.id === "root") return;
+  const remove = new Set([node.id]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const candidate of state.level.nodes) {
+      if (candidate.parentId && remove.has(candidate.parentId) && !remove.has(candidate.id)) {
+        remove.add(candidate.id);
+        changed = true;
+      }
+    }
+  }
+  state.level.nodes = state.level.nodes.filter((candidate) => !remove.has(candidate.id));
+  state.selectedId = "root";
+  renderAll();
+}
+
+function exportLevel() {
+  const blob = new Blob([serializeLevel()], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${state.level.name || "level"}.pictor-level.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+async function importLevel(file) {
+  const text = await file.text();
+  const parsed = JSON.parse(text);
+  if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.assets)) {
+    throw new Error("Invalid level JSON");
+  }
+  state.level = parsed;
+  state.selectedId = parsed.nodes[0]?.id ?? null;
+  renderAll();
+}
+
+function renderJson() {
+  $("jsonPreview").textContent = serializeLevel();
+}
+
+function renderViewport() {
+  viewer.render(state.level, state.selectedId);
+  $("nodeMeta").textContent = `${state.level.nodes.length} nodes`;
+  $("drawMeta").textContent = `${viewer.draws} draws`;
+}
+
+function renderAll() {
+  renderHierarchy();
+  renderAssets();
+  renderInspector();
+  renderJson();
+  renderViewport();
+}
+
+function animate() {
+  renderViewport();
+  requestAnimationFrame(animate);
+}
+
+$("addGroupBtn").addEventListener("click", addGroup);
+$("duplicateBtn").addEventListener("click", duplicateSelected);
+$("deleteBtn").addEventListener("click", deleteSelected);
+$("exportBtn").addEventListener("click", exportLevel);
+$("copyBtn").addEventListener("click", async () => {
+  await navigator.clipboard.writeText(serializeLevel());
+  setStatus("copied JSON", "ok");
+});
+$("newSceneBtn").addEventListener("click", () => {
+  state.level.nodes = [state.level.nodes.find((node) => node.id === "root") ?? {
+    id: "root",
+    parentId: null,
+    name: "Level",
+    kind: "group",
+    transform: defaultTransform(),
+  }];
+  state.selectedId = "root";
+  renderAll();
+});
+$("importInput").addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    await importLevel(file);
+    setStatus(`imported ${file.name}`, "ok");
+  } catch (error) {
+    setStatus(error.message, "warn");
+  }
+});
+document.querySelectorAll(".segmented button").forEach((button) => {
+  button.addEventListener("click", () => {
+    state.tool = button.dataset.tool;
+    document.querySelectorAll(".segmented button").forEach((b) => b.classList.toggle("active", b === button));
+  });
+});
+
+renderAll();
+requestAnimationFrame(animate);

--- a/tools/level-editor/index.html
+++ b/tools/level-editor/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Pictor Level Editor</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">Pictor Level Editor</div>
+    <nav class="toolbar" aria-label="Level editor commands">
+      <button id="newSceneBtn" title="New scene" aria-label="New scene">New</button>
+      <label class="button" title="Import level JSON">
+        Import
+        <input id="importInput" type="file" accept="application/json,.json" hidden>
+      </label>
+      <button id="exportBtn" title="Export level JSON" aria-label="Export level JSON">Export</button>
+      <button id="duplicateBtn" title="Duplicate selected node" aria-label="Duplicate selected node">Duplicate</button>
+      <button id="deleteBtn" title="Delete selected node" aria-label="Delete selected node">Delete</button>
+    </nav>
+    <div id="status" class="status">ready</div>
+  </header>
+
+  <main class="workspace">
+    <aside class="sidebar left">
+      <section class="panel">
+        <div class="panelHeader">
+          <h2>Hierarchy</h2>
+          <button id="addGroupBtn" class="iconButton" title="Add empty node" aria-label="Add empty node">+</button>
+        </div>
+        <div id="hierarchy" class="tree" role="tree"></div>
+      </section>
+
+      <section class="panel assets">
+        <div class="panelHeader">
+          <h2>Assets</h2>
+          <span id="assetCount" class="pill">0</span>
+        </div>
+        <div id="assetList" class="assetList"></div>
+      </section>
+    </aside>
+
+    <section class="viewportShell">
+      <div class="viewportTop">
+        <div class="segmented" role="tablist" aria-label="Transform mode">
+          <button class="active" data-tool="select">Select</button>
+          <button data-tool="move">Move</button>
+          <button data-tool="rotate">Rotate</button>
+          <button data-tool="scale">Scale</button>
+        </div>
+        <div class="viewportMeta">
+          <span id="nodeMeta">0 nodes</span>
+          <span id="drawMeta">0 draws</span>
+        </div>
+      </div>
+      <canvas id="viewport"></canvas>
+    </section>
+
+    <aside class="sidebar right">
+      <section class="panel inspector">
+        <div class="panelHeader">
+          <h2>Inspector</h2>
+          <span id="selectedType" class="pill">none</span>
+        </div>
+        <div id="inspector"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panelHeader">
+          <h2>Level JSON</h2>
+          <button id="copyBtn" class="smallButton">Copy</button>
+        </div>
+        <pre id="jsonPreview"></pre>
+      </section>
+    </aside>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/tools/level-editor/serve.mjs
+++ b/tools/level-editor/serve.mjs
@@ -1,0 +1,34 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const port = Number(process.env.PORT || 8781);
+const types = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+};
+
+createServer(async (req, res) => {
+  const url = new URL(req.url || "/", `http://localhost:${port}`);
+  const pathname = url.pathname === "/" ? "/index.html" : url.pathname;
+  const file = normalize(join(root, pathname));
+  if (!file.startsWith(normalize(root))) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+  try {
+    const body = await readFile(file);
+    res.writeHead(200, { "content-type": types[extname(file)] || "application/octet-stream" });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end("Not found");
+  }
+}).listen(port, () => {
+  console.log(`Pictor Level Editor: http://localhost:${port}/`);
+});

--- a/tools/level-editor/style.css
+++ b/tools/level-editor/style.css
@@ -1,0 +1,304 @@
+:root {
+  color-scheme: dark;
+  --bg: #111316;
+  --panel: #191d22;
+  --panel-2: #20252c;
+  --line: #323943;
+  --text: #eef2f6;
+  --muted: #a8b1bd;
+  --soft: #788391;
+  --accent: #57c7ff;
+  --accent-2: #a6e66e;
+  --danger: #ff6c6c;
+  --focus: rgba(87, 199, 255, 0.22);
+}
+
+* { box-sizing: border-box; }
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 13px/1.45 Inter, "Segoe UI", system-ui, sans-serif;
+  overflow: hidden;
+}
+
+button, input, select {
+  font: inherit;
+}
+
+button, .button {
+  border: 1px solid var(--line);
+  background: #252b33;
+  color: var(--text);
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+button:hover, .button:hover { border-color: #4a5563; background: #2b333d; }
+button:focus-visible, .button:focus-visible, input:focus-visible, select:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 1px;
+}
+
+.topbar {
+  height: 48px;
+  display: grid;
+  grid-template-columns: 220px 1fr 220px;
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  background: #15181d;
+  padding: 0 12px;
+}
+.brand {
+  font-weight: 700;
+  letter-spacing: 0;
+}
+.toolbar {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+.status {
+  justify-self: end;
+  color: var(--muted);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.status.ok { color: var(--accent-2); }
+.status.warn { color: #ffd36e; }
+
+.workspace {
+  height: calc(100vh - 48px);
+  display: grid;
+  grid-template-columns: 280px minmax(420px, 1fr) 320px;
+  min-width: 980px;
+}
+.sidebar {
+  min-width: 0;
+  background: var(--panel);
+  border-right: 1px solid var(--line);
+  display: grid;
+  grid-template-rows: 1.1fr 0.9fr;
+  overflow: hidden;
+}
+.sidebar.right {
+  border-right: 0;
+  border-left: 1px solid var(--line);
+  grid-template-rows: auto 1fr;
+}
+.panel {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--line);
+}
+.panel:last-child { border-bottom: 0; }
+.panelHeader {
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel-2);
+}
+h2 {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: #dce4ed;
+}
+.pill {
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 7px;
+  font-size: 11px;
+  background: #171b20;
+}
+.iconButton {
+  width: 26px;
+  min-height: 26px;
+  padding: 0;
+  font-size: 18px;
+}
+.smallButton {
+  min-height: 25px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.tree, .assetList {
+  overflow: auto;
+  padding: 8px;
+}
+.treeNode {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 4px;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 6px;
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+}
+.treeNode:hover { background: #242a32; color: var(--text); }
+.treeNode.selected { background: #153244; color: var(--text); }
+.treeIndent {
+  width: var(--indent);
+  display: inline-block;
+}
+.nodeIcon {
+  color: var(--accent);
+  font-size: 12px;
+}
+.nodeName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assetList {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+.assetItem {
+  min-height: 56px;
+  border: 1px solid var(--line);
+  background: #15191f;
+  border-radius: 7px;
+  padding: 8px;
+  display: grid;
+  grid-template-columns: 36px 1fr;
+  gap: 8px;
+  align-items: center;
+  cursor: pointer;
+}
+.assetItem:hover { border-color: #4b5968; background: #1a2027; }
+.swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.18);
+}
+.assetName {
+  font-weight: 650;
+  color: var(--text);
+}
+.assetMeta {
+  color: var(--soft);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.viewportShell {
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  display: grid;
+  grid-template-rows: 42px 1fr;
+  background: #0b0d10;
+}
+.viewportTop {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--line);
+  background: #15181d;
+}
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  overflow: hidden;
+}
+.segmented button {
+  border: 0;
+  border-right: 1px solid var(--line);
+  border-radius: 0;
+  background: #1b2027;
+  min-height: 28px;
+}
+.segmented button:last-child { border-right: 0; }
+.segmented button.active {
+  color: #061018;
+  background: var(--accent);
+}
+.viewportMeta {
+  display: flex;
+  gap: 12px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+#viewport {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.inspector #inspector {
+  overflow: auto;
+  padding: 10px;
+}
+.field {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 9px;
+}
+.field label {
+  color: var(--muted);
+  font-size: 12px;
+}
+.field input, .field select {
+  width: 100%;
+  min-height: 30px;
+  color: var(--text);
+  background: #12161b;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 4px 7px;
+}
+.triple {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+.emptyState {
+  color: var(--soft);
+  padding: 12px;
+}
+
+#jsonPreview {
+  margin: 0;
+  padding: 10px;
+  overflow: auto;
+  color: #cfe6ff;
+  background: #101419;
+  flex: 1;
+  font: 11px/1.45 "Cascadia Code", Consolas, monospace;
+}
+
+@media (max-width: 1120px) {
+  .workspace {
+    grid-template-columns: 250px minmax(360px, 1fr) 290px;
+  }
+  .topbar {
+    grid-template-columns: 190px 1fr 160px;
+  }
+}

--- a/tools/level-editor/webgl_model_viewer.js
+++ b/tools/level-editor/webgl_model_viewer.js
@@ -1,0 +1,353 @@
+const TAU = Math.PI * 2;
+
+function mat4Identity() {
+  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+}
+
+function mat4Multiply(a, b) {
+  const out = new Array(16).fill(0);
+  for (let c = 0; c < 4; c++) {
+    for (let r = 0; r < 4; r++) {
+      out[c * 4 + r] =
+        a[0 * 4 + r] * b[c * 4 + 0] +
+        a[1 * 4 + r] * b[c * 4 + 1] +
+        a[2 * 4 + r] * b[c * 4 + 2] +
+        a[3 * 4 + r] * b[c * 4 + 3];
+    }
+  }
+  return out;
+}
+
+function mat4Perspective(fov, aspect, near, far) {
+  const f = 1 / Math.tan(fov / 2);
+  const nf = 1 / (near - far);
+  return [
+    f / aspect, 0, 0, 0,
+    0, f, 0, 0,
+    0, 0, (far + near) * nf, -1,
+    0, 0, 2 * far * near * nf, 0,
+  ];
+}
+
+function vec3Normalize(v) {
+  const l = Math.hypot(v[0], v[1], v[2]) || 1;
+  return [v[0] / l, v[1] / l, v[2] / l];
+}
+
+function vec3Cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function mat4LookAt(eye, target, up) {
+  const z = vec3Normalize([eye[0] - target[0], eye[1] - target[1], eye[2] - target[2]]);
+  const x = vec3Normalize(vec3Cross(up, z));
+  const y = vec3Cross(z, x);
+  return [
+    x[0], y[0], z[0], 0,
+    x[1], y[1], z[1], 0,
+    x[2], y[2], z[2], 0,
+    -(x[0] * eye[0] + x[1] * eye[1] + x[2] * eye[2]),
+    -(y[0] * eye[0] + y[1] * eye[1] + y[2] * eye[2]),
+    -(z[0] * eye[0] + z[1] * eye[1] + z[2] * eye[2]),
+    1,
+  ];
+}
+
+function composeTransform(t) {
+  const [px, py, pz] = t.position;
+  const [rx, ry, rz] = t.rotation.map((v) => v * Math.PI / 180);
+  const [sx, sy, sz] = t.scale;
+  const cx = Math.cos(rx), sxn = Math.sin(rx);
+  const cy = Math.cos(ry), syn = Math.sin(ry);
+  const cz = Math.cos(rz), szn = Math.sin(rz);
+
+  const r00 = cy * cz;
+  const r01 = sxn * syn * cz + cx * szn;
+  const r02 = -cx * syn * cz + sxn * szn;
+  const r10 = -cy * szn;
+  const r11 = -sxn * syn * szn + cx * cz;
+  const r12 = cx * syn * szn + sxn * cz;
+  const r20 = syn;
+  const r21 = -sxn * cy;
+  const r22 = cx * cy;
+
+  return [
+    r00 * sx, r01 * sx, r02 * sx, 0,
+    r10 * sy, r11 * sy, r12 * sy, 0,
+    r20 * sz, r21 * sz, r22 * sz, 0,
+    px, py, pz, 1,
+  ];
+}
+
+function compile(gl, type, source) {
+  const shader = gl.createShader(type);
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    throw new Error(gl.getShaderInfoLog(shader) || "shader compile failed");
+  }
+  return shader;
+}
+
+function program(gl, vertex, fragment) {
+  const p = gl.createProgram();
+  gl.attachShader(p, compile(gl, gl.VERTEX_SHADER, vertex));
+  gl.attachShader(p, compile(gl, gl.FRAGMENT_SHADER, fragment));
+  gl.linkProgram(p);
+  if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+    throw new Error(gl.getProgramInfoLog(p) || "program link failed");
+  }
+  return p;
+}
+
+function createCube() {
+  const p = [
+    [-1, -1,  1], [ 1, -1,  1], [ 1,  1,  1], [-1,  1,  1],
+    [ 1, -1, -1], [-1, -1, -1], [-1,  1, -1], [ 1,  1, -1],
+    [-1,  1,  1], [ 1,  1,  1], [ 1,  1, -1], [-1,  1, -1],
+    [-1, -1, -1], [ 1, -1, -1], [ 1, -1,  1], [-1, -1,  1],
+    [ 1, -1,  1], [ 1, -1, -1], [ 1,  1, -1], [ 1,  1,  1],
+    [-1, -1, -1], [-1, -1,  1], [-1,  1,  1], [-1,  1, -1],
+  ];
+  const n = [
+    [0, 0, 1], [0, 0, -1], [0, 1, 0], [0, -1, 0], [1, 0, 0], [-1, 0, 0],
+  ];
+  const vertices = [];
+  for (let f = 0; f < 6; f++) {
+    for (let i = 0; i < 4; i++) vertices.push(...p[f * 4 + i], ...n[f]);
+  }
+  const indices = [];
+  for (let f = 0; f < 6; f++) {
+    const b = f * 4;
+    indices.push(b, b + 1, b + 2, b, b + 2, b + 3);
+  }
+  return { vertices, indices };
+}
+
+function createPlane() {
+  return {
+    vertices: [
+      -1, 0, -1, 0, 1, 0,
+       1, 0, -1, 0, 1, 0,
+       1, 0,  1, 0, 1, 0,
+      -1, 0,  1, 0, 1, 0,
+    ],
+    indices: [0, 1, 2, 0, 2, 3],
+  };
+}
+
+function createSphere(segments = 24, rings = 12) {
+  const vertices = [];
+  const indices = [];
+  for (let y = 0; y <= rings; y++) {
+    const v = y / rings;
+    const phi = v * Math.PI;
+    for (let x = 0; x <= segments; x++) {
+      const u = x / segments;
+      const theta = u * TAU;
+      const nx = Math.sin(phi) * Math.cos(theta);
+      const ny = Math.cos(phi);
+      const nz = Math.sin(phi) * Math.sin(theta);
+      vertices.push(nx, ny, nz, nx, ny, nz);
+    }
+  }
+  for (let y = 0; y < rings; y++) {
+    for (let x = 0; x < segments; x++) {
+      const a = y * (segments + 1) + x;
+      const b = a + segments + 1;
+      indices.push(a, b, a + 1, b, b + 1, a + 1);
+    }
+  }
+  return { vertices, indices };
+}
+
+function createCylinder(segments = 24) {
+  const vertices = [];
+  const indices = [];
+  for (let i = 0; i <= segments; i++) {
+    const a = i / segments * TAU;
+    const x = Math.cos(a), z = Math.sin(a);
+    vertices.push(x, -1, z, x, 0, z, x, 1, z, x, 0, z);
+  }
+  for (let i = 0; i < segments; i++) {
+    const b = i * 2;
+    indices.push(b, b + 1, b + 2, b + 1, b + 3, b + 2);
+  }
+  return { vertices, indices };
+}
+
+const vertexSource = `#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_position;
+layout(location=1) in vec3 a_normal;
+uniform mat4 u_viewProjection;
+uniform mat4 u_model;
+uniform vec4 u_color;
+out vec3 v_normal;
+out vec3 v_world;
+out vec4 v_color;
+void main() {
+  vec4 world = u_model * vec4(a_position, 1.0);
+  gl_Position = u_viewProjection * world;
+  v_normal = mat3(u_model) * a_normal;
+  v_world = world.xyz;
+  v_color = u_color;
+}`;
+
+const fragmentSource = `#version 300 es
+precision highp float;
+in vec3 v_normal;
+in vec3 v_world;
+in vec4 v_color;
+out vec4 outColor;
+void main() {
+  vec3 n = normalize(v_normal);
+  vec3 light = normalize(vec3(0.45, 0.8, 0.25));
+  float ndl = max(dot(n, light), 0.0);
+  float hemi = n.y * 0.25 + 0.35;
+  vec3 base = v_color.rgb * (0.22 + ndl * 0.68 + hemi * 0.22);
+  float gridFog = smoothstep(90.0, 8.0, length(v_world.xz));
+  outColor = vec4(base * gridFog, v_color.a);
+}`;
+
+export class WebGLModelViewer {
+  constructor(canvas) {
+    this.canvas = canvas;
+    this.gl = canvas.getContext("webgl2", { antialias: true, alpha: false });
+    if (!this.gl) throw new Error("WebGL2 is not available");
+    this.program = program(this.gl, vertexSource, fragmentSource);
+    this.meshes = new Map();
+    this.camera = { yaw: -0.72, pitch: -0.55, distance: 18, target: [0, 0, 0] };
+    this.draws = 0;
+    this._drag = null;
+    this._installCameraControls();
+    this.registerMesh("cube", createCube());
+    this.registerMesh("plane", createPlane());
+    this.registerMesh("sphere", createSphere());
+    this.registerMesh("cylinder", createCylinder());
+  }
+
+  registerMesh(id, mesh) {
+    const gl = this.gl;
+    const vao = gl.createVertexArray();
+    const vbo = gl.createBuffer();
+    const ibo = gl.createBuffer();
+    gl.bindVertexArray(vao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(mesh.vertices), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 24, 0);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 24, 12);
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array(mesh.indices), gl.STATIC_DRAW);
+    gl.bindVertexArray(null);
+    this.meshes.set(id, { vao, count: mesh.indices.length });
+  }
+
+  resize() {
+    const dpr = window.devicePixelRatio || 1;
+    const w = Math.max(1, Math.floor(this.canvas.clientWidth * dpr));
+    const h = Math.max(1, Math.floor(this.canvas.clientHeight * dpr));
+    if (this.canvas.width !== w || this.canvas.height !== h) {
+      this.canvas.width = w;
+      this.canvas.height = h;
+    }
+  }
+
+  render(level, selectedId) {
+    this.resize();
+    const gl = this.gl;
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.enable(gl.DEPTH_TEST);
+    gl.enable(gl.CULL_FACE);
+    gl.clearColor(0.045, 0.052, 0.062, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    const aspect = this.canvas.width / this.canvas.height;
+    const projection = mat4Perspective(52 * Math.PI / 180, aspect, 0.05, 200);
+    const eye = this._eye();
+    const view = mat4LookAt(eye, this.camera.target, [0, 1, 0]);
+    const viewProjection = mat4Multiply(projection, view);
+
+    gl.useProgram(this.program);
+    gl.uniformMatrix4fv(gl.getUniformLocation(this.program, "u_viewProjection"), false, viewProjection);
+    this.draws = 0;
+    this._drawGrid(viewProjection);
+
+    for (const node of level.nodes) {
+      if (node.kind !== "model") continue;
+      const asset = level.assets.find((a) => a.id === node.assetId);
+      if (!asset) continue;
+      const mesh = this.meshes.get(asset.previewMesh || "cube") || this.meshes.get("cube");
+      gl.bindVertexArray(mesh.vao);
+      const model = composeTransform(node.transform);
+      const color = node.id === selectedId ? [1.0, 0.86, 0.35, 1] : asset.color;
+      gl.uniformMatrix4fv(gl.getUniformLocation(this.program, "u_model"), false, model);
+      gl.uniform4fv(gl.getUniformLocation(this.program, "u_color"), color);
+      gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_INT, 0);
+      this.draws++;
+    }
+
+    gl.bindVertexArray(null);
+  }
+
+  _drawGrid() {
+    const gl = this.gl;
+    const mesh = this.meshes.get("plane");
+    const model = composeTransform({
+      position: [0, -0.02, 0],
+      rotation: [0, 0, 0],
+      scale: [24, 1, 24],
+    });
+    gl.bindVertexArray(mesh.vao);
+    gl.uniformMatrix4fv(gl.getUniformLocation(this.program, "u_model"), false, model);
+    gl.uniform4fv(gl.getUniformLocation(this.program, "u_color"), [0.12, 0.14, 0.16, 1]);
+    gl.drawElements(gl.TRIANGLES, mesh.count, gl.UNSIGNED_INT, 0);
+    this.draws++;
+  }
+
+  _eye() {
+    const { yaw, pitch, distance, target } = this.camera;
+    const cp = Math.cos(pitch);
+    return [
+      target[0] + Math.sin(yaw) * cp * distance,
+      target[1] + Math.sin(-pitch) * distance,
+      target[2] + Math.cos(yaw) * cp * distance,
+    ];
+  }
+
+  _installCameraControls() {
+    this.canvas.addEventListener("pointerdown", (event) => {
+      this.canvas.setPointerCapture(event.pointerId);
+      this._drag = { x: event.clientX, y: event.clientY };
+    });
+    this.canvas.addEventListener("pointermove", (event) => {
+      if (!this._drag) return;
+      const dx = event.clientX - this._drag.x;
+      const dy = event.clientY - this._drag.y;
+      this._drag = { x: event.clientX, y: event.clientY };
+      this.camera.yaw -= dx * 0.006;
+      this.camera.pitch = Math.max(-1.25, Math.min(0.1, this.camera.pitch + dy * 0.006));
+    });
+    this.canvas.addEventListener("pointerup", () => { this._drag = null; });
+    this.canvas.addEventListener("wheel", (event) => {
+      event.preventDefault();
+      const scale = Math.exp(event.deltaY * 0.001);
+      this.camera.distance = Math.max(4, Math.min(80, this.camera.distance * scale));
+    }, { passive: false });
+  }
+}
+
+export function defaultAssetCatalog() {
+  return [
+    { id: "stage_floor", name: "Stage Floor", model: "models/stage_floor.glb", previewMesh: "plane", color: [0.24, 0.28, 0.32, 1] },
+    { id: "spawn_marker", name: "Spawn Marker", model: "models/spawn_marker.glb", previewMesh: "cylinder", color: [0.2, 0.72, 1.0, 1] },
+    { id: "enemy_anchor", name: "Enemy Anchor", model: "models/enemy_anchor.glb", previewMesh: "sphere", color: [1.0, 0.36, 0.32, 1] },
+    { id: "cover_block", name: "Cover Block", model: "models/cover_block.glb", previewMesh: "cube", color: [0.62, 0.72, 0.46, 1] },
+  ];
+}


### PR DESCRIPTION
## Summary
- add a static browser-based level editor under tools/level-editor
- provide hierarchy, asset palette, inspector, JSON import/export, and local server script
- add a standalone WebGL2 model viewer module with built-in preview meshes for model placement
- keep level JSON model paths in the asset schema so native Pictor/GLB loading can be wired next

## Verification
- node --check tools/level-editor/app.js
- node --check tools/level-editor/webgl_model_viewer.js
- node --check tools/level-editor/serve.mjs
- git diff --check -- tools/level-editor
- local server check: http://localhost:8781/ returned index.html and ES modules

## Notes
- In-app Browser verification failed in this environment with a node_repl sandbox spawn error, and Playwright is not installed locally. WebGL pixel verification still needs a real browser pass.