### PR TITLE
fix(profiler): GpuTimerManager に明示 shutdown() を追加 (teardown クラッシュ修正)

### DIFF
--- a/include/pictor/profiler/gpu_timer.h
+++ b/include/pictor/profiler/gpu_timer.h
@@ -63,6 +63,13 @@ public:
 
     /// 実 Vulkan 計測が有効か。
     bool is_vulkan_ready() const { return vulkan_ready_; }
+
+    /// 実 Vulkan 計測リソース (query pool) を明示的に解放する。 冪等。
+    ///
+    /// owner は **VkDevice を破棄する前** に必ず呼ぶこと。 デストラクタ任せに
+    /// すると、 owner の破棄順次第で device 破棄後に destroy_pools_ が走り、
+    /// `vkDestroyQueryPool: Invalid device` で異常終了する。
+    void shutdown();
 #endif
 
     /// Begin a new frame's timing

--- a/src/profiler/gpu_timer.cpp
+++ b/src/profiler/gpu_timer.cpp
@@ -76,6 +76,11 @@ bool GpuTimerManager::initialize_vulkan(VulkanContext& vk) {
     return true;
 }
 
+void GpuTimerManager::shutdown() {
+    // device 破棄前に owner が明示的に呼ぶ解放経路 (デストラクタと同処理、冪等)。
+    destroy_pools_();
+}
+
 void GpuTimerManager::destroy_pools_() {
     if (device_ != VK_NULL_HANDLE) {
         for (VkQueryPool p : query_pools_) {


### PR DESCRIPTION
## 問題
`GpuTimerManager` の `VkQueryPool` はデストラクタ (`~GpuTimerManager` → `destroy_pools_`) でのみ解放していた。 そのため owner (consumer) の破棄順次第で **VkDevice 破棄後** に `destroy_pools_` が走り、 Vulkan ローダーが `vkDestroyQueryPool: Invalid device` を出してプロセスが異常終了する (KuzuSurvivors の autoplay 実機テストで exit code が 0xC0000005 等に化けていた)。

## 修正
device 破棄前に owner が明示的に呼べる public な `void GpuTimerManager::shutdown()` (= `destroy_pools_`、 冪等) を追加。 `initialize_vulkan()` と対称な API。 consumer は **VkDevice 破棄前** にこれを呼ぶ。

- `include/pictor/profiler/gpu_timer.h`: public `shutdown()` 宣言 (PICTOR_HAS_VULKAN ガード内)
- `src/profiler/gpu_timer.cpp`: 定義 (`destroy_pools_()` を呼ぶだけ)

## 検証
consumer (KuzuSurvivors) で `GameRenderer::shutdown()` から本メソッドを device 破棄前に呼ぶ変更と合わせ、 autoplay 実機実行が **exit 0 / RESULT PASS / teardown エラーなし** になることを確認 (別 PR: KuzuSurvivors 側)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)