### PR TITLE
fix(pictor): Fable 全量診断の Critical/High 修正 (deadlock/heap破壊/font OOB/path traversal)

### DIFF
--- a/include/pictor/batch/batch_builder.h
+++ b/include/pictor/batch/batch_builder.h
@@ -66,12 +66,17 @@ private:
     void sort_pool(ObjectPool& pool, FrameAllocator& allocator,
                    SortPair*& out_pairs, size_t& out_count);
 
-    /// Create batches from sorted pairs
+    /// Create batches from sorted pairs, appending them to `out`.
     void create_batches_from_sorted(const SortPair* pairs, size_t count,
-                                    const ObjectPool& pool);
+                                    const ObjectPool& pool,
+                                    std::vector<RenderBatch>& out);
 
     SceneRegistry&         registry_;
     std::vector<RenderBatch> batches_;
+    // Static batches are rebuilt only when the static pool is dirty, but must
+    // survive into every frame's `batches_`; caching them here prevents static
+    // objects from disappearing on the first non-dirty frame.
+    std::vector<RenderBatch> static_batches_;
     IBatchPolicy*          policy_   = nullptr;
     uint32_t*              sorted_indices_ = nullptr;
     size_t                 sorted_index_count_ = 0;

--- a/include/pictor/memory/frame_allocator.h
+++ b/include/pictor/memory/frame_allocator.h
@@ -43,6 +43,11 @@ public:
     size_t capacity() const { return capacity_; }
 
 private:
+    // Frees buffer_ with the deallocator matching how it was allocated
+    // (large-pages vs aligned malloc). Single source of truth shared by the
+    // destructor and move assignment so the two cannot diverge.
+    void release_() noexcept;
+
     uint8_t*          buffer_   = nullptr;
     size_t            capacity_ = 0;
     std::atomic<size_t> offset_{0};

--- a/src/batch/batch_builder.cpp
+++ b/src/batch/batch_builder.cpp
@@ -10,10 +10,14 @@ BatchBuilder::BatchBuilder(SceneRegistry& registry)
 void BatchBuilder::build(FrameAllocator& allocator) {
     batches_.clear();
 
-    // Build batches for each pool type (§6.1)
+    // Build batches for each pool type (§6.1).
+    // Static batches are only re-sorted when the static pool changes, but the
+    // cached result is merged into every frame so static geometry keeps drawing.
     if (dirty_[static_cast<int>(PoolType::STATIC)]) {
         build_static(allocator);
     }
+    batches_.insert(batches_.end(), static_batches_.begin(), static_batches_.end());
+
     build_dynamic(allocator);  // Always rebuild dynamic batches
     build_gpu_driven();
 
@@ -79,7 +83,8 @@ void BatchBuilder::sort_pool(ObjectPool& pool, FrameAllocator& allocator,
 }
 
 void BatchBuilder::create_batches_from_sorted(const SortPair* pairs, size_t count,
-                                               const ObjectPool& pool) {
+                                               const ObjectPool& pool,
+                                               std::vector<RenderBatch>& out) {
     if (count == 0) return;
 
     // Skip culled objects (sort key == UINT64_MAX)
@@ -114,7 +119,7 @@ void BatchBuilder::create_batches_from_sorted(const SortPair* pairs, size_t coun
         if (should_merge) {
             current_batch.count++;
         } else {
-            batches_.push_back(current_batch);
+            out.push_back(current_batch);
             current_batch.sortKey = pairs[i].key;
             current_batch.startIndex = static_cast<uint32_t>(i);
             current_batch.count = 1;
@@ -128,12 +133,14 @@ void BatchBuilder::create_batches_from_sorted(const SortPair* pairs, size_t coun
 }
 
 void BatchBuilder::build_static(FrameAllocator& allocator) {
-    // §6.1: Static Pool — Multi Draw Indirect with index indirection
+    // §6.1: Static Pool — Multi Draw Indirect with index indirection.
+    // Rebuild the cache from scratch; build() merges it into batches_ each frame.
+    static_batches_.clear();
     ObjectPool& pool = registry_.static_pool();
     SortPair* pairs;
     size_t count;
     sort_pool(pool, allocator, pairs, count);
-    create_batches_from_sorted(pairs, count, pool);
+    create_batches_from_sorted(pairs, count, pool, static_batches_);
 }
 
 void BatchBuilder::build_dynamic(FrameAllocator& allocator) {
@@ -142,7 +149,7 @@ void BatchBuilder::build_dynamic(FrameAllocator& allocator) {
     SortPair* pairs;
     size_t count;
     sort_pool(pool, allocator, pairs, count);
-    create_batches_from_sorted(pairs, count, pool);
+    create_batches_from_sorted(pairs, count, pool, batches_);
 
     // Store sorted indices for indirect data access
     if (count > 0 && pairs) {

--- a/src/memory/frame_allocator.cpp
+++ b/src/memory/frame_allocator.cpp
@@ -60,7 +60,7 @@ FrameAllocator::FrameAllocator(size_t capacity)
     }
 }
 
-FrameAllocator::~FrameAllocator() {
+void FrameAllocator::release_() noexcept {
     if (buffer_ && owns_memory_) {
 #ifdef PICTOR_LARGE_PAGES
 #ifdef _WIN32
@@ -78,6 +78,10 @@ FrameAllocator::~FrameAllocator() {
     }
 }
 
+FrameAllocator::~FrameAllocator() {
+    release_();
+}
+
 FrameAllocator::FrameAllocator(FrameAllocator&& other) noexcept
     : buffer_(other.buffer_)
     , capacity_(other.capacity_)
@@ -93,13 +97,10 @@ FrameAllocator::FrameAllocator(FrameAllocator&& other) noexcept
 
 FrameAllocator& FrameAllocator::operator=(FrameAllocator&& other) noexcept {
     if (this != &other) {
-        if (buffer_ && owns_memory_) {
-#ifdef _MSC_VER
-            _aligned_free(buffer_);
-#else
-            std::free(buffer_);
-#endif
-        }
+        // Use the same large-pages-aware deallocator as the destructor; the
+        // previous unconditional _aligned_free/std::free corrupted the heap on
+        // PICTOR_LARGE_PAGES builds (freeing an mmap/VirtualAlloc region).
+        release_();
         buffer_ = other.buffer_;
         capacity_ = other.capacity_;
         offset_.store(other.offset_.load(std::memory_order_relaxed), std::memory_order_relaxed);

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -105,7 +105,6 @@ bool VulkanContext::recreate_swapchain() {
 
 uint32_t VulkanContext::acquire_next_image() {
     vkWaitForFences(device_, 1, &in_flight_fence_, VK_TRUE, UINT64_MAX);
-    vkResetFences(device_, 1, &in_flight_fence_);
 
     uint32_t index = 0;
     VkResult result = vkAcquireNextImageKHR(
@@ -113,9 +112,17 @@ uint32_t VulkanContext::acquire_next_image() {
         image_available_sem_, VK_NULL_HANDLE, &index);
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
+        // No queue submit will follow this frame, so the fence must stay
+        // signaled — resetting it here (as the old code did before acquire)
+        // left it unsignaled with nothing to signal it, deadlocking the next
+        // frame's vkWaitForFences during a resize.
         recreate_swapchain();
         return UINT32_MAX;
     }
+
+    // Image acquired; a submit signaling in_flight_fence_ will follow, so it is
+    // safe to reset the fence now (must happen before that submit).
+    vkResetFences(device_, 1, &in_flight_fence_);
     return index;
 }
 

--- a/src/text/font_loader.cpp
+++ b/src/text/font_loader.cpp
@@ -222,7 +222,7 @@ std::vector<FontLoader::TableRecord> FontLoader::read_table_directory(
         // offsetTable[0] at byte 12
         if (size < 16) return records;
         uint32_t first_font_offset = read_u32(data + 12);
-        if (first_font_offset + 12 > size) return records;
+        if (static_cast<size_t>(first_font_offset) + 12 > size) return records;
         font_data = data + first_font_offset;
     }
 
@@ -267,7 +267,9 @@ bool FontLoader::parse_font_tables(FontTableEntry& entry) {
     const uint8_t* name_data = nullptr; uint32_t name_len = 0;
 
     for (const auto& rec : tables) {
-        if (rec.offset + rec.length > size) continue;
+        // size_t arithmetic: offset/length are file-controlled uint32s whose
+        // 32-bit sum could wrap and pass this check while pointing past the buffer.
+        if (static_cast<size_t>(rec.offset) + rec.length > size) continue;
         const uint8_t* tdata = data + rec.offset;
 
         if      (rec.tag == make_tag('h','e','a','d')) { head_data = tdata; head_len = rec.length; }

--- a/src/text/text_rasterizer.cpp
+++ b/src/text/text_rasterizer.cpp
@@ -89,28 +89,30 @@ bool extract_glyph_edges(const uint8_t* data, size_t data_size,
         uint32_t len = rd_u32(data + r + 12);
         if (tag == mk_tag('g','l','y','f'))                              glyf_off = off;
         else if (tag == mk_tag('l','o','c','a'))                         loca_off = off;
-        else if (tag == mk_tag('m','a','x','p') && off + 6 <= data_size) num_glyphs = rd_u16(data + off + 4);
-        else if (tag == mk_tag('h','e','a','d') && off + 54 <= data_size) loc_fmt = rd_i16(data + off + 50);
+        else if (tag == mk_tag('m','a','x','p') && static_cast<size_t>(off) + 6 <= data_size) num_glyphs = rd_u16(data + off + 4);
+        else if (tag == mk_tag('h','e','a','d') && static_cast<size_t>(off) + 54 <= data_size) loc_fmt = rd_i16(data + off + 50);
     }
     if (glyf_off == 0 || loca_off == 0 || glyph_index >= num_glyphs)
         return false;
 
-    // Resolve glyph offset via 'loca'
+    // Resolve glyph offset via 'loca'. All offsets are file-controlled uint32s,
+    // so every bounds check is done in size_t to avoid 32-bit wraparound that
+    // would let an out-of-range offset slip past the comparison.
     uint32_t g_off, g_end;
     if (loc_fmt == 0) {
-        uint32_t li = loca_off + glyph_index * 2;
+        size_t li = static_cast<size_t>(loca_off) + static_cast<size_t>(glyph_index) * 2;
         if (li + 4 > data_size) return false;
         g_off = static_cast<uint32_t>(rd_u16(data + li)) * 2;
         g_end = static_cast<uint32_t>(rd_u16(data + li + 2)) * 2;
     } else {
-        uint32_t li = loca_off + glyph_index * 4;
+        size_t li = static_cast<size_t>(loca_off) + static_cast<size_t>(glyph_index) * 4;
         if (li + 8 > data_size) return false;
         g_off = rd_u32(data + li);
         g_end = rd_u32(data + li + 4);
     }
     if (g_off == g_end) return false; // empty glyph (space etc.)
 
-    uint32_t abs = glyf_off + g_off;
+    size_t abs = static_cast<size_t>(glyf_off) + static_cast<size_t>(g_off);
     if (abs + 10 > data_size) return false;
 
     const uint8_t* g = data + abs;
@@ -125,7 +127,17 @@ bool extract_glyph_edges(const uint8_t* data, size_t data_size,
         ends[c] = rd_u16(g + p);
         p += 2;
     }
-    uint16_t total_pts = ends.back() + 1;
+    // Endpoint indices must be monotonically non-decreasing; otherwise a later
+    // cend = ends[c] can exceed total_pts-1 and index fl/xs/ys out of bounds.
+    for (int16_t c = 1; c < n_contours; ++c) {
+        if (ends[c] < ends[c - 1]) return false;
+    }
+    // Compute total_pts in 32-bit: a last endpoint of 0xFFFF would wrap a
+    // uint16_t sum to 0, under-allocating fl/xs/ys and causing a heap OOB read
+    // during the contour walk. >65535 points is impossible in 'glyf' and would
+    // also break the uint16_t loop counters below, so reject it.
+    uint32_t total_pts = static_cast<uint32_t>(ends.back()) + 1u;
+    if (total_pts > 0xFFFFu) return false;
 
     // Skip instructions
     if (abs + p + 2 > data_size) return false;

--- a/src/update/job_dispatcher.cpp
+++ b/src/update/job_dispatcher.cpp
@@ -6,8 +6,11 @@ namespace pictor {
 ThreadPoolDispatcher::ThreadPoolDispatcher(uint32_t thread_count) {
     if (thread_count == 0) {
         // Auto-detect: CPU logical cores - 1 (§5.2)
-        thread_count = std::max(1u,
-            static_cast<uint32_t>(std::thread::hardware_concurrency()) - 1);
+        // hardware_concurrency() may return 0 (undetectable); guard the
+        // subtraction so it does not wrap to UINT32_MAX and spawn billions
+        // of threads.
+        unsigned hw = std::thread::hardware_concurrency();
+        thread_count = hw > 1 ? hw - 1 : 1;
     }
     thread_count_ = thread_count;
 
@@ -41,7 +44,9 @@ void ThreadPoolDispatcher::dispatch(uint32_t count, uint32_t chunk_size, JobFunc
             uint32_t end = std::min(start + aligned_chunk, count);
             task_queue_.push({fn, start, end});
         }
-        pending_tasks_.store(job_count, std::memory_order_release);
+        // Accumulate rather than overwrite: a second dispatch issued while
+        // earlier tasks are still pending must not lose their count.
+        pending_tasks_.fetch_add(job_count, std::memory_order_release);
     }
     cv_task_.notify_all();
 }
@@ -74,6 +79,11 @@ void ThreadPoolDispatcher::worker_thread() {
         task.fn(task.start, task.end);
 
         if (pending_tasks_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+            // Serialize the notify with the waiter's predicate check: without
+            // holding mutex_ here, the notify can land between wait_all()'s
+            // predicate evaluation and its wait(), a lost wakeup that hangs
+            // the render thread permanently.
+            std::lock_guard<std::mutex> lock(mutex_);
             cv_done_.notify_all();
         }
     }

--- a/src/update/update_scheduler.cpp
+++ b/src/update/update_scheduler.cpp
@@ -17,8 +17,9 @@ UpdateScheduler::UpdateScheduler(SceneRegistry& registry, const UpdateConfig& co
 {
     uint32_t threads = config.worker_threads;
     if (threads == 0) {
-        threads = std::max(1u,
-            static_cast<uint32_t>(std::thread::hardware_concurrency()) - 1);
+        // Guard against hardware_concurrency()==0 wrapping to UINT32_MAX.
+        unsigned hw = std::thread::hardware_concurrency();
+        threads = hw > 1 ? hw - 1 : 1;
     }
     default_dispatcher_ = std::make_unique<ThreadPoolDispatcher>(threads);
     dispatcher_ = default_dispatcher_.get();

--- a/src/visus/resource_loader.cpp
+++ b/src/visus/resource_loader.cpp
@@ -1,8 +1,10 @@
 #include "pictor/visus/resource_loader.h"
 
+#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <string>
+#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -24,8 +26,6 @@ std::vector<uint8_t> FileSystemResourceLoader::fetch(const ResourceRef& ref,
         return set_error("FileSystemResourceLoader: local_path is empty");
     }
 
-    // root + path を素直に結合 (絶対パスはそのまま使う想定で、 ここでは
-    // root_ が空または末尾 / の正規化はしない — 呼び出し側の責任)。
     std::string full;
     bool absolute = false;
 #ifdef _WIN32
@@ -35,12 +35,33 @@ std::vector<uint8_t> FileSystemResourceLoader::fetch(const ResourceRef& ref,
 #else
     absolute = !ref.local_path.empty() && ref.local_path[0] == '/';
 #endif
-    if (absolute || root_.empty()) {
+
+    if (root_.empty()) {
+        // No sandbox configured: caller is trusted to supply an absolute or
+        // already-validated path (legacy behaviour, kept intentionally).
         full = ref.local_path;
     } else {
-        full = root_;
-        if (full.back() != '/' && full.back() != '\\') full.push_back('/');
-        full += ref.local_path;
+        // A root_ sandbox is configured, so local_path is attacker-controllable
+        // (visus JSON is supplied via CDN/UGC). Reject absolute paths and
+        // confirm the resolved path stays inside root_ — closes ".." / absolute
+        // traversal that would otherwise read arbitrary files.
+        if (absolute) {
+            return set_error("FileSystemResourceLoader: absolute path rejected");
+        }
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        const fs::path root_canon = fs::weakly_canonical(fs::path(root_), ec);
+        if (ec) return set_error("root canonicalization failed");
+        const fs::path resolved =
+            fs::weakly_canonical(root_canon / fs::path(ref.local_path), ec);
+        if (ec) return set_error("path canonicalization failed");
+
+        // resolved must be root_canon itself or a descendant of it.
+        const auto rel = resolved.lexically_relative(root_canon);
+        if (rel.empty() || *rel.begin() == "..") {
+            return set_error("FileSystemResourceLoader: path escapes root");
+        }
+        full = resolved.string();
     }
 
     std::ifstream f(full, std::ios::binary | std::ios::ate);


### PR DESCRIPTION
## 背景

PR #75 でマージされた **Fable 全量診断** (`review/2026-06-11/`) の指摘に対する一次対応。
Critical 1 + High 12 のうち、**明確に正しく外科的に直せる相関バグ群**を 1 PR に集約して修正した。
レビュー観点は `review/2026-06-11/FABLE_PERSPECTIVE.md` 参照。

## 修正内容 (推奨アクション順)

| # | 重大度 | 指摘 | 修正 | ファイル |
|---|---|---|---|---|
| C-1 | **Critical** | ThreadPoolDispatcher lost wakeup → レンダースレッド永久ハング (毎フレーム) | worker の notify を mutex 下に入れ、述語評価〜wait() 間の通知消失を解消 | `src/update/job_dispatcher.cpp` |
| Q-1 | High | acquire 失敗時の fence デッドロック | fence reset を acquire 成功後 (submit 前) に移動、OUT_OF_DATE 時は signaled のまま残す | `src/surface/vulkan_context.cpp` |
| H-2 | High | FrameAllocator move 代入の解放関数ミスマッチ (ヒープ破壊) | dtor と共有する `release_()` に一本化 | `src/memory/frame_allocator.{h,cpp}` |
| V-1 | High | TrueType glyf の heap OOB read (total_pts 巻き戻り / ends 非単調) | total_pts を 32bit 計算 + ends 単調性検証 + 上限チェック | `src/text/text_rasterizer.cpp` |
| V-2 | High | font テーブル/グリフオフセットの uint32 加算オーバーフロー | 境界チェックを size_t に昇格 | `src/text/{text_rasterizer,font_loader}.cpp` |
| V-3 | High | FileSystemResourceLoader のパストラバーサル | root_ 設定時は `weakly_canonical` で root 配下を検証、絶対パス拒否 | `src/visus/resource_loader.cpp` |
| H-1 | High | BatchBuilder static バッチが 2 フレーム目以降消失 | static バッチを別キャッシュし毎フレームマージ | `src/batch/batch_builder.{h,cpp}` |
| M-7 | Med | dispatch の pending_tasks_ 上書き | `store` → `fetch_add` | `src/update/job_dispatcher.cpp` |
| M-8 | Med | `hardware_concurrency()==0` で uint32 ラップ (4G スレッド生成) | 0 ガード | `src/update/{job_dispatcher,update_scheduler}.cpp` |

## 検証

- `pictor.lib` (Release, `PICTOR_ENABLE_RIVE=OFF`) ビルド成功。エラーなし (警告は全て既存)。
- `ctest` **12/12 pass** — text 系 (`pixel_text_test` = V-1 経路) / `fps_baseline_test` (update/dispatcher 経路) 含む。

## 本 PR では扱わない (別 PR でフォローアップ予定)

規模が大きいため分離:
- **設計系**: D-1 PictorRenderer God Class 分割 / D-2 managed スタブ経路の削除・隔離 (虚偽統計) / D-3 Profiler の per-frame string → enum 化
- **DoS ハードニング** (共通の深度/サイズ/カウント上限で一括対応可能): V-4 zip bomb / V-5,V-7,V-8 無制限再帰 / V-6 過大確保 / V-9 cmap 巨大レンジ / V-10 level-editor DOM XSS
- **GPU 同期**: H-3 instance/staging プールの flight 多重化、Q-2 iOS surface case 欠落、Q-3 frames-in-flight 1 固定
- 各種 Medium (M-2〜M-6, M-9〜M-11) と VkResult 未チェック群 (`VK_CHECK` 導入)

🤖 Generated with [Claude Code](https://claude.com/claude-code)