### PR TITLE
docs(spec): 基盤4サブシステム設計書追加 (surface/memory/culling/text)

### DIFF
--- a/spec/subsystem/README.md
+++ b/spec/subsystem/README.md
@@ -1,0 +1,16 @@
+# subsystem — 基盤サブシステム設計
+
+Pictor (低レイヤ Vulkan 描画ライブラリ) の基盤サブシステムごとの設計資料。
+パイプライン上位の設計は `spec/rendering-extensibility-design.md` /
+`spec/pipeline-*.md` を参照。
+
+| ファイル | サブシステム | 概要 |
+|---|---|---|
+| `surface.md` | surface | プラットフォーム抽象 (`ISurfaceProvider`) + `VulkanContext` (instance/device/swapchain) |
+| `memory.md` | memory | frame(bump) / pool(SoA) / GPU サブアロケータ。DoD を支える |
+| `culling.md` | culling | WorldPartition 広域 → FlatBVH 詳細 → GPU Hi-Z の多段カリング |
+| `text.md` | text | 自前 TTF/OTF パース + 3 描画経路 (atlas / image / SVG) |
+
+> 各文書は実装 (`include/pictor/<name>/` + `src/<name>/`) を読んで起こしたもの。
+> 未文書のサブシステム (data / scene / batch / gpu / shader / gi / update / decal /
+> webgl 等) は順次追加予定。

--- a/spec/subsystem/culling.md
+++ b/spec/subsystem/culling.md
@@ -1,0 +1,86 @@
+# Culling — 視錐台/空間分割によるカリング
+
+> 実装: `include/pictor/culling/`, `src/culling/`
+
+frustum を入力に可視オブジェクト集合を求める多段カリング。CPU 側 (WorldPartition 広域 → FlatBVH 詳細) と GPU 側 (Hi-Z occlusion) に分かれる。
+
+## CullingSystem (culling_system.h)
+
+オーケストレータ。`SceneRegistry` の各 `ObjectPool` を視錐台でふるい、`uint8_t* visibility_flags` (1=可視/0=cull) を設定する。
+
+```cpp
+explicit CullingSystem(SceneRegistry& registry);
+void configure_partition(const WorldPartitionConfig&);     // grid 広域分割を有効化
+void rebuild_partition(PoolType);                          // static/dynamic の grid 再構築
+void build_static_bvh(PoolAllocator&);                     // static は SAH で flat BVH 構築
+void refit_dynamic_bvh();                                  // dynamic は bound を bottom-up 更新
+void cull(const Frustum&, FrameAllocator&);                // 全段を 1 回で実行
+Stats get_stats() const;                                   // total/visible/culled/cells_*/cull_ratio
+void set_culling_provider(ICullingProvider*);              // カスタムカリング差替
+```
+
+- 入力 `Frustum` は view-projection から `frustum_utils::extract_frustum()` で 6 平面抽出
+- 対象プール: `static_pool` (partition+BVH) / `dynamic_pool` (partition+linear) / `gpu_driven_pool` (GPU で cull、CPU flag は全 1)
+
+## FlatBVH (flat_bvh.h)
+
+flat 配列 (DoD) の加速構造。
+
+```cpp
+struct alignas(32) BVHNode {           // 32B = 2/cache line
+  float3 aabb_min; uint32_t child_or_object_index;   // 内部=左child / leaf=object 開始
+  float3 aabb_max; uint32_t flags;                   // bit0=isLeaf, bit1-7=objectCount(≤127)
+};
+void build(const AABB*, const uint32_t* indices, uint32_t count, PoolAllocator&);  // binned SAH(12bin) + vEB レイアウト
+void refit(const AABB*);                                                            // leaf→root bound 更新
+bool needs_rebuild(float quality_threshold = 2.0f);
+uint32_t query_frustum(const Frustum&, uint32_t* out_visible, uint32_t max) const;  // stack 走査 (64要素)
+uint32_t query_aabb(const AABB&, uint32_t* out, uint32_t max) const;
+```
+
+- 構築: iterative stack + per-axis binned SAH、leaf ≤4 obj、max node = 2N-1。構築後に BFS 順の **van Emde Boas レイアウト**へ並べ替えて cache 最適化
+- refit は構造を保ったまま dynamic 用に bound のみ更新
+
+## WorldPartition (world_partition.h)
+
+一様 3D グリッドの広域分割。
+
+```cpp
+struct WorldPartitionConfig { float3 origin; float world_size=10000; float cell_size=100; };
+struct PartitionCell { AABB bounds; std::vector<uint32_t> object_indices; };
+void configure(const WorldPartitionConfig&);
+void rebuild(const AABB*, uint32_t count);
+void assign_object(uint32_t index, const AABB&);   // 旧 cell から移動 (incremental)
+void remove_object(uint32_t index);
+uint32_t query_frustum(const Frustum&, const PartitionCell** out, uint32_t max) const;  // cell の AABB が frustum と交差するものを返す
+```
+
+- `CellKey` = 64bit (軸 21bit ずつ、負 index 対応)。cell は object AABB の **中心**で決定
+- `cells_` (`unordered_map<CellKey, PartitionCell>`) + `object_cell_map_` (object→cell 逆引き)
+
+## フレーム位置
+
+`pictor_renderer.cpp` のメインループ:
+
+```
+DataUpdate (transform/bound 更新)
+  → CullingSystem::cull(camera.frustum, frame_alloc)   ← 本サブシステム
+      Level0: WorldPartition  frustum × cell AABB (cell 単位スキップ)
+      Level1: FlatBVH or linear  frustum × 個別 AABB (iterative 走査)
+      Level3: gpu_driven_pool は GPU へ委譲
+  → BatchBuilder が visibility_flags を読んで draw batch 構築
+  → RenderPassScheduler → GPUDrivenPipeline (Hi-Z compute cull)
+profiler に visible/culled を record
+```
+
+## GPU カリング
+
+`gpu_driven_pool` は compute で 2 段カリング:
+
+- `shaders/compute_cull.comp` (local_size 256): `gpu_bounds`(SSBO) + frustumPlanes + viewProj + `hiZTexture` → `gpu_visibility`。frustum test → Hi-Z occlusion test
+- `shaders/hiz_build.comp` (16×16): max-depth の mip ピラミッド生成
+- `GPUDrivenConfig { two_phase_culling, compute_update }`
+
+## 依存
+
+`pictor/core/types.h` (AABB/Frustum/float3)、`scene/scene_registry.h`、`memory/{frame,pool}_allocator.h`、標準ライブラリのみ。CPU 側は外部数学ライブラリ非依存。

--- a/spec/subsystem/memory.md
+++ b/spec/subsystem/memory.md
@@ -1,0 +1,83 @@
+# Memory — フレーム/プール/GPU アロケータ
+
+> 実装: `include/pictor/memory/`, `src/memory/`
+
+DoD 方針 (per-frame の scatter alloc を作らない、flat array、参照データは init 1 回ロード) を
+支えるメモリ基盤。永続 (scene 寿命) と一時 (per-frame) を分離し、外部アロケータ (VMA) 非依存。
+
+## MemorySubsystem (memory_subsystem.h)
+
+アロケータ群を束ねる umbrella。
+
+- 所有: `FlightFrameAllocator flight_allocator_` / `PoolAllocator pool_allocator_` / `GpuMemoryAllocator gpu_allocator_`
+- API: `frame_allocator()` (= flight の current) / `pool_allocator()` / `gpu_allocator()` / `get_stats()`
+- `begin_frame()`: `flight_allocator_.advance_frame()` (次 flight へ回転 + reset) → `gpu_allocator_.reset_ring_buffers()` → ++frame_number。`end_frame()` は no-op (cleanup は次 begin に遅延)
+- `MemoryConfig`: frame_allocator_size=16MB / flight_count=3 / pool_chunk_size=64KB / gpu_config / use_large_pages
+
+## FrameAllocator (frame_allocator.h) — 線形 bump
+
+per-frame の使い捨て。O(1)、個別 free 無し、lock-free。
+
+```cpp
+void* allocate(size_t size, size_t alignment = 16);   // atomic CAS で bump
+template<typename T> T* allocate_array(size_t count);
+void  reset();                                        // フレーム頭で巻戻し
+size_t used() / peak() / capacity() const;
+```
+
+- バッファは 64B アライン (`_aligned_malloc` / `std::aligned_alloc`)、任意で 2MB large page (`VirtualAlloc(MEM_LARGE_PAGES)` / `mmap(MAP_HUGETLB)`)
+- `std::atomic<size_t>` の relaxed CAS で多スレッド bump (peak は非 atomic、統計用途で許容)
+
+### FlightFrameAllocator — 三重バッファ
+
+`FrameAllocator` を N 個 (既定 3) 回転して CPU を GPU フレーム遅延から隔離。`current()` / `advance_frame()` (= `(idx+1)%N` + その allocator を reset)。フレーム N は flight (N%3) に書き、GPU が N-2 を処理中でも安全。
+
+## PoolAllocator (pool_allocator.h) — 永続 SoA backing
+
+長寿命の SoA インスタンスデータ用。chunk 単位で必要時に伸長、free 無し (allocate-only)。
+
+```cpp
+void* allocate(size_t size);                          // 64B (cache line) アライン
+void* allocate_array(size_t element_size, size_t count);
+void* reallocate_array(void* old, size_t elem, size_t old_count, size_t new_count); // 新規確保+memcpy (真の free なし)
+void  clear();                                        // 全 chunk 巻戻し (level 遷移用)
+size_t total_allocated() / chunk_count() const;
+```
+
+- 確保: 64B アライン → 既存 chunk を first-fit → 入らねば `max(chunk_size, size)` の chunk 追加
+- `Chunk { data, capacity, used }`。watermark 方式で per-allocation free list は持たない (mono-directional 成長)
+
+## GpuMemoryAllocator (gpu_memory_allocator.h) — VkBuffer サブアロケーション
+
+自前サブアロケータ (VMA 非依存)。用途別 4+1 プール + free-list (coalescing 付き)。
+
+| プール | 既定 | 種別 | reset |
+|---|---|---|---|
+| mesh (VB/IB) | 256MB | 永続 | 明示 `free()` のみ |
+| ssbo (SoA) | 128MB | 永続 | 明示 `free()` のみ |
+| instance | 64MB | ring | per-frame |
+| indirect | 16MB | ring | per-frame |
+| staging (CPU→GPU) | 64MB | ring | per-frame |
+
+```cpp
+GpuAllocation allocate_mesh(size_t, size_t align=256);      // 永続
+GpuAllocation allocate_ssbo(size_t, size_t align=256);      // 永続
+GpuAllocation allocate_instance(size_t, size_t align=16);   // ring
+GpuAllocation allocate_staging(size_t, size_t align=16);    // ring
+void free(const GpuAllocation&);                            // free-list へ戻し + 隣接 merge
+void reset_ring_buffers();                                  // instance/staging を 1 ブロックへ
+Stats get_stats() const;                                    // 各プールの used/capacity + fragmentation
+```
+
+- `GpuAllocation { buffer_id, offset, size, valid }`。`buffer_id` はプール識別子で、実 VkBuffer/VkDeviceMemory の bind は上位の graphics context が担う (この層は offset 管理のみ)
+- 確保: free_list を first-fit + アライン → ブロック分割。`free()` は offset 順挿入 + 前後 coalesce
+
+## DoD 整合
+
+- per-frame の `malloc`/`new` を排除 (bump or ring)
+- CPU 確保はすべて 64B cache-line アライン、large page 任意
+- 永続 (mesh/ssbo) と一時 (instance/staging/indirect) を物理的に分離 → フレーム境界で ring を一括 reset
+
+## 依存
+
+`<atomic>` / `<vector>` 等の標準のみ。Windows は `<windows.h>` + `<malloc.h>`、POSIX は `<sys/mman.h>` (large page)。VMA / 独自 STL は不使用。

--- a/spec/subsystem/surface.md
+++ b/spec/subsystem/surface.md
@@ -1,0 +1,84 @@
+# Surface / Swapchain — プラットフォーム抽象 + Vulkan コンテキスト
+
+> 実装: `include/pictor/surface/`, `src/surface/`
+
+ウィンドウシステムと Vulkan の境界。`ISurfaceProvider` でプラットフォームを抽象化し、
+`VulkanContext` が instance/device/swapchain のライフタイムを管理する。
+
+## ISurfaceProvider (surface_provider.h)
+
+VulkanContext をウィンドウ実装から切り離すインターフェース。仮想メソッド:
+
+| メソッド | 役割 |
+|---|---|
+| `NativeWindowHandle get_native_handle() const` | プラットフォーム固有ハンドル (Win32/Xlib/Xcb/Wayland/Cocoa/Android/iOS) |
+| `SwapchainConfig get_swapchain_config() const` | 希望 width/height/vsync/image_count (既定 3) |
+| `void on_swapchain_created(uint32_t w, uint32_t h)` | swapchain 確定時の通知 |
+| `void poll_events()` | 毎フレーム呼ぶ (glfwPollEvents 等)。組込 provider は no-op |
+| `bool should_close() const` | 終了要求 (既定 false) |
+| `uint32_t get_required_instance_extensions(const char** out, uint32_t max) const` | 必要な VK instance 拡張 (VK_KHR_surface + 各プラットフォーム拡張) |
+
+**2 つの使い方**: ① ホストがウィンドウを所有して `ISurfaceProvider` を実装し VulkanContext へ渡す / ② Pictor 同梱の `GlfwSurfaceProvider` を使う。
+
+### プラットフォーム実装
+
+- **`GlfwSurfaceProvider`** — `GLFWwindow` 所有。`create(GlfwWindowConfig)` / `destroy()`、framebuffer size callback でリサイズ捕捉、`glfwGetRequiredInstanceExtensions` 経由で拡張返却。
+- **`AndroidSurfaceProvider`** — `ANativeWindow` 橋渡し。`update_window(ANativeWindow*, w, h)` (onNativeWindowCreated/Destroyed)。window=nullptr で background。拡張 = VK_KHR_surface + VK_KHR_android_surface。常時 vsync。
+- **`IOSSurfaceProvider`** — `CAMetalLayer` 橋渡し (MoltenVK)。`update_layer(void*, w, h)` (回転/SafeArea)。拡張 = VK_KHR_surface + VK_EXT_metal_surface。常時 vsync。
+
+## VulkanContext (vulkan_context.h)
+
+VkInstance / VkPhysicalDevice / VkDevice / VkSurfaceKHR / VkSwapchainKHR を所有 (provider は borrow)。
+
+**初期化順 `initialize(ISurfaceProvider*, VulkanContextConfig)`**:
+
+```
+create_instance        ← provider の拡張 + 任意で validation layer
+create_surface         ← vkCreate*SurfaceKHR (プラットフォーム別)
+pick_physical_device   ← graphics + present 対応の最初の GPU
+create_logical_device  ← 任意 feature を probe して有効化
+                          (tessellation / fillModeNonSolid / samplerAnisotropy …)
+                          Rive 用拡張 (VK_EXT_fragment_shader_interlock /
+                          rasterization_order_attachment_access) も probe
+                          VK_KHR_swapchain 常時有効
+create_swapchain       ← format=B8G8R8A8_SRGB 優先、present=FIFO(vsync)/IMMEDIATE/MAILBOX
+create_image_views
+create_render_pass     ← config.create_default_render_pass=true のとき (color-only, finalLayout=PRESENT_SRC)
+create_framebuffers    ← 同上
+create_command_pool_and_buffers
+create_sync_objects    ← per-frame: image_available_sem / render_finished_sem / in_flight_fence
+```
+
+**毎フレーム acquire/present**:
+
+```cpp
+uint32_t acquire_next_image();  // waitFence→resetFence→vkAcquireNextImageKHR
+                                // VK_ERROR_OUT_OF_DATE → recreate_swapchain() → UINT32_MAX
+bool     present(uint32_t image_index);  // vkQueuePresentKHR
+                                // OUT_OF_DATE / SUBOPTIMAL → recreate_swapchain()
+```
+
+**リサイズ**: `recreate_swapchain()` = deviceWaitIdle → cleanup_swapchain → swapchain/views/(renderpass/FB) 再生成。acquire/present の out-of-date で自動発火、手動でも呼べる。
+
+**`create_default_render_pass=false`**: ホストが profile 駆動の `RenderPassRegistry` / `FramebufferRegistry` で pass/FB を管理する場合 (KuzuSurvivors Phase 4 等)、既定 RP/FB をスキップできる。
+
+**拡張フラグ**: `has_fragment_shader_interlock()` / `has_rasterization_order_attachment_access()` を Rive レンダラの coverage モード選択 (pixel-interlock > ROV > atomic) に渡す。
+
+## SimpleRenderer (simple_renderer.h)
+
+デモ/ベンチ用の最小インスタンスドレンダラ (icosphere インスタンシング)。`initialize(VulkanContext&, shader_dir)` で `simple_inst.{vert,frag}.spv` をロード、`update_instances(data, count)` で SSBO 更新、`render(cmd, render_pass, fb, extent, view, proj)`。プロダクション用ではない (本番は `PictorRenderer`)。
+
+## 起動配線 (demo/main.cpp)
+
+```
+GlfwSurfaceProvider::create(config)
+VulkanContext::initialize(&provider, cfg)
+PictorRenderer::initialize(cfg)  // または SimpleRenderer::initialize(vk, shader_dir)
+loop: provider.poll_events() → img=vk.acquire_next_image()
+      → (img!=UINT32_MAX) record → vk.present(img)
+shutdown: vk.shutdown() → provider.destroy()
+```
+
+## 依存
+
+`<vulkan/vulkan.h>`、GlfwSurfaceProvider のみ `<GLFW/glfw3.h>` + `glfw3native.h`。Android は `<android/native_window.h>`、iOS は CAMetalLayer (Obj-C bridge)。volk/VMA は不使用。

--- a/spec/subsystem/text.md
+++ b/spec/subsystem/text.md
@@ -1,0 +1,72 @@
+# Text — フォント読込 + グリフ描画
+
+> 実装: `include/pictor/text/`, `src/text/`
+> 外部ライブラリ非依存 (FreeType / stb を使わず TrueType/OpenType を自前パース)。CPU 側処理で、出力は texture/vertex として描画パイプラインに渡す。
+
+## 構成
+
+| クラス / namespace | ヘッダ | 役割 |
+|---|---|---|
+| `FontLoader` | font_loader.h | TTF/OTF を file/memory から読込、テーブル (head/cmap/hmtx/glyf/CFF) パース、グリフメトリクス・コードポイント対応・カーニング照会 |
+| `TextRasterizer` | text_rasterizer.h | グリフをマルチページのテクスチャアトラスへラスタライズ (shelf-pack)、描画用 quad 頂点 (`TextVertex`) 生成 |
+| `TextImageRenderer` | text_image_renderer.h | 文字列を RGBA `ImageBuffer` へラスタライズ (固定/自動サイズ、行折返し、整列、色合成) + 寸法計測 |
+| `TextSvgRenderer` | text_svg_renderer.h | グリフ輪郭を SVG path として抽出、文字列を SVG ドキュメントへ |
+| `glyph_path_effects` | glyph_path_effects.h | `GlyphOutline` (パス) への効果: stroke / drop shadow (平行移動) / glow (拡大) / polyline 化 / bbox |
+| `text_effects` | text_effects.h | ラスタ済 alpha bitmap への効果: outline 膨張+tint / shadow+blur / glow + 合成ヘルパ |
+
+## 3 つの描画経路
+
+実装は用途別に独立した 3 経路を持つ (共通の `FontLoader` を土台にする)。
+
+| 経路 | 解像度 | 用途 | 出力 |
+|---|---|---|---|
+| **A. TextRasterizer** | 固定 (atlas 焼込時のサイズ) | 高頻度・繰返しの多い UI/HUD | atlas `ImageBuffer[]` (page) + `TextVertex[]` (glyph 6 頂点) |
+| **B. TextImageRenderer** | 動的 (毎回ラスタ) | 可変サイズ・効果付き・オフライン | RGBA `ImageBuffer` 1 枚 |
+| **C. TextSvgRenderer** | 解像度非依存 (ベクター) | スケーラブル / SVG エクスポート / 外部ラスタライザ供給 | SVG XML 文字列 |
+
+効果は経路に対応: パス系効果 (`glyph_path_effects`) は B/C 用、ラスタ系効果 (`text_effects`) は B の出力 `ImageBuffer` に適用。
+
+## 主要 API (抜粋)
+
+```cpp
+// FontLoader
+FontHandle load_from_file(const std::string& path);
+bool get_glyph_metrics(FontHandle, uint32_t codepoint, float size, GlyphMetrics& out) const;
+int16_t get_kerning(FontHandle, uint32_t left, uint32_t right) const;
+
+// TextRasterizer
+bool build_atlas(FontHandle, CharSet, const Config&);          // shelf-pack して page を焼く
+const ImageBuffer* get_page(uint32_t page_index) const;        // GPU upload 元
+std::vector<TextVertex> generate_vertices(const std::string&, const TextStyle&, float x, float y) const;
+
+// TextImageRenderer
+ImageBuffer render_text(FontHandle, const std::string&, const TextStyle&);
+TextExtent  measure_text(FontHandle, const std::string&, const TextStyle&) const;
+
+// TextSvgRenderer
+GlyphOutline extract_glyph_outline(FontHandle, uint32_t codepoint) const;
+std::string  render_text_svg(FontHandle, const std::string&, const TextStyle&) const;
+```
+
+## コアデータ型 (text_types.h)
+
+- `FontHandle = uint32_t` (`INVALID_FONT`)、`GlyphMetrics` / `FontMetrics` / `GlyphAtlasEntry` (UV + page)
+- `CharSet` (bitflags: ASCII / LATIN_EXTENDED / CJK_COMMON / HIRAGANA / KATAKANA / … と合成 `JAPANESE` / `KOREAN` / `WESTERN`)、`CodepointRange`
+- `TextStyle` (font_size / color / align_h/v / line_spacing / letter_spacing / max_width / word_wrap)
+- `GlyphOutline` (`SvgPathPoint[]`: MOVE/LINE/QUAD/CUBIC/CLOSE)、`ImageBuffer` (CPU 側 pixels + w/h/channels)、`TextVertex` (pos+uv+color)
+
+## パイプライン統合
+
+text は専用 render pass を持たない。出力は texture/quad として既存の Material + Mesh 経路に乗る:
+
+```
+TextImageRenderer::render_text() → ImageBuffer(RGBA) ─┐
+TextRasterizer::get_page()       → ImageBuffer(page) ─┴→ GPU テクスチャ化 → Material 参照 → quad 描画
+TextRasterizer::generate_vertices() → TextVertex[] → VB へ
+TextSvgRenderer は SVG 文字列を返すのみ (外部ラスタライザ or Rive へ供給)
+```
+
+## 注意
+
+- フォントパースは自前 (big-endian、cmap format 4/12)。外部フォントライブラリに差し替えない。
+- アトラスは焼込時サイズ固定 → 動的スケールは B 経路 or atlas 再構築。


### PR DESCRIPTION
## 概要
spec 充実度レビューで「194ファイルの基盤ライブラリに対し spec が3本のみ、Text/Surface/Memory/Culling 等の重大サブシステムが完全未文書」と指摘された箇所への第1弾。ご指定の4サブシステムを実装から起こした。

## 追加 (`spec/subsystem/`)
- **surface.md** — `ISurfaceProvider` プラットフォーム抽象 + `VulkanContext` (初期化順 / acquire-present / recreate_swapchain / 拡張 probe / `create_default_render_pass=false` 経路) + GLFW/Android/iOS provider
- **memory.md** — `MemorySubsystem` 傘下の `FrameAllocator`(lock-free bump) / `FlightFrameAllocator`(三重) / `PoolAllocator`(SoA, no-free) / `GpuMemoryAllocator`(mesh/ssbo/instance/indirect/staging プール + coalescing)。DoD 整合
- **culling.md** — `CullingSystem` 多段 (WorldPartition 広域 → FlatBVH 詳細 → GPU Hi-Z) + `BVHNode`(32B)/binned SAH/vEB レイアウト + フレーム位置 + compute_cull/hiz_build シェーダ
- **text.md** — 自前 TTF/OTF パース + 3 描画経路 (TextRasterizer atlas / TextImageRenderer / TextSvgRenderer) + path/raster 効果
- **README.md** — 索引 + 未文書サブシステム (data/scene/batch/gpu/shader/gi/update/decal/webgl) の列挙

## 補足
- コード変更なし (docs のみ)。各文書は `include/pictor/<name>/` + `src/<name>/` の実シンボル (クラス名・シグネチャ) に基づく。投機的な性能数値は載せていない。
- 残りの未文書サブシステムは段階的に追加予定 (README に列挙)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)