### PR TITLE
docs(spec): 基盤サブシステム第2弾 (data/scene/update/batch/gpu/shader/gi/decal/webgl)

### DIFF
--- a/spec/subsystem/README.md
+++ b/spec/subsystem/README.md
@@ -4,13 +4,32 @@ Pictor (低レイヤ Vulkan 描画ライブラリ) の基盤サブシステム�
 パイプライン上位の設計は `spec/rendering-extensibility-design.md` /
 `spec/pipeline-*.md` を参照。
 
+## フレームパイプライン順
+
+```
+data(asset) → scene(SoA store) → update(transform) → culling → batch → gpu(driven)
+            → render passes [ gi(shadow/AO/probe) → decal → post-process ]
+surface / memory / shader / text は横断基盤、webgl は Vulkan と並行の代替バックエンド
+```
+
+## 一覧
+
 | ファイル | サブシステム | 概要 |
 |---|---|---|
 | `surface.md` | surface | プラットフォーム抽象 (`ISurfaceProvider`) + `VulkanContext` (instance/device/swapchain) |
 | `memory.md` | memory | frame(bump) / pool(SoA) / GPU サブアロケータ。DoD を支える |
+| `data.md` | data | texture/mesh/model のアセットライフサイクル (FBX 等) |
+| `scene.md` | scene | `SceneRegistry` + `ObjectPool` の SoA オブジェクト store |
+| `update.md` | update | per-frame transform 更新スケジューラ (CPU並列/NT/GPU compute 自動選択) |
 | `culling.md` | culling | WorldPartition 広域 → FlatBVH 詳細 → GPU Hi-Z の多段カリング |
+| `batch.md` | batch | `BatchBuilder` + radix sort で draw batch / indirect 生成 |
+| `gpu.md` | gpu | GPU-driven パイプライン (compute update→cull→LOD→indirect) + バッファ管理 |
+| `shader.md` | shader | Visus カスタムシェーダ登録 + Vulkan pipeline 生成 (SPIR-V 事前コンパイル前提) |
+| `gi.md` | gi | 影 (CSM) / AO (SSAO) / 間接光 (irradiance probe) のランタイム + bake |
+| `decal.md` | decal | 投影デカール (depth から world 復元 + OBB 投影) |
 | `text.md` | text | 自前 TTF/OTF パース + 3 描画経路 (atlas / image / SVG) |
+| `webgl.md` | webgl | WebGL2 (Emscripten) 代替バックエンド。Vulkan と並行・非抽象 |
 
 > 各文書は実装 (`include/pictor/<name>/` + `src/<name>/`) を読んで起こしたもの。
-> 未文書のサブシステム (data / scene / batch / gpu / shader / gi / update / decal /
-> webgl 等) は順次追加予定。
+> 上位レイヤ (`material` / `postprocess` / `animation` / `vector` / `visus` / `c_api` /
+> `profiler` / `ui`) は pipeline 設計書側または別途で扱う。

--- a/spec/subsystem/batch.md
+++ b/spec/subsystem/batch.md
@@ -1,0 +1,46 @@
+# Batch — draw batch / indirect コマンド生成
+
+> 実装: `include/pictor/batch/` (2), `src/batch/`
+
+culling 結果 (`visibility_flags`) と shader/material キーから描画バッチを生成する。
+データは動かさず index 間接で参照する。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `BatchBuilder` | ObjectPool の visibility_flags + shader_keys を読み、SortPair を radix sort して `RenderBatch[]` を生成 (データ移動なし、index 間接) |
+| `RadixSort` | 64bit キーの LSB-first radix sort (O(n)、8 pass × 8bit、stable)。temp は FrameAllocator |
+| `IBatchPolicy` | 隣接バッチ結合のカスタムポリシー (`should_merge(key_a, key_b)`) |
+
+## sort key
+
+`build_sort_key(render_pass_id:63-60, transparency:59-56, shader_key:55-40, material_key:39-24, depth:23-0)`。cull 済 (visibility=0) は `UINT64_MAX` にして末尾へ送り batch から除外。
+
+## プール別生成
+
+| プール | 方式 |
+|---|---|
+| STATIC | sort → (shaderKey,materialKey) で連続グループ化 → `RenderBatch[]` (Multi Draw Indirect) |
+| DYNAMIC | 上記 + `sorted_indices_[i]=pairs[i].index` を保持 (instanced、per-instance 間接) |
+| GPU_DRIVEN | CPU batch なし、プール全体を 1 RenderBatch (compute が cull/LOD/draw 生成) |
+
+## 主要 API
+
+```cpp
+explicit BatchBuilder(SceneRegistry&);
+void build(FrameAllocator&);                  // 全プール再構築
+void invalidate_pool(PoolType);
+void set_batch_policy(IBatchPolicy*);
+const std::vector<RenderBatch>& batches() const;
+const uint32_t* sorted_indices() const;       // SoA への間接 index
+Stats get_stats() const;
+```
+
+## データフロー
+
+データは動かさない: `RenderBatch.startIndex` が sorted_indices を指し、render pass が sorted_indices 経由で ObjectPool の SoA (transform/material) を間接アクセスする。
+
+## 位置 / 依存
+
+フレームでは **culling の後・render の前**: scene → culling(visibility) → **batch** → render pass。依存: `memory/{pool,frame}_allocator.h`、`scene/`、`core/types.h` (RenderBatch)。関連: [scene.md](scene.md) / [culling.md](culling.md) / [gpu.md](gpu.md)。

--- a/spec/subsystem/data.md
+++ b/spec/subsystem/data.md
@@ -1,0 +1,44 @@
+# Data — アセット (texture/mesh/model) ライフサイクル
+
+> 実装: `include/pictor/data/` (6), `src/data/`
+
+GPU リソース (テクスチャ / メッシュ / 3D モデル) の登録・アップロード・破棄を束ねる
+ファサード層。全描画 (culling/batch/draw) の上流に位置する。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `DataHandler` | texture/vertex/model を束ねる中央ファサード。下記3つへ委譲 |
+| `TextureRegistry` | GPU テクスチャの登録/upload/破棄、format-aware サイズ計算、名前引き、swap-and-pop 削除 |
+| `VertexDataUploader` | 任意 `VertexLayout` のメッシュ VB/IB 管理、`update_vertex_region()` で部分更新、flat 配列 |
+| `ModelDataHandler` | FBX/OBJ/MMD/glTF 等の 3D モデル。SkinMesh(weights/morph) + Rig(skeleton/IK) + AnimationClip を統括、VB は VertexDataUploader へ・skeleton/clip は AnimationSystem へ委譲 |
+| `DataQueryAPI` | 読み取り専用の introspection (texture/mesh 列挙、format/semantic filter、JSON エクスポート)。level editor / asset browser 用 |
+
+## 主要 API (抜粋)
+
+```cpp
+// TextureRegistry
+TextureHandle register_texture(const TextureDescriptor&);
+bool upload_texture_data(TextureHandle, const void* data, size_t size, uint32_t mip=0, uint32_t layer=0);
+TextureHandle find_by_name(const std::string&) const;
+// VertexDataUploader
+MeshHandle register_mesh(const MeshDataDescriptor&);
+bool upload_vertex_data(MeshHandle, const void* data, size_t size);
+bool update_vertex_region(MeshHandle, size_t offset, const void* data, size_t size);
+// ModelDataHandler
+ModelHandle load_model_from_fbx(const std::string& path);
+ModelHandle load_model_from_fbx_memory(const uint8_t*, size_t, const std::string& name);
+std::shared_ptr<FBXScene> get_fbx_scene(ModelHandle) const;
+```
+
+## レイアウト
+
+- 各レジストリは flat `std::vector<Entry>` + `unordered_map<name, Handle>` の名前引き、削除は swap-and-pop
+- テクスチャサイズは `compute_texture_size()` (format-aware: 1-16 B/px、block-compressed 8-16 B/4x4)
+- メッシュは `GPUBufferManager::MeshAllocation` (VB/IB = GpuAllocation + count)
+- オブジェクトの SoA SSBO は **scene の ObjectPool** 側が持つ (本層は asset 実体を管理)
+
+## 依存 / 位置
+
+`memory/gpu_memory_allocator.h`、`gpu/gpu_buffer_manager.h`、`animation/{animation_system,fbx_importer,fbx_scene}.h`、`core/types.h`。フレームでは **全描画の上流** (アセットロード ↔ フレーム実行の結節点)。関連: [text.md](text.md) (ImageBuffer→texture)、[scene.md](scene.md) (object 登録)。

--- a/spec/subsystem/decal.md
+++ b/spec/subsystem/decal.md
@@ -1,0 +1,48 @@
+# Decal — 投影デカール
+
+> 実装: `include/pictor/decal/decal_system.h`, `src/decal/`、設計 `docs/design/decals.md`
+
+scene depth から world 位置を復元し、OBB 内に収まる画素へデカールテクスチャを投影する
+フルスクリーンパス。scene pass の後・post-process の前に挿入する。
+
+## 構成
+
+| 型 | 役割 |
+|---|---|
+| `DecalSystem` | デカールの追加/更新/削除 + scene HDR への投影パス記録 |
+| `DecalDescriptor` | world transform (単位 OBB `[-0.5,0.5]³`→world) / VkImageView / blend / opacity / angle fade / depth fade / sort order |
+| `DecalBlend` | Alpha / Additive / Multiply |
+| `DecalHandle` | 1-based 32bit (0=INVALID)、free-list でスロット再利用 |
+
+## 投影技法
+
+1. 各デカールは local 単位ボックス `[-0.5,0.5]³` を `world_transform` で配置、投影軸 = local Y (column1)
+2. フルスクリーン三角形 (P2) を描き、fragment で `gl_FragCoord` + scene depth + inverse view-proj から world 位置復元
+3. `inverse(world_transform)` (push constant) で decal local へ → `[-0.5,0.5]³` 外は discard
+4. local XZ → texture UV、angle fade (法線 vs 投影軸) + depth fade (Y 端) を適用、blend モードで scene HDR に合成
+
+## 主要 API
+
+```cpp
+bool initialize(VulkanContext&, const std::string& shader_dir,
+                VkFormat scene_color_format, VkImageView scene_color, VkImageView scene_depth, VkExtent2D);
+bool resize(VkImageView scene_color, VkImageView scene_depth, VkExtent2D);
+void record(VkCommandBuffer, const float view[16], const float proj[16]);  // scene 後・PP 前
+DecalHandle add(const DecalDescriptor&);
+void update(DecalHandle, const DecalDescriptor&);
+void remove(DecalHandle); void clear();
+```
+
+- TTL は呼び出し側 (例: ゲーム側 GameRenderer) が opacity を更新して管理。本層は寿命を持たない
+- descriptor set0 = scene (UBO inv-view-proj + depth sampler)、set1 = per-decal texture。push constant `DecalPC` (inv_decal[16] + opacity/angle/depth fade + axis)
+- pipeline は blend モード毎に 3 本 (同一 shader)。同時上限 `kMaxDecals`=64
+
+## パス位置
+
+```
+scene pass (color+depth) → DecalSystem::record (depth read-only, HDR color blend write) → post-process → HUD → present
+```
+
+## 依存 / フェーズ
+
+`VulkanContext`、scene の depth/color (借用)、`fullscreen_quad.vert.spv` + `decal.frag.spv`。P2=fullscreen+Alpha、P3+ で Additive/Multiply + angle/depth fade + OBB box mesh + ゲーム側 TTL 統合。関連: [gi.md](gi.md) / [surface.md](surface.md)。

--- a/spec/subsystem/gi.md
+++ b/spec/subsystem/gi.md
@@ -1,0 +1,43 @@
+# GI — グローバルイルミネーション (影 / AO / プローブ)
+
+> 実装: `include/pictor/gi/` (2), `src/gi/`
+
+影 (CSM) + 環境遮蔽 (SSAO) + 間接光 (irradiance probe) のランタイム + オフライン bake。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `GILightingSystem` | ランタイム GI パス統括。可視カリング後に shadow / SSAO / probe sampling の 3 前パスを実行、cascade uniform と GPU binding を管理 |
+| `GIBakeSystem` | Static プール向けの高品質オフライン事前計算 → GPU SSBO にキャッシュ |
+
+設定: `GIConfig` (shadows+SSAO+probes 統合) / `ShadowMapConfig` (cascade 数/解像度/PCF・PCSS/bias) / `SSAOConfig` / `GIProbeConfig` (grid 原点/間隔/寸法)。bake は `GIBakeConfig` + `BakeTarget` enum (SHADOW_MAP / AMBIENT_OCCLUSION / PROBE_IRRADIANCE / LIGHTMAP)。
+
+## 技法
+
+- **影**: Cascaded Shadow Maps (1-4 cascade、既定 2048²、depth array)。hard/PCF/PCSS フィルタ、cascade 割当は `shadow_map_gen.comp`、constant+normal+slope bias
+- **AO**: ランタイム SSAO (hemisphere sampling + bilateral blur)。bake は object-space 高サンプル (256 vs 32)
+- **間接光**: irradiance probe grid。per-probe を **L2 球面調和 (9係数)** で保持、`gi_probe_sample.comp` でオブジェクト位置に補間。bake は per-object SH をキャッシュ
+- **lightmap**: direct+indirect (multi-bounce 最大3)
+
+## 主要 API
+
+```cpp
+// GILightingSystem
+void initialize(uint32_t max_objects, uint32_t w, uint32_t h);
+void execute(const float4x4& view, const float4x4& proj);   // compute cull 後
+void set_directional_light(const DirectionalLight&);
+void upload_probe_data(const float* sh, uint32_t probe_count);
+const ShadowUniformData& shadow_uniforms() const;
+// GIBakeSystem
+GIBakeResult bake(BakeProgressCallback);
+void apply(const GIBakeResult&);
+bool save(const std::string&, const GIBakeResult&);
+GIBakeResult load(const std::string&);
+```
+
+baked データ: `BakedShadow` (cascade flags + 4 depth) / `BakedAO` / `BakedIrradiance` (9×vec4 SH) / `BakedLightmap`。
+
+## 統合 / 依存
+
+`execute()` を compute cull 後に呼び、shadow → SSAO → probe の順に dispatch。fragment shader が `shadow_atlas` / `ao_output` / `object_irradiance` を read-only で sample。bake は `static_pool()` を 4 パス処理し binary 永続化、ランタイムは先頭 `baked_static_count()` 個を bake 済データで skip。依存: `gpu/gpu_buffer_manager.h`、`scene/`、`shaders/shadow.glsl`。関連: [decal.md](decal.md) / [gpu.md](gpu.md)。

--- a/spec/subsystem/gpu.md
+++ b/spec/subsystem/gpu.md
@@ -1,0 +1,46 @@
+# GPU — GPU-driven パイプライン + バッファ管理
+
+> 実装: `include/pictor/gpu/` (2), `src/gpu/`
+
+オブジェクトデータを GPU 常駐 SoA バッファ化し、compute シェーダ連鎖で update→cull→LOD→
+indirect draw 生成までを on-device で回す GPU-driven レイヤー。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `GPUBufferManager` | GPU SoA SSBO / mesh pool / instance / indirect / staging を確保。dirty region 追跡で CPU→GPU 転送最適化 |
+| `GPUDrivenPipeline` | GPU-driven の全段を統括: compute update → 2 段 cull (frustum + Hi-Z) → LOD 選択 → compact → indirect draw 生成 |
+| `GPUDrivenConfig` | max tri=50000 / min instance=32 / workgroup=256 / two_phase_culling / compute_update |
+
+## 主要 API
+
+```cpp
+// GPUBufferManager
+SSBOLayout allocate_soa_buffers(uint32_t object_count);
+void resize_soa_buffers(SSBOLayout&, uint32_t new_count);
+MeshAllocation allocate_mesh(size_t vbytes, size_t ibytes);
+void mark_dirty(uint32_t start, uint32_t end, uint32_t chunk=16384);
+// GPUDrivenPipeline
+void initialize(uint32_t max_objects);
+void upload_initial_data(const ObjectPool&);
+void execute(const Frustum&, const UpdateScheduler::ComputeUpdateParams&);
+Stats get_stats() const;   // {total/visible objects, draw_calls, workgroups}
+```
+
+## SoA レイアウト (SSBOLayout)
+
+| バッファ | 中身 | 更新 |
+|---|---|---|
+| gpu_bounds (24B) / gpu_transforms (64B) / gpu_velocities (12B) | per-object 変動 | compute update |
+| gpu_mesh_info / gpu_material_ids / gpu_lod_info | 安定 metadata | upload 時 |
+| gpu_visibility (4B) | cull + LOD bits | compute cull 出力 |
+| indirect_draw (`DrawIndexedIndirectCommand` 20B) / draw_count (atomic) | compact 出力 | GPU |
+
+## 2 段カリング
+
+`gpu_driven_pool` を SSBO 化 → ① frustum cull で画面内候補に絞る → ② Hi-Z occlusion で遮蔽除外。可視のみ indirect draw entry を生成 ([culling.md](culling.md) の GPU 側に対応)。
+
+## 位置 / 依存
+
+フレームでは **CPU update の後・render pass 記録の前**。compute dispatch は update と graphics の間で非同期実行、出力 (indirect buffer + draw_count) が graphics command 記録へ。依存: `memory/gpu_memory_allocator.h` 経由で VkBuffer (公開 IF に Vulkan ヘッダ非露出)。関連: [batch.md](batch.md) / [update.md](update.md)。

--- a/spec/subsystem/scene.md
+++ b/spec/subsystem/scene.md
@@ -1,0 +1,44 @@
+# Scene — オブジェクト store (SoA / ObjectPool)
+
+> 実装: `include/pictor/scene/` (4), `src/scene/`
+
+全描画オブジェクトの SoA ストア。culling/update/batch/render の全下流が参照する土台。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `SceneRegistry` | 3 つの `ObjectPool` (STATIC/DYNAMIC/GPU_DRIVEN) を統括。`ObjectId → (PoolType, index)` 逆引き、登録/削除/transform更新/プール移動 |
+| `ObjectPool` | 1 カテゴリの SoA。11 個の並列 `SoAStream` を同一 index で保持 |
+| `ObjectClassifier` | 登録時に PoolType を決定 (`classify(ObjectDescriptor)`)。GPU 適格判定 (≤50K tri / ≥32 instance / indirect 対応) |
+| `SoAStream<T>` | 1 属性の連続配列。`push_back`→index / `swap_and_pop(index)`。cache-line アライン、PoolAllocator が確保 |
+
+## SoA グループ (hot/cold)
+
+ObjectPool は 11 stream を 4 グループに分けてアクセス局所性を出す:
+
+- **A culling(hot)**: `bounds_`(AABB) / `visibility_flags_`(u8)
+- **B sort/batch(hot)**: `shader_keys_`(u64) / `sort_keys_`(u64) / `material_keys_`(u32)
+- **C transform(dynamic hot)**: `transforms_`(float4x4) / `prev_transforms_`(motion vector 用)
+- **D metadata(cold)**: `mesh_handles_` / `material_handles_` / `lod_levels_` / `flags_` / `last_frame_updated_`
+- ID: `object_ids_`
+
+## 主要 API
+
+```cpp
+ObjectId register_object(const ObjectDescriptor&);   // Classifier がプール決定
+void unregister_object(ObjectId);                    // swap_and_pop で密詰め維持
+void update_transform(ObjectId, const float4x4&);
+void update_bounds(ObjectId, const AABB&);
+void change_pool(ObjectId, PoolType);                // プール間移動
+ObjectLocation find_object(ObjectId) const;          // {PoolType, index, valid}
+void for_each_pool(std::function<void(ObjectPool&, PoolType)>);
+```
+
+## ライフサイクル
+
+登録 = Classifier→pool 決定→全 11 stream に同 index で push。削除 = `swap_and_pop` を全 stream に適用し id_map を更新 (末尾と入替)。移動 = 旧プールから状態回収→新プールへ追加。
+
+## 位置 / 依存
+
+フレームでは **最上流のストア**: scene → (update が transform 更新) → culling が `visibility_flags` 書込 → batch が読込。依存: `memory/pool_allocator.h` (SoA 実体)、`core/types.h`。関連: [culling.md](culling.md) / [batch.md](batch.md) / [update.md](update.md)。

--- a/spec/subsystem/shader.md
+++ b/spec/subsystem/shader.md
@@ -1,0 +1,45 @@
+# Shader — カスタムシェーダ登録 + pipeline 生成
+
+> 実装: `include/pictor/shader/` (3), `src/shader/`
+
+Visus CUSTOM kind のカスタムシェーダを登録し、Vulkan graphics pipeline を生成する最小レジストリ。
+SPIR-V は **事前コンパイル済**を前提 (Pictor は runtime コンパイルしない)。
+
+## 構成
+
+| クラス / struct | 役割 |
+|---|---|
+| `ShaderRegistry` | カスタム vert+frag SPIR-V を受け取り on-demand で pipeline 生成・handle 保持。Phase 1 は vert+frag 固定 (compute/permutation は Phase 2)。`PICTOR_HAS_VULKAN` 条件 |
+| `CustomShaderDef` | 1 ペアの定義: name / vert_spv / frag_spv / vertex_layout (空=Phase1 gl_VertexIndex 駆動) |
+| `GraphicsPipelineDesc` + `build_graphics_pipeline()` | pipeline 生成の共通記述子 (ShaderRegistry と PostProcessPipeline で共用) |
+| vertex_layout 変換 | `to_vk_format()` / `to_vk_vertex_input()` — agnostic な `VertexLayout` を Vulkan の binding/attribute へ |
+
+## 主要 API
+
+```cpp
+ShaderHandle register_shader(CustomShaderDef def);
+const CustomShaderDef* get(ShaderHandle) const;
+// Vulkan のみ
+bool build_pipelines(VulkanContext&, VkRenderPass, uint32_t subpass, VkPipelineLayout);
+VkPipeline pipeline(ShaderHandle) const;     // O(1)
+```
+
+## SPIR-V / pipeline
+
+- **事前コンパイル**: `.spv` を `vkCreateShaderModule` へ。runtime の shaderc/glslang 依存なし (コンパイルは Ergo tools 等の asset pipeline 責務)
+- `build_pipelines()` を 1 回呼んで全 handle 分の pipeline を同期生成。`pipeline(handle)` は配列引き
+- stage: vertex (binding0 mesh VB) → fragment (color attachment0、blend なし)、backface cull + depth test/write on、viewport/scissor は dynamic
+- hot-reload は Phase 1 非対応 (再 register + rebuild)
+
+## 設計シーム
+
+```
+Visus CUSTOM → VisusDesc.shader_stages[] (vert/frag spv path)
+  → ShaderRegistry::register_shader() → ShaderHandle
+  → ObjectDescriptor.customShader → ShaderKey (bit63=custom, 32-62=handle)
+  → DrawCommand.shader_key → render loop が pipeline(handle) を lookup + vkCmdBindPipeline
+```
+
+## 依存 / 位置
+
+`vulkan/vulkan.h` (`PICTOR_HAS_VULKAN` 条件、headless test は省略)、`VulkanContext`。フレームでは **render setup で 1 回 init**、record 時に host が `ShaderKey::is_custom()` で判定して既定 PBR の代わりに bind。関連: [surface.md](surface.md) / Visus (`spec/subsystem/` 外、`include/pictor/visus/`)。

--- a/spec/subsystem/update.md
+++ b/spec/subsystem/update.md
@@ -1,0 +1,45 @@
+# Update — per-frame オブジェクト更新スケジューラ
+
+> 実装: `include/pictor/update/` (2), `src/update/`
+
+毎フレームの transform/bounds 更新を、オブジェクト数とプール種別に応じて最適な戦略で
+ディスパッチする。culling の手前に位置する。
+
+## 構成
+
+| クラス | 役割 |
+|---|---|
+| `UpdateScheduler` | プール別に更新戦略を自動選択しディスパッチ。motion vector 用に prev_transforms を事前 copy |
+| `ThreadPoolDispatcher` | `IJobDispatcher` 実装。64B アライン chunk 分配 + worker pool (auto = cores-1) + atomic queue |
+
+## 更新戦略 (自動選択)
+
+```
+select_strategy(type, count):
+  STATIC                                  → NONE        (更新しない)
+  GPU_DRIVEN & compute shader あり          → GPU_COMPUTE
+  DYNAMIC & count > nt_threshold & NT 有効  → CPU_PARALLEL_NT
+  DYNAMIC その他                           → CPU_PARALLEL
+```
+
+- **CPU_PARALLEL**: ThreadPoolDispatcher で chunk (既定 16384) 並列、callback が `transforms[]`/`bounds[]` を直接書込
+- **CPU_PARALLEL_NT**: 上記 + AVX2 non-temporal store (`_mm256_stream_ps` + `_mm_sfence`) で大バッチの LLC 汚染回避
+- **GPU_COMPUTE**: `ComputeUpdateParams` (dt/total_time/frame/gravity) を stage、実 dispatch は `GPUDrivenPipeline::execute()` 内で非同期
+
+## 主要 API
+
+```cpp
+void update(float delta_time);                    // プール毎に戦略選択 + dispatch
+void set_update_callback(IUpdateCallback*);
+void set_job_dispatcher(IJobDispatcher*);
+UpdateStrategy strategy_for(PoolType) const;
+// ThreadPoolDispatcher
+void dispatch(uint32_t count, uint32_t chunk_size, JobFunction);
+void wait_all();
+```
+
+`UpdateConfig`: chunk_size=16384 / worker_threads=0(auto) / nt_store_enabled=true / nt_store_threshold=10000。
+
+## 位置 / 依存
+
+フレームでは **culling の直前**: pre-update で prev_transforms を copy (motion vector) → 戦略別更新 → 更新後の transform/bounds を culling と batch が次段で使う。依存: `scene/{scene_registry,object_pool}.h`、`<thread>/<atomic>`、`<immintrin.h>` (AVX2)。関連: [scene.md](scene.md) / [gpu.md](gpu.md)。

--- a/spec/subsystem/webgl.md
+++ b/spec/subsystem/webgl.md
@@ -1,0 +1,53 @@
+# WebGL — WebGL2 (Emscripten) バックエンド
+
+> 実装: `include/pictor/webgl/` (4), `src/webgl/`、デモ `demo/webgl/`
+
+Vulkan と**並行**の独立レンダリングバックエンド (WebGL2 / GLSL ES 3.00 via Emscripten)。
+現状は共通抽象 (`RenderBackend` trait) を持たない最小リファレンス実装。
+
+## 構成
+
+| クラス / struct | 役割 |
+|---|---|
+| `WebGLContext` | HTML canvas に紐づく WebGL2 context のライフサイクル (Emscripten handle 所有) |
+| `WebGLBufferManager` | VBO/IBO/UBO/VAO 管理 |
+| `WebGLShaderManager` | GLSL ES 3.00 program のコンパイル/リンク/キャッシュ + uniform 引き |
+| `WebGLRenderer` | 最小インスタンスドレンダラ (icosphere + per-instance transform/color + CPU frustum cull) |
+
+設定: `WebGLContextConfig` / `WebGLCapabilities` (max texture/extension) / `WebGLRendererConfig` / `WebGLInstanceData` (80B = 4x4 + RGBA) / `WebGLFrameStats`。
+
+## 主要 API
+
+```cpp
+// WebGLContext
+bool initialize(const WebGLContextConfig&);
+void begin_frame(float r,g,b,a); void end_frame();
+void resize(uint32_t w, uint32_t h);
+// WebGLRenderer
+bool initialize(const WebGLRendererConfig&);
+ObjectId register_object(const ObjectDescriptor&);
+void update_transform(ObjectId, const float4x4&);
+void render(const float* view, const float* projection);
+void set_camera(const float3& eye, const float3& target, const float3& up);
+const WebGLFrameStats& stats() const;
+```
+
+## Vulkan 経路との関係
+
+- **並行・非抽象**: Vulkan 側 `SimpleRenderer` と機能対応するが共通 IF はまだ無い。ヘッダコメントに「将来 `RenderBackend` trait で `PictorRenderer` に統合予定」と明記
+- **サポート**: instanced (transform+color) / icosphere 生成 / CPU frustum cull / depth・cull・blend / UBO / half-Lambert + rim の簡易ライティング / HiDPI / extension 検出
+- **未サポート (vs Vulkan)**: deferred / compute / post-process / テクスチャ sampling / push constant / dynamic pipeline。**意図的に subset** のリファレンス実装
+
+## ビルド / プラットフォーム gating
+
+```cmake
+option(PICTOR_BUILD_WEBGL "Build WebGL2 backend (Emscripten)" OFF)  # 既定 OFF
+# ON で src/webgl/*.cpp をコンパイル、PICTOR_HAS_WEBGL=1、-sUSE_WEBGL2=1 -sFULL_ES3=1
+```
+
+- C++ ガード: `#ifdef PICTOR_HAS_WEBGL`
+- **Emscripten 専用** (`emcxx`/`emar`、`-sUSE_WEBGL2=1` 前提)
+
+## 依存 / デモ
+
+`<GLES3/gl3.h>`、`<emscripten/html5.h>`、`<emscripten.h>` (Vulkan ヘッダなし)。デモ `demo/webgl/{main.cpp,shell.html}` = 10×10 アニメ icosphere + 軌道カメラ + stats overlay。shader は renderer に埋込。専用 level editor は無し。関連: [surface.md](surface.md) (Vulkan 経路)。


### PR DESCRIPTION
## 概要
spec 充実度レビュー (#73 に続く第2弾)。残りの未文書サブシステム9本を実装から起こし、`spec/subsystem/` を 4→13 本に拡充。これで主要な描画パイプライン経路がほぼ網羅された。

## 追加 (`spec/subsystem/`)
フレームパイプライン順:
- **data.md** — texture/mesh/model アセットライフサイクル (DataHandler 系 + FBX)
- **scene.md** — `SceneRegistry` + `ObjectPool` (11 SoAStream / 4 group) + ObjectClassifier
- **update.md** — `UpdateScheduler` 戦略自動選択 (NONE/CPU_PARALLEL/_NT/GPU_COMPUTE) + ThreadPoolDispatcher
- **batch.md** — `BatchBuilder` + RadixSort + sort key + プール別 (static/dynamic/gpu_driven)
- **gpu.md** — `GPUBufferManager` + `GPUDrivenPipeline` (compute update→2段 cull→LOD→indirect)
- **shader.md** — `ShaderRegistry` (Visus CUSTOM、SPIR-V 事前コンパイル前提) + pipeline 生成
- **gi.md** — `GILightingSystem`/`GIBakeSystem` (CSM / SSAO / irradiance probe L2 SH / lightmap)
- **decal.md** — `DecalSystem` (depth→world 復元 + OBB 投影 + Alpha/Additive/Multiply)
- **webgl.md** — WebGL2/Emscripten 代替バックエンド (Vulkan と並行・非抽象、`PICTOR_BUILD_WEBGL`)

`README.md` を 13 本へ更新 + フレームパイプライン順を明示 + 上位レイヤ (material/postprocess/animation/vector/visus/c_api/profiler/ui) の扱い注記。

## 補足
コード変更なし (docs のみ)。各文書は `include/pictor/<name>/` + `src/<name>/` の実シンボルに基づく。投機的性能数値なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)