### PR TITLE
fix(pictor): Fable 診断 DoS ハードニング (V-4〜V-10 + level-editor)

### DIFF
--- a/include/pictor/animation/bvh_importer.h
+++ b/include/pictor/animation/bvh_importer.h
@@ -59,7 +59,7 @@ private:
     /// Parse a single joint/end-site block
     bool parse_joint(const char*& cursor, const char* end,
                      std::vector<JointInfo>& joints,
-                     int32_t parent_index) const;
+                     int32_t parent_index, int depth = 0) const;
 
     /// Parse MOTION section
     bool parse_motion(const char*& cursor, const char* end,

--- a/include/pictor/core/parse_limits.h
+++ b/include/pictor/core/parse_limits.h
@@ -1,0 +1,30 @@
+﻿#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// ============================================================
+// パーサ DoS ハードニング上限
+//
+// 信頼できない入力 (FBX / BVH / 手書き JSON / フォント等) を処理する
+// 全パーサが共有する「絶対上限」。 ファイル由来のカウント / 深さ /
+// 出力量を無条件に信用しないための一括の防御パラメータ。
+//
+// 参照: review/2026-06-11/REVIEW_VULNERABILITY.md (V-4〜V-9)
+// ============================================================
+
+namespace pictor::parse_limits {
+
+// 再帰下降パーサのネスト深度上限。 これを超えたらスタックオーバーフロー前に
+// 失敗させる (FBX ノード木 / 手書き JSON の skip_value 相互再帰など)。
+inline constexpr int kMaxNestingDepth = 256;
+
+// 自前 inflate / 圧縮配列の展開が生成してよい出力バイト数の絶対上限 (256 MiB)。
+// zip bomb (小さな入力 → 巨大出力) によるメモリ枯渇を抑止する。
+inline constexpr std::size_t kMaxInflateBytes = std::size_t{256} << 20;
+
+// cmap など「コードポイント範囲 → グリフ」展開の総挿入数上限 (全 Unicode 範囲)。
+// 巨大レンジ (最大 ~40 億) の全展開による CPU / メモリ枯渇を抑止する。
+inline constexpr std::uint32_t kMaxCodepointExpansion = 0x110000u;
+
+} // namespace pictor::parse_limits

--- a/src/animation/bvh_importer.cpp
+++ b/src/animation/bvh_importer.cpp
@@ -1,4 +1,5 @@
 ﻿#include "pictor/animation/bvh_importer.h"
+#include "pictor/core/parse_limits.h"
 #include <fstream>
 #include <sstream>
 #include <cstring>
@@ -106,7 +107,8 @@ bool BVHImporter::parse_hierarchy(const char*& cursor, const char* end,
 
 bool BVHImporter::parse_joint(const char*& cursor, const char* end,
                                std::vector<JointInfo>& joints,
-                               int32_t parent_index) const {
+                               int32_t parent_index, int depth) const {
+    if (depth > parse_limits::kMaxNestingDepth) return false; // 無制限再帰ガード
     JointInfo joint;
     joint.name = read_token(cursor, end);
     joint.parent_index = parent_index;
@@ -143,11 +145,14 @@ bool BVHImporter::parse_joint(const char*& cursor, const char* end,
             }
         } else if (token == "CHANNELS") {
             int num_channels = read_int(cursor, end);
+            // 各チャンネル名トークンは最低 1 バイトを要するため、残りバイト数を
+            // 超える数 (および負値) は不正。 過大確保 / 空読みループを防ぐ。
+            if (num_channels < 0 || num_channels > static_cast<int>(end - cursor)) return false;
             for (int i = 0; i < num_channels; ++i) {
                 joints[current_index].channel_order.push_back(read_token(cursor, end));
             }
         } else if (token == "JOINT") {
-            if (!parse_joint(cursor, end, joints, current_index)) return false;
+            if (!parse_joint(cursor, end, joints, current_index, depth + 1)) return false;
         } else if (token == "End") {
             // End Site
             token = read_token(cursor, end); // "Site"
@@ -188,7 +193,10 @@ bool BVHImporter::parse_motion(const char*& cursor, const char* end,
     // "Frames:" line
     std::string token = read_token(cursor, end);
     if (token != "Frames:") return false;
-    frame_count = static_cast<uint32_t>(read_int(cursor, end));
+    // `Frames: -1` の uint32 巻き戻りによる過大確保を防ぐ (負値拒否)。
+    int raw_frame_count = read_int(cursor, end);
+    if (raw_frame_count < 0) return false;
+    frame_count = static_cast<uint32_t>(raw_frame_count);
 
     // "Frame Time:" line
     token = read_token(cursor, end);
@@ -201,6 +209,12 @@ bool BVHImporter::parse_motion(const char*& cursor, const char* end,
     for (const auto& j : joints) {
         total_channels += static_cast<uint32_t>(j.channel_order.size());
     }
+
+    // 過大確保 / CPU DoS 抑止: frame_count・(frame×channel) の総 float 数は、
+    // 各値が最低 1 バイトのトークンなので残りバイト数を超えない。
+    const uint64_t remaining = static_cast<uint64_t>(end - cursor);
+    if (frame_count > remaining) return false;
+    if (static_cast<uint64_t>(frame_count) * total_channels > remaining) return false;
 
     // Read frame data
     frame_data.resize(frame_count);

--- a/src/animation/fbx_document.cpp
+++ b/src/animation/fbx_document.cpp
@@ -12,6 +12,8 @@
 
 #include "pictor/animation/fbx_document.h"
 
+#include "pictor/core/parse_limits.h"
+
 #include <algorithm>
 #include <array>
 #include <cctype>
@@ -199,8 +201,11 @@ static void build_fixed_tables(HuffTable& lit, HuffTable& dist) {
 }
 
 static bool inflate_block_data(BitReader& br, const HuffTable& lit, const HuffTable& dist,
-                               std::vector<uint8_t>& out, std::string* error) {
+                               std::vector<uint8_t>& out, size_t max_out, std::string* error) {
     while (true) {
+        // 出力上限ガード (zip bomb / DoS): 1 シンボルあたり最大 258 バイトなので
+        // ループ先頭で一度確認すれば overshoot は high bound に収まる。
+        if (out.size() > max_out) return set_err(error,"deflate: output exceeds limit");
         int sym = lit.decode(br);
         if (sym < 0) return set_err(error,"deflate: bad literal/length symbol");
         if (sym < 256) {
@@ -276,9 +281,10 @@ static bool decode_dynamic_tables(BitReader& br, HuffTable& lit, HuffTable& dist
 
 static bool inflate_stream(const uint8_t* in, size_t in_size,
                            std::vector<uint8_t>& out, size_t expected_out_size,
-                           std::string* error) {
+                           size_t max_out, std::string* error) {
     BitReader br(in, in_size);
-    if (expected_out_size > 0) out.reserve(expected_out_size);
+    // reserve は上限でクランプ (期待値が攻撃由来で巨大でも過大確保しない)。
+    if (expected_out_size > 0) out.reserve(std::min(expected_out_size, max_out));
 
     bool last = false;
     while (!last) {
@@ -297,16 +303,17 @@ static bool inflate_stream(const uint8_t* in, size_t in_size,
                 return set_err(error,"deflate: stored len/nlen mismatch");
             }
             if (br.byte_pos + len > br.size) return set_err(error,"deflate: stored body EOF");
+            if (out.size() + len > max_out) return set_err(error,"deflate: output exceeds limit");
             out.insert(out.end(), in + br.byte_pos, in + br.byte_pos + len);
             br.byte_pos += len;
         } else if (btype == 1) {
             HuffTable lit, dist;
             build_fixed_tables(lit, dist);
-            if (!inflate_block_data(br, lit, dist, out, error)) return false;
+            if (!inflate_block_data(br, lit, dist, out, max_out, error)) return false;
         } else if (btype == 2) {
             HuffTable lit, dist;
             if (!decode_dynamic_tables(br, lit, dist, error)) return false;
-            if (!inflate_block_data(br, lit, dist, out, error)) return false;
+            if (!inflate_block_data(br, lit, dist, out, max_out, error)) return false;
         } else {
             return set_err(error,"deflate: reserved BTYPE 11");
         }
@@ -333,7 +340,12 @@ bool fbx_zlib_decompress(const uint8_t* in, size_t in_size,
     if (flg & 0x20) return set_err(error,"zlib: preset dictionary not supported");
     // payload は header の 2 バイト後から、末尾 4 バイトの ADLER32 まで
     // (ADLER32 検証は省略 — FBX では破損検知は file-level で行うため)
-    return inflate_stream(in + 2, in_size - 2 - 4, out, expected_out_size, error);
+    // 出力上限: 期待値が分かっていればそれ、無ければ絶対上限。 いずれも
+    // parse_limits::kMaxInflateBytes を超えない (zip bomb 抑止)。
+    const size_t max_out = std::min(
+        expected_out_size ? expected_out_size : parse_limits::kMaxInflateBytes,
+        parse_limits::kMaxInflateBytes);
+    return inflate_stream(in + 2, in_size - 2 - 4, out, expected_out_size, max_out, error);
 }
 
 // ── FBXProperty アクセサ ──────────────────────────────────────
@@ -600,6 +612,11 @@ bool read_property(BinReader& br, FBXProperty& p, std::string* error) {
                 default: break;
             }
             size_t expected = static_cast<size_t>(length) * elem_size;
+            // 過大確保 / zip bomb 抑止: ファイル由来の length をそのまま信用せず
+            // 絶対上限で弾く (raw/zlib いずれの経路でも resize/reserve 前に検査)。
+            if (expected > parse_limits::kMaxInflateBytes) {
+                return set_err(error,"binary: ARR length exceeds limit");
+            }
 
             std::vector<uint8_t> raw_storage;
             const uint8_t* raw = nullptr;
@@ -655,7 +672,10 @@ bool read_property(BinReader& br, FBXProperty& p, std::string* error) {
     }
 }
 
-bool read_node(BinReader& br, FBXNode& out, uint32_t version, std::string* error) {
+bool read_node(BinReader& br, FBXNode& out, uint32_t version, int depth, std::string* error) {
+    if (depth > parse_limits::kMaxNestingDepth) {
+        return set_err(error,"binary: node nesting too deep");
+    }
     bool is_v75 = version >= 7500;
     uint64_t end_offset = 0, num_props = 0, prop_list_len = 0;
     if (is_v75) {
@@ -681,6 +701,11 @@ bool read_node(BinReader& br, FBXNode& out, uint32_t version, std::string* error
     out.name.assign(reinterpret_cast<const char*>(br.data + br.pos), name_len);
     br.pos += name_len;
 
+    // 過大確保 / bad_alloc 抑止: 各プロパティは最低 1 バイト (型コード) を要するため、
+    // 残りバイト数を超える num_props は不正。 実体読み出し前に弾く。
+    if (num_props > static_cast<uint64_t>(br.size - br.pos)) {
+        return set_err(error,"binary: num_props exceeds input");
+    }
     out.properties.resize(num_props);
     for (uint64_t i = 0; i < num_props; ++i) {
         if (!read_property(br, out.properties[i], error)) return false;
@@ -689,7 +714,7 @@ bool read_node(BinReader& br, FBXNode& out, uint32_t version, std::string* error
     // 子ノードがある場合、ここまでの位置 != end_offset
     while (br.pos < end_offset) {
         FBXNode child;
-        if (!read_node(br, child, version, error)) return false;
+        if (!read_node(br, child, version, depth + 1, error)) return false;
         if (child.empty()) break;       // sentinel に到達
         out.children.push_back(std::move(child));
     }
@@ -725,7 +750,7 @@ bool FBXDocument::parse_binary(const uint8_t* data, size_t size, std::string* er
 
     while (br.pos < size) {
         FBXNode child;
-        if (!read_node(br, child, version, error)) return false;
+        if (!read_node(br, child, version, 0, error)) return false;
         if (child.empty()) break;
         root.children.push_back(std::move(child));
     }
@@ -904,7 +929,10 @@ bool parse_property_value(AsciiReader& r, FBXProperty& p, std::string* error) {
     return set_err(error,std::string("ascii: unexpected char '") + c + "' at line " + std::to_string(r.line));
 }
 
-bool parse_node_ascii(AsciiReader& r, FBXNode& out, std::string* error) {
+bool parse_node_ascii(AsciiReader& r, FBXNode& out, int depth, std::string* error) {
+    if (depth > parse_limits::kMaxNestingDepth) {
+        return set_err(error,"ascii: node nesting too deep");
+    }
     r.skip_ws();
     if (r.eof()) { out = FBXNode{}; return true; }
     if (!r.read_identifier(out.name)) {
@@ -942,7 +970,7 @@ bool parse_node_ascii(AsciiReader& r, FBXNode& out, std::string* error) {
             if (r.peek() == '}') { r.get(); break; }
             if (r.eof()) return set_err(error,"ascii: unterminated block");
             FBXNode child;
-            if (!parse_node_ascii(r, child, error)) return false;
+            if (!parse_node_ascii(r, child, depth + 1, error)) return false;
             if (child.name.empty() && child.properties.empty() && child.children.empty()) continue;
             out.children.push_back(std::move(child));
         }
@@ -962,7 +990,7 @@ bool FBXDocument::parse_ascii(const uint8_t* data, size_t size, std::string* err
         r.skip_ws();
         if (r.eof()) break;
         FBXNode node;
-        if (!parse_node_ascii(r, node, error)) return false;
+        if (!parse_node_ascii(r, node, 0, error)) return false;
         if (node.name == "FBXVersion" && !node.properties.empty()) {
             version = static_cast<uint32_t>(node.properties[0].as_int());
         }

--- a/src/material/material_serializer.cpp
+++ b/src/material/material_serializer.cpp
@@ -1,5 +1,7 @@
 #include "pictor/material/material_serializer.h"
 
+#include "pictor/core/parse_limits.h"
+
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
@@ -75,6 +77,7 @@ struct Parser {
     const char* p;
     const char* end;
     std::string err;
+    int nest_depth = 0;   // skip_value 相互再帰の深度 (DoS ガード)
 
     bool fail(const char* what) {
         if (err.empty()) err = what;
@@ -167,8 +170,15 @@ struct Parser {
         if (p >= end) return fail("unexpected end");
         switch (*p) {
             case '"': { std::string tmp; return parse_string(tmp); }
-            case '{': return skip_object();
-            case '[': return skip_array();
+            case '{':
+            case '[': {
+                // ネスト深度上限 (`[[[[...` スタックオーバーフロー DoS ガード)。
+                if (++nest_depth > parse_limits::kMaxNestingDepth)
+                    return fail("json nesting too deep");
+                bool ok = (*p == '{') ? skip_object() : skip_array();
+                --nest_depth;
+                return ok;
+            }
             case 't': case 'f': { bool tmp; return parse_bool(tmp); }
             case 'n':
                 if (p + 4 <= end && std::memcmp(p, "null", 4) == 0) { p += 4; return true; }

--- a/src/pipeline/pipeline_profile_serializer.cpp
+++ b/src/pipeline/pipeline_profile_serializer.cpp
@@ -1,5 +1,7 @@
 #include "pictor/pipeline/pipeline_profile_serializer.h"
 
+#include "pictor/core/parse_limits.h"
+
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
@@ -296,6 +298,7 @@ struct Parser {
     const char* p;
     const char* end;
     std::string err;
+    int nest_depth = 0;   // skip_value 相互再帰の深度 (DoS ガード)
 
     bool fail(const char* what) {
         if (err.empty()) err = what;
@@ -385,8 +388,15 @@ struct Parser {
         if (p >= end) return fail("unexpected end");
         switch (*p) {
             case '"': { std::string tmp; return parse_string(tmp); }
-            case '{': return skip_object();
-            case '[': return skip_array();
+            case '{':
+            case '[': {
+                // ネスト深度上限 (`[[[[...` スタックオーバーフロー DoS ガード)。
+                if (++nest_depth > parse_limits::kMaxNestingDepth)
+                    return fail("json nesting too deep");
+                bool ok = (*p == '{') ? skip_object() : skip_array();
+                --nest_depth;
+                return ok;
+            }
             case 't': case 'f': { bool tmp; return parse_bool(tmp); }
             case 'n':
                 if (p + 4 <= end && std::memcmp(p, "null", 4) == 0) { p += 4; return true; }

--- a/src/text/font_loader.cpp
+++ b/src/text/font_loader.cpp
@@ -1,4 +1,5 @@
 ﻿#include "pictor/text/font_loader.h"
+#include "pictor/core/parse_limits.h"
 #include <fstream>
 #include <cstring>
 #include <algorithm>
@@ -462,6 +463,10 @@ bool FontLoader::parse_font_tables(FontTableEntry& entry) {
         if (best_offset > 0 && best_offset < cmap_len) {
             uint16_t format = read_u16(cmap_data + best_offset);
 
+            // cmap 展開の総量予算 (DoS: 巨大レンジ / 多数セグメントの全展開を防ぐ)。
+            // format 4 / 12 共通でこの予算を消費し、 尽きたら以降の展開を打ち切る。
+            uint32_t cmap_budget = parse_limits::kMaxCodepointExpansion;
+
             if (format == 4) {
                 // Format 4: Segment mapping to delta values
                 if (best_offset + 14 <= cmap_len) {
@@ -470,6 +475,7 @@ bool FontLoader::parse_font_tables(FontTableEntry& entry) {
                     uint32_t base = best_offset + 14;
 
                     for (uint16_t seg = 0; seg < seg_count; ++seg) {
+                        if (cmap_budget == 0) break;
                         uint32_t end_off   = base + seg * 2;
                         uint32_t start_off = base + (seg_count + 1) * 2 + seg * 2;
                         uint32_t delta_off = base + (seg_count + 1) * 2 + seg_count * 2 + seg * 2;
@@ -485,6 +491,8 @@ bool FontLoader::parse_font_tables(FontTableEntry& entry) {
                         if (start_code == 0xFFFF) break;
 
                         for (uint32_t c = start_code; c <= end_code; ++c) {
+                            if (cmap_budget == 0) break;
+                            --cmap_budget;
                             uint16_t glyph_index;
                             if (id_range == 0) {
                                 glyph_index = static_cast<uint16_t>(
@@ -510,15 +518,22 @@ bool FontLoader::parse_font_tables(FontTableEntry& entry) {
                 if (best_offset + 16 <= cmap_len) {
                     uint32_t num_groups = read_u32(cmap_data + best_offset + 12);
                     for (uint32_t g = 0; g < num_groups; ++g) {
+                        if (cmap_budget == 0) break;
                         uint32_t grp_off = best_offset + 16 + g * 12;
                         if (grp_off + 12 > cmap_len) break;
                         uint32_t start_code  = read_u32(cmap_data + grp_off);
                         uint32_t end_code    = read_u32(cmap_data + grp_off + 4);
                         uint32_t start_glyph = read_u32(cmap_data + grp_off + 8);
-                        for (uint32_t c = start_code; c <= end_code; ++c) {
-                            uint16_t gi = static_cast<uint16_t>(start_glyph + (c - start_code));
+                        if (end_code < start_code) continue;
+                        // 巨大レンジ (最大 ~40 億) の全展開を予算で打ち切る (DoS ガード)。
+                        uint64_t range = static_cast<uint64_t>(end_code) - start_code + 1;
+                        uint32_t take  = static_cast<uint32_t>(std::min<uint64_t>(range, cmap_budget));
+                        for (uint32_t i = 0; i < take; ++i) {
+                            uint32_t c = start_code + i;
+                            uint16_t gi = static_cast<uint16_t>(start_glyph + i);
                             if (gi != 0) parsed.cmap[c] = gi;
                         }
+                        cmap_budget -= take;
                     }
                 }
             }

--- a/src/visus/visus_serializer.cpp
+++ b/src/visus/visus_serializer.cpp
@@ -1,5 +1,7 @@
 #include "pictor/visus/visus_serializer.h"
 
+#include "pictor/core/parse_limits.h"
+
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
@@ -274,6 +276,7 @@ struct Parser {
     const char* p;
     const char* end;
     std::string err;
+    int nest_depth = 0;   // skip_value 相互再帰の深度 (DoS ガード)
 
     bool fail(const char* what) {
         if (err.empty()) err = what;
@@ -363,8 +366,15 @@ struct Parser {
         if (p >= end) return fail("unexpected end");
         switch (*p) {
             case '"': { std::string tmp; return parse_string(tmp); }
-            case '{': return skip_object();
-            case '[': return skip_array();
+            case '{':
+            case '[': {
+                // ネスト深度上限 (`[[[[...` スタックオーバーフロー DoS ガード)。
+                if (++nest_depth > parse_limits::kMaxNestingDepth)
+                    return fail("json nesting too deep");
+                bool ok = (*p == '{') ? skip_object() : skip_array();
+                --nest_depth;
+                return ok;
+            }
             case 't': case 'f': { bool tmp; return parse_bool(tmp); }
             case 'n':
                 if (p + 4 <= end && std::memcmp(p, "null", 4) == 0) { p += 4; return true; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PICTOR_TESTS
     unit_postprocess_chain_test
     unit_attachment_def_test
     unit_pipeline_registries_test
+    unit_parser_dos_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_parser_dos_test.cpp
+++ b/tests/unit_parser_dos_test.cpp
@@ -1,0 +1,66 @@
+﻿/// パーサ DoS ハードニング回帰テスト (review/2026-06-11 V-5 / V-8)。
+///
+/// 深くネストした入力を与えても「スタックオーバーフローでクラッシュせず、
+/// false を返して安全に失敗する」ことを確認する。 上限は
+/// pictor::parse_limits::kMaxNestingDepth。
+
+#include "pictor/core/parse_limits.h"
+#include "pictor/visus/visus_serializer.h"
+#include "pictor/animation/fbx_document.h"
+#include "test_common.h"
+
+#include <string>
+
+using namespace pictor;
+using namespace pictor_test;
+
+namespace {
+
+// 深度上限を十分に超える nest を作る。
+constexpr int kDeep = parse_limits::kMaxNestingDepth * 8;
+
+// V-8: 手書き JSON パーサの skip_value 相互再帰。
+// 未知キーの値として `[[[[...]]]]` を与えると skip_value 経路に入る。
+void test_json_skip_value_deep_nesting() {
+    std::string json = "{\"_dos\":";
+    json.append(kDeep, '[');
+    json.append(kDeep, ']');
+    json += "}";
+
+    VisusDesc out;
+    std::string err;
+    // クラッシュしないこと自体が検証対象。 深すぎる入力は失敗扱い。
+    bool ok = from_visus_json(json, out, &err);
+    PT_ASSERT(!ok, "deeply-nested unknown value must fail, not crash");
+}
+
+// 正常系: 浅いネストはこれまで通り成功する (上限導入で回帰させない)。
+void test_json_shallow_ok() {
+    VisusDesc out;
+    std::string err;
+    bool ok = from_visus_json("{\"name\":\"x\",\"_extra\":[[1,2],[3,4]]}", out, &err);
+    PT_ASSERT(ok, "shallow nesting must still parse");
+}
+
+// V-5: FBX ASCII パーサ parse_node_ascii の無制限再帰。
+void test_fbx_ascii_deep_nesting() {
+    // `A: { A: { ... } }` を深くネスト。
+    std::string fbx;
+    for (int i = 0; i < kDeep; ++i) fbx += "A: {\n";
+    for (int i = 0; i < kDeep; ++i) fbx += "}\n";
+
+    FBXDocument doc;
+    std::string err;
+    bool ok = doc.parse_ascii(reinterpret_cast<const uint8_t*>(fbx.data()),
+                              fbx.size(), &err);
+    PT_ASSERT(!ok, "deeply-nested FBX ASCII must fail, not crash");
+}
+
+} // namespace
+
+int main() {
+    test_json_skip_value_deep_nesting();
+    test_json_shallow_ok();
+    test_fbx_ascii_deep_nesting();
+    return report("unit_parser_dos_test");
+}

--- a/tools/level-editor/app.js
+++ b/tools/level-editor/app.js
@@ -2,6 +2,12 @@ import { WebGLModelViewer, defaultAssetCatalog } from "./webgl_model_viewer.js";
 
 const $ = (id) => document.getElementById(id);
 
+// インポートした .pictor-level.json 由来の文字列を innerHTML に埋め込む際の
+// HTML エスケープ (DOM XSS ガード: `<img src=x onerror=...>` 等の任意 JS 実行を防ぐ)。
+const escapeHtml = (s) =>
+  String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
 const defaultTransform = () => ({
   position: [0, 0, 0],
   rotation: [0, 0, 0],
@@ -58,7 +64,7 @@ function renderHierarchy() {
       row.className = `treeNode${node.id === state.selectedId ? " selected" : ""}`;
       row.style.setProperty("--indent", `${depth * 14}px`);
       row.role = "treeitem";
-      row.innerHTML = `<span class="nodeIcon">${node.kind === "group" ? "◆" : "●"}</span><span class="nodeName"><span class="treeIndent"></span>${node.name}</span>`;
+      row.innerHTML = `<span class="nodeIcon">${node.kind === "group" ? "◆" : "●"}</span><span class="nodeName"><span class="treeIndent"></span>${escapeHtml(node.name)}</span>`;
       row.addEventListener("click", () => {
         state.selectedId = node.id;
         renderAll();
@@ -80,8 +86,8 @@ function renderAssets() {
     item.innerHTML = `
       <div class="swatch" style="background: rgba(${asset.color.slice(0, 3).map((v) => Math.round(v * 255)).join(",")},1)"></div>
       <div>
-        <div class="assetName">${asset.name}</div>
-        <div class="assetMeta">${asset.previewMesh} · ${asset.model}</div>
+        <div class="assetName">${escapeHtml(asset.name)}</div>
+        <div class="assetMeta">${escapeHtml(asset.previewMesh)} · ${escapeHtml(asset.model)}</div>
       </div>`;
     item.addEventListener("click", () => addAssetNode(asset));
     list.appendChild(item);

--- a/tools/level-editor/serve.mjs
+++ b/tools/level-editor/serve.mjs
@@ -1,9 +1,10 @@
 import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
-import { dirname, extname, join, normalize } from "node:path";
+import { dirname, extname, join, normalize, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(import.meta.url));
+const rootPrefix = normalize(root) + sep;
 const port = Number(process.env.PORT || 8781);
 const types = {
   ".html": "text/html; charset=utf-8",
@@ -16,7 +17,9 @@ createServer(async (req, res) => {
   const url = new URL(req.url || "/", `http://localhost:${port}`);
   const pathname = url.pathname === "/" ? "/index.html" : url.pathname;
   const file = normalize(join(root, pathname));
-  if (!file.startsWith(normalize(root))) {
+  // パストラバーサル防御: 末尾セパレータ付き接頭辞で照合し、root を接頭辞に持つ
+  // 兄弟ディレクトリ (例: <root>-secret) を弾く。 root 直下のファイルも許可。
+  if (file !== normalize(root) && !file.startsWith(rootPrefix)) {
     res.writeHead(403);
     res.end("Forbidden");
     return;
@@ -29,6 +32,7 @@ createServer(async (req, res) => {
     res.writeHead(404);
     res.end("Not found");
   }
-}).listen(port, () => {
+}).listen(port, "127.0.0.1", () => {
+  // ローカル開発ツールを LAN に晒さないよう loopback のみに bind。
   console.log(`Pictor Level Editor: http://localhost:${port}/`);
 });


### PR DESCRIPTION
## 背景

PR #76 (Fable 全量診断の Critical/High 修正) で「別 PR フォローアップ」として分離した **DoS / XSS 系**を 1 PR に集約。
レビュー原典: `review/2026-06-11/REVIEW_VULNERABILITY.md` (V-4〜V-10) + `FABLE_PERSPECTIVE.md`。

共通方針 ―― **「ファイル由来のカウント / 深さ / 出力量を無条件に信用しない」** ―― を
新ヘッダ `include/pictor/core/parse_limits.h` の絶対上限に集約し、各パーサへ一括適用した。

| # | 重大度 | 指摘 | 修正 | ファイル |
|---|---|---|---|---|
| V-4 | Med | 自前 inflate に出力上限なし (zip bomb) | inflate に絶対出力上限 (256 MiB)、配列 `length` を上限検証 | `src/animation/fbx_document.cpp` |
| V-5 | Med | バイナリ/ASCII FBX パーサの無制限再帰 | ノード再帰に深度上限 (`kMaxNestingDepth=256`) | `src/animation/fbx_document.cpp` |
| V-6 | Med | FBX `num_props` 過大確保 (bad_alloc) | 残バイト数で検証してから resize | `src/animation/fbx_document.cpp` |
| V-7 | Med | BVH の未検証カウント / 無制限再帰 | `Frames`/`CHANNELS` 負値・過大拒否 + `parse_joint` 深度上限 | `src/animation/bvh_importer.{h,cpp}` |
| V-8 | Med | 手書き JSON パーサ 3 系統の無制限再帰 | `skip_value` に共通の深度上限 (3 ファイル同型パッチ) | `src/{visus,material,pipeline}/*_serializer.cpp` |
| V-9 | Med | cmap format 12 の巨大レンジ DoS | format 4/12 の展開を総量予算 (全 Unicode 範囲) で打ち切り | `src/text/font_loader.cpp` |
| V-10 | Med | level-editor のインポート JSON 由来 DOM XSS | `node.name`/`asset.*` を HTML エスケープ | `tools/level-editor/app.js` |
| Low | Low | serve.mjs の traversal 接頭辞 / 全 IF bind | 末尾 `sep` 付き接頭辞照合 + `127.0.0.1` bind | `tools/level-editor/serve.mjs` |

## 設計

- 上限定数 (`kMaxNestingDepth` / `kMaxInflateBytes` / `kMaxCodepointExpansion`) を 1 ヘッダに集約し、FBX / BVH / 3 JSON / フォントが共有。「同型の問題はパターンで束ねる」(FABLE_PERSPECTIVE §修正側の渡し方) に沿う。
- いずれも **失敗は false 返却** (FBX ヘッダの「例外を投げない」契約を維持)。

## 検証

- `pictor.lib` (Release, `PICTOR_ENABLE_RIVE=OFF`) ビルド成功 (新規警告なし)。
- `ctest` **13/13 pass**。新規 `unit_parser_dos_test` で V-5 (FBX ASCII) / V-8 (JSON skip_value) の深ネスト入力が**クラッシュせず false で安全に失敗**することを回帰確認。

## 本 PR では扱わない (PR #76 の残フォローアップ)

設計系 (D-1〜D-3) / GPU 同期 (H-3, Q-2, Q-3, VK_CHECK) は別 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)