### PR TITLE
fix(pictor): Fable 診断 GPU 同期 (H-3 flight多重化 / Q-2 iOS surface / VK_CHECK)

### DIFF
--- a/include/pictor/memory/gpu_memory_allocator.h
+++ b/include/pictor/memory/gpu_memory_allocator.h
@@ -22,9 +22,14 @@ public:
     struct Config {
         size_t mesh_pool_size       = 256 * 1024 * 1024; // 256MB
         size_t ssbo_pool_size       = 128 * 1024 * 1024; // 128MB
-        size_t instance_buffer_size = 64  * 1024 * 1024; // 64MB
+        size_t instance_buffer_size = 64  * 1024 * 1024; // 64MB (per flight)
         size_t indirect_buffer_size = 16  * 1024 * 1024; // 16MB
-        size_t staging_buffer_size  = 64  * 1024 * 1024; // 64MB
+        size_t staging_buffer_size  = 64  * 1024 * 1024; // 64MB (per flight)
+        // ring プール (instance / staging) を多重化するフライト数。 各フライトは
+        // 上記サイズを丸ごと専有する (合計確保 = size × flight_count)。
+        // GPU が前フレームのコマンドバッファ経由で参照中の領域を begin_frame で
+        // 上書きしないための保護 (review/2026-06-11 H-3)。
+        uint32_t flight_count       = 3;
     };
 
     GpuMemoryAllocator();
@@ -78,10 +83,19 @@ private:
             size_t offset;
             size_t size;
         };
-        std::vector<FreeBlock> free_list;
+        std::vector<FreeBlock> free_list;   // 非 ring プール (mesh / ssbo) のみ使用。
+
+        // ring プール (instance / staging) 用。 capacity を flight_count 等分し、
+        // 各フライトの区画内を bump 確保する。 begin_frame では current_flight の
+        // 区画のみリセットし、 他フライトが GPU 参照中の領域は温存する (H-3)。
+        uint32_t flight_count   = 1;
+        uint32_t current_flight = 0;
+        size_t   region_size    = 0;   // = capacity / flight_count
+        size_t   head           = 0;   // 現フライト区画内の bump 位置 (絶対 offset)
     };
 
     GpuAllocation allocate_from_pool(Pool& pool, size_t size, size_t alignment);
+    GpuAllocation allocate_ring(Pool& pool, size_t size, size_t alignment);
 
     Pool mesh_pool_;
     Pool ssbo_pool_;

--- a/include/pictor/surface/vk_result.h
+++ b/include/pictor/surface/vk_result.h
@@ -1,0 +1,54 @@
+﻿#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include <cstdio>
+
+// ============================================================
+// VK_CHECK — VkResult 一括チェックヘルパー
+//
+// 戻り値を捨てていた Vulkan 呼び出し (acquire / present / fence / surface
+// query 等) を一律に検査するためのユーティリティ (review/2026-06-11 Q-M3/M5/M6)。
+//
+//   VkResult r = VK_CHECK(vkSomeCall(...));   // 失敗時に call site + code を stderr へ
+//   if (r != VK_SUCCESS) { ... }              // 分岐は呼び出し側の責務
+//
+// マクロは VkResult をそのまま評価値として返すので、 既存の戻り値分岐を壊さずに
+// 「失敗時のログ出力」だけを差し込める。
+// ============================================================
+
+namespace pictor {
+
+/// 代表的な VkResult を文字列化する (ログ用途、 網羅でなくてよい)。
+inline const char* vk_result_string(VkResult r) {
+    switch (r) {
+        case VK_SUCCESS:                        return "VK_SUCCESS";
+        case VK_NOT_READY:                      return "VK_NOT_READY";
+        case VK_TIMEOUT:                        return "VK_TIMEOUT";
+        case VK_SUBOPTIMAL_KHR:                 return "VK_SUBOPTIMAL_KHR";
+        case VK_ERROR_OUT_OF_HOST_MEMORY:       return "VK_ERROR_OUT_OF_HOST_MEMORY";
+        case VK_ERROR_OUT_OF_DEVICE_MEMORY:     return "VK_ERROR_OUT_OF_DEVICE_MEMORY";
+        case VK_ERROR_INITIALIZATION_FAILED:    return "VK_ERROR_INITIALIZATION_FAILED";
+        case VK_ERROR_DEVICE_LOST:              return "VK_ERROR_DEVICE_LOST";
+        case VK_ERROR_SURFACE_LOST_KHR:         return "VK_ERROR_SURFACE_LOST_KHR";
+        case VK_ERROR_OUT_OF_DATE_KHR:          return "VK_ERROR_OUT_OF_DATE_KHR";
+        case VK_ERROR_NATIVE_WINDOW_IN_USE_KHR: return "VK_ERROR_NATIVE_WINDOW_IN_USE_KHR";
+        case VK_ERROR_EXTENSION_NOT_PRESENT:    return "VK_ERROR_EXTENSION_NOT_PRESENT";
+        case VK_ERROR_FEATURE_NOT_PRESENT:      return "VK_ERROR_FEATURE_NOT_PRESENT";
+        case VK_ERROR_MEMORY_MAP_FAILED:        return "VK_ERROR_MEMORY_MAP_FAILED";
+        default:                                return "VK_ERROR_<other>";
+    }
+}
+
+/// 失敗時にのみ stderr へ call site + result code を出し、 result をそのまま返す。
+inline VkResult vk_check_impl(VkResult r, const char* expr, const char* file, int line) {
+    if (r != VK_SUCCESS && r != VK_SUBOPTIMAL_KHR) {
+        std::fprintf(stderr, "[Pictor][VK] %s:%d  %s -> %s\n",
+                     file, line, expr, vk_result_string(r));
+    }
+    return r;
+}
+
+} // namespace pictor
+
+#define VK_CHECK(expr) ::pictor::vk_check_impl((expr), #expr, __FILE__, __LINE__)

--- a/src/memory/gpu_memory_allocator.cpp
+++ b/src/memory/gpu_memory_allocator.cpp
@@ -6,19 +6,34 @@ namespace pictor {
 GpuMemoryAllocator::GpuMemoryAllocator() : GpuMemoryAllocator(Config{}) {}
 
 GpuMemoryAllocator::GpuMemoryAllocator(const Config& config) {
-    // Initialize pools with free list
-    auto init_pool = [this](Pool& pool, size_t capacity, bool is_ring) {
+    const uint32_t flights = config.flight_count > 0 ? config.flight_count : 1;
+
+    // 非 ring プール (mesh / ssbo): 従来通り free-list 管理。
+    auto init_free_pool = [this](Pool& pool, size_t capacity) {
         pool.buffer_id = next_buffer_id_++;
-        pool.capacity = capacity;
-        pool.used = 0;
-        pool.is_ring = is_ring;
+        pool.capacity  = capacity;
+        pool.used      = 0;
+        pool.is_ring   = false;
         pool.free_list.push_back({0, capacity});
     };
 
-    init_pool(mesh_pool_, config.mesh_pool_size, false);
-    init_pool(ssbo_pool_, config.ssbo_pool_size, false);
-    init_pool(instance_pool_, config.instance_buffer_size, true);
-    init_pool(staging_pool_, config.staging_buffer_size, true);
+    // ring プール (instance / staging): per-flight サイズ × flight_count を確保し、
+    // フライトごとに独立した区画を bump 確保する (H-3: in-flight GPU 参照保護)。
+    auto init_ring_pool = [this, flights](Pool& pool, size_t per_flight_size) {
+        pool.buffer_id     = next_buffer_id_++;
+        pool.region_size   = per_flight_size;
+        pool.flight_count  = flights;
+        pool.capacity      = per_flight_size * flights;
+        pool.current_flight = 0;
+        pool.head          = 0;          // flight 0 区画の先頭
+        pool.used          = 0;
+        pool.is_ring       = true;
+    };
+
+    init_free_pool(mesh_pool_, config.mesh_pool_size);
+    init_free_pool(ssbo_pool_, config.ssbo_pool_size);
+    init_ring_pool(instance_pool_, config.instance_buffer_size);
+    init_ring_pool(staging_pool_, config.staging_buffer_size);
 }
 
 GpuMemoryAllocator::~GpuMemoryAllocator() = default;
@@ -75,12 +90,30 @@ GpuAllocation GpuMemoryAllocator::allocate_ssbo(size_t size, size_t alignment) {
     return allocate_from_pool(ssbo_pool_, size, alignment);
 }
 
+GpuAllocation GpuMemoryAllocator::allocate_ring(Pool& pool, size_t size, size_t alignment) {
+    // 現フライト区画 [base, base + region_size) 内で bump 確保。
+    const size_t base    = static_cast<size_t>(pool.current_flight) * pool.region_size;
+    const size_t aligned = (pool.head + alignment - 1) & ~(alignment - 1);
+    if (aligned + size > base + pool.region_size) {
+        return {}; // 現フライト区画が満杯
+    }
+    GpuAllocation alloc;
+    alloc.buffer_id = pool.buffer_id;
+    alloc.offset    = aligned;
+    alloc.size      = size;
+    alloc.valid     = true;
+
+    pool.head = aligned + size;
+    pool.used = pool.head - base;
+    return alloc;
+}
+
 GpuAllocation GpuMemoryAllocator::allocate_instance(size_t size, size_t alignment) {
-    return allocate_from_pool(instance_pool_, size, alignment);
+    return allocate_ring(instance_pool_, size, alignment);
 }
 
 GpuAllocation GpuMemoryAllocator::allocate_staging(size_t size, size_t alignment) {
-    return allocate_from_pool(staging_pool_, size, alignment);
+    return allocate_ring(staging_pool_, size, alignment);
 }
 
 void GpuMemoryAllocator::free(const GpuAllocation& alloc) {
@@ -92,6 +125,9 @@ void GpuMemoryAllocator::free(const GpuAllocation& alloc) {
     else if (alloc.buffer_id == instance_pool_.buffer_id) pool = &instance_pool_;
     else if (alloc.buffer_id == staging_pool_.buffer_id) pool = &staging_pool_;
     else return;
+
+    // ring プールは個別 free しない (フライト区画ごと reset_ring_buffers で一括回収)。
+    if (pool->is_ring) return;
 
     pool->used -= alloc.size;
 
@@ -123,15 +159,16 @@ void GpuMemoryAllocator::free(const GpuAllocation& alloc) {
 }
 
 void GpuMemoryAllocator::reset_ring_buffers() {
-    // Ring buffers reset each frame (§11.2)
-    auto reset_pool = [](Pool& pool) {
+    // フライトを 1 つ進め、 新しいフライトの区画だけをリセットする (§11.2 / H-3)。
+    // 直前 (N-1) / N-2 フライトの区画は GPU が参照中の可能性があるため温存。
+    auto advance_pool = [](Pool& pool) {
+        pool.current_flight = (pool.current_flight + 1) % pool.flight_count;
+        pool.head = static_cast<size_t>(pool.current_flight) * pool.region_size;
         pool.used = 0;
-        pool.free_list.clear();
-        pool.free_list.push_back({0, pool.capacity});
     };
 
-    reset_pool(instance_pool_);
-    reset_pool(staging_pool_);
+    advance_pool(instance_pool_);
+    advance_pool(staging_pool_);
 }
 
 GpuMemoryAllocator::Stats GpuMemoryAllocator::get_stats() const {
@@ -140,10 +177,12 @@ GpuMemoryAllocator::Stats GpuMemoryAllocator::get_stats() const {
     stats.mesh_pool_capacity = mesh_pool_.capacity;
     stats.ssbo_used          = ssbo_pool_.used;
     stats.ssbo_capacity      = ssbo_pool_.capacity;
+    // ring プールの capacity は「現フライトが使える区画サイズ」を報告する
+    // (used / capacity 比を意味あるものに保つ)。
     stats.instance_used      = instance_pool_.used;
-    stats.instance_capacity  = instance_pool_.capacity;
+    stats.instance_capacity  = instance_pool_.region_size;
     stats.staging_used       = staging_pool_.used;
-    stats.staging_capacity   = staging_pool_.capacity;
+    stats.staging_capacity   = staging_pool_.region_size;
 
     // Calculate fragmentation: ratio of free blocks to ideal (1 block)
     if (mesh_pool_.free_list.size() > 1) {

--- a/src/memory/memory_subsystem.cpp
+++ b/src/memory/memory_subsystem.cpp
@@ -2,12 +2,22 @@
 
 namespace pictor {
 
+namespace {
+// MemoryConfig.flight_count を GPU allocator の ring 多重化数へ伝播させる
+// (両者が divergence しないよう単一ソースに揃える)。
+GpuMemoryAllocator::Config with_flight(const MemoryConfig& c) {
+    GpuMemoryAllocator::Config g = c.gpu_config;
+    g.flight_count = c.flight_count;
+    return g;
+}
+} // namespace
+
 MemorySubsystem::MemorySubsystem() : MemorySubsystem(MemoryConfig{}) {}
 
 MemorySubsystem::MemorySubsystem(const MemoryConfig& config)
     : flight_allocator_(config.frame_allocator_size, config.flight_count)
     , pool_allocator_(config.pool_chunk_size)
-    , gpu_allocator_(config.gpu_config)
+    , gpu_allocator_(with_flight(config))
     , config_(config)
 {
 }

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -2,6 +2,8 @@
 
 #ifdef PICTOR_HAS_VULKAN
 
+#include "pictor/surface/vk_result.h"
+
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
@@ -104,12 +106,12 @@ bool VulkanContext::recreate_swapchain() {
 }
 
 uint32_t VulkanContext::acquire_next_image() {
-    vkWaitForFences(device_, 1, &in_flight_fence_, VK_TRUE, UINT64_MAX);
+    VK_CHECK(vkWaitForFences(device_, 1, &in_flight_fence_, VK_TRUE, UINT64_MAX));
 
     uint32_t index = 0;
-    VkResult result = vkAcquireNextImageKHR(
+    VkResult result = VK_CHECK(vkAcquireNextImageKHR(
         device_, swapchain_, UINT64_MAX,
-        image_available_sem_, VK_NULL_HANDLE, &index);
+        image_available_sem_, VK_NULL_HANDLE, &index));
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         // No queue submit will follow this frame, so the fence must stay
@@ -120,9 +122,16 @@ uint32_t VulkanContext::acquire_next_image() {
         return UINT32_MAX;
     }
 
+    // DEVICE_LOST / SURFACE_LOST など: このフレームは描画しない。 submit が無いので
+    // fence は signaled のまま温存し (OUT_OF_DATE と同様)、 次フレームの待機が
+    // デッドロックしないようにする (Q-M3)。 SUBOPTIMAL は image 有効なので継続。
+    if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
+        return UINT32_MAX;
+    }
+
     // Image acquired; a submit signaling in_flight_fence_ will follow, so it is
     // safe to reset the fence now (must happen before that submit).
-    vkResetFences(device_, 1, &in_flight_fence_);
+    VK_CHECK(vkResetFences(device_, 1, &in_flight_fence_));
     return index;
 }
 
@@ -135,7 +144,7 @@ bool VulkanContext::present(uint32_t image_index) {
     info.pSwapchains        = &swapchain_;
     info.pImageIndices      = &image_index;
 
-    VkResult result = vkQueuePresentKHR(present_queue_, &info);
+    VkResult result = VK_CHECK(vkQueuePresentKHR(present_queue_, &info));
     if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
         recreate_swapchain();
     }
@@ -270,6 +279,24 @@ bool VulkanContext::create_surface() {
         info.pView = handle.cocoa.ns_view;
         if (vkCreateMacOSSurfaceMVK(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
             fprintf(stderr, "[Pictor] Failed to create macOS surface\n");
+            return false;
+        }
+        return true;
+    }
+#endif
+
+#ifdef VK_USE_PLATFORM_METAL_EXT
+    case NativeWindowHandle::Type::iOS: {
+        // iOS (MoltenVK): CAMetalLayer* を VK_EXT_metal_surface で橋渡し。
+        // IOSSurfaceProvider は Type::iOS / metal_layer を返すのに受け側 case が
+        // 欠落しており、iOS は必ず "Unsupported platform surface type 7" で初期化
+        // 失敗していた (review/2026-06-11 Q-2)。 非 ObjC TU では CAMetalLayer は
+        // void なので void* からそのまま渡せる。
+        VkMetalSurfaceCreateInfoEXT info{};
+        info.sType  = VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT;
+        info.pLayer = static_cast<const CAMetalLayer*>(handle.ios.metal_layer);
+        if (vkCreateMetalSurfaceEXT(instance_, &info, nullptr, &surface_) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create iOS (Metal) surface\n");
             return false;
         }
         return true;
@@ -473,17 +500,27 @@ bool VulkanContext::create_logical_device() {
 
 bool VulkanContext::create_swapchain() {
     VkSurfaceCapabilitiesKHR caps;
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device_, surface_, &caps);
+    if (VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+            physical_device_, surface_, &caps)) != VK_SUCCESS) {
+        return false;
+    }
 
     uint32_t fmt_count = 0;
-    vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, nullptr);
+    VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, nullptr));
     std::vector<VkSurfaceFormatKHR> formats(fmt_count);
-    vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, formats.data());
+    VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device_, surface_, &fmt_count, formats.data()));
 
     uint32_t pm_count = 0;
-    vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, nullptr);
+    VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, nullptr));
     std::vector<VkPresentModeKHR> present_modes(pm_count);
-    vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, present_modes.data());
+    VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(physical_device_, surface_, &pm_count, present_modes.data()));
+
+    // surface format / present mode が 0 件だと formats[0] が UB (Q-M5)。
+    if (fmt_count == 0 || pm_count == 0) {
+        fprintf(stderr, "[Pictor] Surface reports no formats (%u) or present modes (%u)\n",
+                fmt_count, pm_count);
+        return false;
+    }
 
     // Choose format
     swapchain_format_ = formats[0].format;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PICTOR_TESTS
     unit_attachment_def_test
     unit_pipeline_registries_test
     unit_parser_dos_test
+    unit_gpu_ring_flight_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_gpu_ring_flight_test.cpp
+++ b/tests/unit_gpu_ring_flight_test.cpp
@@ -1,0 +1,80 @@
+﻿/// GPU ring プール (instance / staging) の flight 多重化テスト
+/// (review/2026-06-11 H-3)。
+///
+/// 不変条件: 連続するフライトの ring 確保は互いに重ならない区画に入り、
+/// flight_count 回の reset で元の区画へ巡回する。 これにより GPU が前フレームの
+/// コマンドバッファ経由で参照中の領域を begin_frame が上書きしないことを保証する。
+
+#include "pictor/memory/gpu_memory_allocator.h"
+#include "test_common.h"
+
+using namespace pictor;
+using namespace pictor_test;
+
+namespace {
+
+struct Range { size_t lo, hi; };
+bool overlaps(const Range& a, const Range& b) {
+    return a.lo < b.hi && b.lo < a.hi;
+}
+
+GpuMemoryAllocator::Config make_config(size_t per_flight, uint32_t flights) {
+    GpuMemoryAllocator::Config c;
+    c.instance_buffer_size = per_flight;
+    c.staging_buffer_size  = per_flight;
+    c.flight_count         = flights;
+    return c;
+}
+
+// 3 フライト分の instance 確保が互いに非重複の区画に入ること。
+void test_flights_do_not_overlap() {
+    constexpr size_t kPerFlight = 1024;
+    constexpr uint32_t kFlights = 3;
+    GpuMemoryAllocator alloc(make_config(kPerFlight, kFlights));
+
+    Range r[kFlights];
+    for (uint32_t f = 0; f < kFlights; ++f) {
+        auto a = alloc.allocate_instance(256, 16);
+        PT_ASSERT(a.valid, "instance allocation must succeed within region");
+        r[f] = {a.offset, a.offset + a.size};
+        alloc.reset_ring_buffers(); // 次フライトへ前進
+    }
+
+    for (uint32_t i = 0; i < kFlights; ++i)
+        for (uint32_t j = i + 1; j < kFlights; ++j)
+            PT_ASSERT(!overlaps(r[i], r[j]),
+                      "allocations in different flights must not overlap");
+}
+
+// flight_count 回 reset すると最初の区画へ巡回すること。
+void test_wraps_after_flight_count() {
+    constexpr size_t kPerFlight = 1024;
+    constexpr uint32_t kFlights = 3;
+    GpuMemoryAllocator alloc(make_config(kPerFlight, kFlights));
+
+    auto first = alloc.allocate_instance(128, 16);
+    for (uint32_t f = 0; f < kFlights; ++f) alloc.reset_ring_buffers(); // 1 周
+    auto wrapped = alloc.allocate_instance(128, 16);
+
+    PT_ASSERT(first.valid && wrapped.valid, "allocations valid");
+    PT_ASSERT_OP(first.offset, ==, wrapped.offset,
+                 "after flight_count resets, region base must repeat");
+}
+
+// 区画 (per-flight) を超える確保は失敗すること。
+void test_region_overflow_fails() {
+    GpuMemoryAllocator alloc(make_config(1024, 3));
+    auto ok  = alloc.allocate_instance(1024, 16);
+    auto bad = alloc.allocate_instance(1, 16); // 区画満杯
+    PT_ASSERT(ok.valid, "exact-fit allocation succeeds");
+    PT_ASSERT(!bad.valid, "over-region allocation must fail (no spill into next flight)");
+}
+
+} // namespace
+
+int main() {
+    test_flights_do_not_overlap();
+    test_wraps_after_flight_count();
+    test_region_overflow_fails();
+    return report("unit_gpu_ring_flight_test");
+}


### PR DESCRIPTION
## 背景

PR #76 (Fable 全量診断の Critical/High 修正) で「別 PR フォローアップ」とした **GPU 同期系**を集約。
原典: `review/2026-06-11/REVIEW_IMPLEMENTATION.md` (H-3) / `REVIEW_QUALITY.md` (Q-2, Q-M3/M5/M6)。

| # | 重大度 | 指摘 | 修正 |
|---|---|---|---|
| H-3 | High | instance/staging ring に in-flight 保護なし (GPU 参照中領域を毎フレーム即時回収) | flight_count 分の独立区画に多重化、begin_frame は現フライト区画のみ reset |
| Q-2 | High | iOS surface 受け口欠落 (必ず初期化失敗) | `create_surface()` に `vkCreateMetalSurfaceEXT` の iOS case 追加 |
| Q-M3/M5/M6 | Med | acquire/present/fence/surface query の VkResult 未チェック | `VK_CHECK` ヘルパー導入で一括検査 + 危険分岐の補強 |

## 設計

### H-3 — ring プールの flight 多重化
`GpuMemoryAllocator` の instance/staging プールを `FlightFrameAllocator と同方式`で `flight_count` 個の区画に分割。
- 各フライトは設定サイズを丸ごと専有 (合計確保 = size × flight_count、per-flight 予算は不変)。
- `reset_ring_buffers()` は `current_flight` を前進させ、その区画だけを reset。GPU が参照中の N-1/N-2 区画は温存。
- ring の個別 `free()` は no-op (区画ごと一括回収)。stats は per-flight 区画サイズを capacity として報告。
- `MemoryConfig.flight_count` を GPU allocator config へ伝播 (単一ソース化)。

### Q-2 — iOS surface
`IOSSurfaceProvider` は `Type::iOS` / `metal_layer` を返すのに `create_surface()` の switch に iOS case が無く、iOS は必ず `Unsupported platform surface type 7` で失敗していた。`VK_USE_PLATFORM_METAL_EXT` ガードで `vkCreateMetalSurfaceEXT` 経路を追加。

### VK_CHECK — VkResult 一括チェック
`include/pictor/surface/vk_result.h` を新設。`VK_CHECK(expr)` は失敗時に call site + result code を stderr に出し、VkResult をそのまま評価値として返す (既存の戻り値分岐を壊さない)。
- acquire: `DEVICE_LOST`/`SURFACE_LOST` 等で fence を **signaled のまま** return → 次フレーム待機のデッドロック回避。`SUBOPTIMAL` は描画継続。
- swapchain: surface format / present mode が 0 件のとき `formats[0]` の UB をガード。

## 検証

- `pictor.lib` (Release, `PICTOR_ENABLE_RIVE=OFF`) ビルド成功、`ctest` **14/14 pass**。
- 新規 `unit_gpu_ring_flight_test`: 異フライトの ring 確保が**非重複**／`flight_count` 回 reset で**区画巡回**／区画超過確保は**失敗 (隣フライトに溢れない)** を回帰確認。

## 注意・残課題

- iOS / Cocoa の case は Windows ビルドではプリプロセッサで除外されるため当環境では**コンパイル未検証** (既存 case と同型・iOS CI で要確認)。
- `Q-3` (frames-in-flight 1 固定の per-flight fence/semaphore 化) は実 Vulkan + validation layer での検証が必須なため**本 PR では未対応** (別 PR)。
- `demo/postprocess` は main 時点で `set_postprocess_config` 未定義のため未ビルド (**本変更と無関係の既存破綻**、別途要対応)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)