### PR TITLE
refactor(pictor): Fable D-1 PictorRenderer God Class 分割 (3 抽出)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,9 @@ add_library(pictor STATIC
 
     # Public API
     src/core/pictor_renderer.cpp
+    src/core/renderer_subsystem_manager.cpp
+    src/core/mobile_lifecycle_controller.cpp
+    src/core/gi_facade.cpp
 )
 
 # サーフェスプロバイダ — プラットフォーム別に条件付きで追加。

--- a/include/pictor/core/gi_facade.h
+++ b/include/pictor/core/gi_facade.h
@@ -1,0 +1,42 @@
+﻿#pragma once
+
+#include "pictor/gi/gi_lighting_system.h"
+#include "pictor/gi/gi_bake.h"
+#include <cstdint>
+#include <string>
+
+namespace pictor {
+
+class RendererSubsystemManager;
+
+/// GI ライティング + 静的ベイクの委譲ファサード
+/// (review/2026-06-11 D-1: PictorRenderer God Class からの切り出し)。
+///
+/// gi_system / bake_system の所有は RendererSubsystemManager 側にあり (profile 切替で
+/// 生成・破棄され得る) 、 本ファサードは毎回 manager から live に取得して委譲する
+/// (stale ポインタを持たない)。 bake_timestamp 用に現フレーム番号を参照する。
+class GIFacade {
+public:
+    GIFacade(RendererSubsystemManager& subsystems, const uint64_t& frame_number)
+        : subsystems_(subsystems), frame_number_(frame_number) {}
+
+    // ---- GI Lighting ----
+    void set_directional_light(const DirectionalLight& light);
+    void upload_gi_probe_data(const float* sh_data, uint32_t probe_count);
+    void set_gi_config(const GIConfig& config);
+
+    // ---- GI Bake (static objects) ----
+    GIBakeResult bake_static_gi();
+    GIBakeResult bake_static_gi(BakeProgressCallback progress);
+    void apply_bake(const GIBakeResult& result);
+    void invalidate_bake();
+    bool save_bake(const std::string& path, const GIBakeResult& result);
+    GIBakeResult load_bake(const std::string& path);
+    void set_bake_data_provider(IBakeDataProvider* provider);
+
+private:
+    RendererSubsystemManager& subsystems_;
+    const uint64_t&           frame_number_;
+};
+
+} // namespace pictor

--- a/include/pictor/core/mobile_lifecycle_controller.h
+++ b/include/pictor/core/mobile_lifecycle_controller.h
@@ -1,0 +1,60 @@
+﻿#pragma once
+
+#include "pictor/core/mobile_lifecycle.h"
+#include <functional>
+#include <string>
+
+namespace pictor {
+
+/// モバイル lifecycle / thermal のステートマシン
+/// (review/2026-06-11 D-1: PictorRenderer God Class からの切り出し)。
+///
+/// OS レベルのイベント (pause/resume/suspend/surface lost-regain/low-memory/
+/// thermal) を受け、 lifecycle 状態・自動ダウングレードを管理する。 レンダラ本体
+/// への依存は `Hooks` (フレーム番号取得 / frame allocator フラッシュ / プロファイル
+/// 取得・切替) に限定し、 循環依存を避ける。
+class MobileLifecycleController {
+public:
+    /// レンダラ本体が提供する最小限の操作。
+    struct Hooks {
+        std::function<uint64_t()>                  current_frame;          // frame_number
+        std::function<void()>                      flush_frame_allocator;  // resume 時の stale flush
+        std::function<std::string()>               active_profile;         // current_profile_name
+        std::function<void(const std::string&)>    switch_profile;         // set_profile
+    };
+
+    MobileLifecycleController(Hooks hooks, MobileAutoDowngradePolicy policy)
+        : hooks_(std::move(hooks)), policy_(policy) {}
+
+    // ---- OS イベント ----
+    void on_pause();
+    void on_resume();
+    void on_suspend();
+    void on_surface_lost();
+    void on_surface_regained();
+    void on_low_memory(MemoryPressure level);
+    void on_thermal_state(ThermalState state);
+
+    // ---- 状態 / 設定 ----
+    MobileLifecycleSnapshot snapshot() const { return snapshot_; }
+    void set_observer(IMobileLifecycleObserver* observer) { observer_ = observer; }
+    void set_policy(const MobileAutoDowngradePolicy& policy) { policy_ = policy; }
+
+    /// ACTIVE 以外では per-frame 作業を抑制する (scene/handle/GPU resource は温存)。
+    bool frame_work_suppressed() const {
+        return snapshot_.lifecycle != LifecycleState::ACTIVE;
+    }
+
+private:
+    void transition_lifecycle_(LifecycleState next);
+    void transition_thermal_(ThermalState next);
+
+    Hooks                     hooks_;
+    MobileAutoDowngradePolicy policy_;
+    MobileLifecycleSnapshot   snapshot_{};
+    IMobileLifecycleObserver* observer_ = nullptr;
+    /// 自動ダウングレード前に active だったプロファイル。 未ダウングレード時は空。
+    std::string               pre_downgrade_profile_;
+};
+
+} // namespace pictor

--- a/include/pictor/core/pictor_renderer.h
+++ b/include/pictor/core/pictor_renderer.h
@@ -20,6 +20,9 @@
 #include "pictor/gi/gi_lighting_system.h"
 #include "pictor/gi/gi_bake.h"
 #include "pictor/animation/animation_system.h"
+#include "pictor/core/renderer_subsystem_manager.h"
+#include "pictor/core/mobile_lifecycle_controller.h"
+#include "pictor/core/gi_facade.h"
 #include <memory>
 
 namespace pictor {
@@ -205,7 +208,7 @@ public:
 
     /// Access GI system configuration
     void set_gi_config(const GIConfig& config);
-    GILightingSystem* gi_system() { return gi_system_.get(); }
+    GILightingSystem* gi_system() { return gi_system_; }
 
     // ---- GI Bake (static objects) ----
 
@@ -229,7 +232,7 @@ public:
     void set_bake_data_provider(IBakeDataProvider* provider);
 
     /// Access bake system
-    GIBakeSystem* bake_system() { return bake_system_.get(); }
+    GIBakeSystem* bake_system() { return bake_system_; }
 
     // ---- Post-Process ----
     // host-driven の `pictor::PostProcessPipeline` を使う。 ホストがシーンを
@@ -252,44 +255,47 @@ public:
     PipelineProfileManager& profile_manager() { return *profile_manager_; }
 
 private:
-    /// Profile switch procedure (§8.4)
+    /// Profile switch procedure (§8.4)。 subsystems_.apply_profile に委譲した後、
+    /// 動的に生成/破棄される alias (gpu_pipeline_ / gi_system_ / bake_system_) を再同期。
     void apply_profile(const PipelineProfileDef& profile);
+
+    /// subsystems_ が所有する実体から非所有 alias を取り直す。
+    void sync_subsystem_aliases_();
+
+    bool is_frame_work_suppressed_() const;
 
     bool initialized_ = false;
 
-    // Subsystems (owned)
-    std::unique_ptr<MemorySubsystem>        memory_;
-    std::unique_ptr<SceneRegistry>          scene_;
-    std::unique_ptr<UpdateScheduler>        update_scheduler_;
-    std::unique_ptr<BatchBuilder>           batch_builder_;
-    std::unique_ptr<CullingSystem>          culling_;
-    std::unique_ptr<GPUBufferManager>       gpu_buffer_manager_;
-    std::unique_ptr<GPUDrivenPipeline>      gpu_pipeline_;
-    std::unique_ptr<PipelineProfileManager> profile_manager_;
-    std::unique_ptr<RenderPassScheduler>    pass_scheduler_;
-    std::unique_ptr<Profiler>               profiler_;
-    std::unique_ptr<OverlayRenderer>        overlay_;
-    std::unique_ptr<StatsOverlay>           stats_overlay_;
-    std::unique_ptr<DataExporter>           data_exporter_;
-    std::unique_ptr<DataHandler>            data_handler_;
-    std::unique_ptr<GILightingSystem>       gi_system_;
-    std::unique_ptr<GIBakeSystem>           bake_system_;
-    std::unique_ptr<AnimationSystem>        animation_system_;
+    // サブシステムの所有・構築順序・プロファイル再構成は manager に集約 (D-1)。
+    RendererSubsystemManager subsystems_;
+
+    // 非所有 alias (subsystems_ が所有)。 本体 hot path / API 実装の簡潔さのために
+    // 保持し、 initialize() / apply_profile() 後に sync_subsystem_aliases_() で更新。
+    MemorySubsystem*        memory_             = nullptr;
+    SceneRegistry*          scene_              = nullptr;
+    UpdateScheduler*        update_scheduler_   = nullptr;
+    BatchBuilder*           batch_builder_      = nullptr;
+    CullingSystem*          culling_            = nullptr;
+    GPUBufferManager*       gpu_buffer_manager_ = nullptr;
+    GPUDrivenPipeline*      gpu_pipeline_       = nullptr;
+    PipelineProfileManager* profile_manager_    = nullptr;
+    RenderPassScheduler*    pass_scheduler_     = nullptr;
+    Profiler*               profiler_           = nullptr;
+    OverlayRenderer*        overlay_            = nullptr;
+    StatsOverlay*           stats_overlay_      = nullptr;
+    DataExporter*           data_exporter_      = nullptr;
+    DataHandler*            data_handler_       = nullptr;
+    GILightingSystem*       gi_system_          = nullptr;
+    GIBakeSystem*           bake_system_        = nullptr;
+    AnimationSystem*        animation_system_   = nullptr;
+
+    // 切り出したコントローラ / ファサード (initialize で生成)。
+    std::unique_ptr<MobileLifecycleController> mobile_;
+    std::unique_ptr<GIFacade>                  gi_facade_;
 
     RendererConfig config_;
     float          delta_time_     = 0.0f;
     uint64_t       frame_number_   = 0;
-
-    // Mobile lifecycle state
-    MobileLifecycleSnapshot   lifecycle_{};
-    IMobileLifecycleObserver* lifecycle_observer_ = nullptr;
-    /// Profile that was active when we auto-downgraded. Empty
-    /// when no auto-downgrade is in effect.
-    std::string               pre_downgrade_profile_;
-
-    void transition_lifecycle_(LifecycleState next);
-    void transition_thermal_(ThermalState next);
-    bool is_frame_work_suppressed_() const;
 };
 
 } // namespace pictor

--- a/include/pictor/core/renderer_subsystem_manager.h
+++ b/include/pictor/core/renderer_subsystem_manager.h
@@ -1,0 +1,96 @@
+﻿#pragma once
+
+#include "pictor/core/types.h"
+#include "pictor/memory/memory_subsystem.h"
+#include "pictor/scene/scene_registry.h"
+#include "pictor/update/update_scheduler.h"
+#include "pictor/batch/batch_builder.h"
+#include "pictor/culling/culling_system.h"
+#include "pictor/gpu/gpu_buffer_manager.h"
+#include "pictor/gpu/gpu_driven_pipeline.h"
+#include "pictor/pipeline/pipeline_profile.h"
+#include "pictor/pipeline/render_pass_scheduler.h"
+#include "pictor/profiler/profiler.h"
+#include "pictor/profiler/overlay_renderer.h"
+#include "pictor/profiler/stats_overlay.h"
+#include "pictor/profiler/data_exporter.h"
+#include "pictor/data/data_handler.h"
+#include "pictor/gi/gi_lighting_system.h"
+#include "pictor/gi/gi_bake.h"
+#include "pictor/animation/animation_system.h"
+#include <memory>
+
+namespace pictor {
+
+struct RendererConfig; // pictor_renderer.h
+
+/// 全サブシステムの所有・構築順序・プロファイル再構成を一手に引き受ける
+/// (review/2026-06-11 D-1: PictorRenderer God Class からの所有/初期化順序の切り出し)。
+///
+/// 初期化順序の依存 (旧 PictorRenderer::initialize のコメントでしか守られて
+/// いなかった 18 段) を `initialize()` の手続きに閉じ込め、 破棄は逆順で行う。
+/// PictorRenderer はこのマネージャを所有し、 本体コードからは各 accessor 越しに
+/// サブシステムへアクセスする。
+class RendererSubsystemManager {
+public:
+    RendererSubsystemManager();
+    ~RendererSubsystemManager();
+
+    RendererSubsystemManager(const RendererSubsystemManager&) = delete;
+    RendererSubsystemManager& operator=(const RendererSubsystemManager&) = delete;
+
+    /// 18 サブシステムを依存順に構築する (旧 initialize の手続きそのまま)。
+    void initialize(const RendererConfig& config);
+
+    /// 構築の逆順で破棄する。
+    void shutdown();
+
+    /// §8.4 プロファイル切替: 下流サブシステムを再構成する。
+    /// gpu_pipeline / gi_system / bake_system を profile に応じて生成/破棄するため、
+    /// 呼び出し後はこれらの accessor が指す実体が変わり得る (呼び出し側で再取得)。
+    void apply_profile(const PipelineProfileDef& profile);
+
+    // ---- accessors (非所有、 null 可なものは null を返し得る) ----
+    MemorySubsystem*        memory()             { return memory_.get(); }
+    SceneRegistry*          scene()              { return scene_.get(); }
+    UpdateScheduler*        update_scheduler()   { return update_scheduler_.get(); }
+    BatchBuilder*           batch_builder()      { return batch_builder_.get(); }
+    CullingSystem*          culling()            { return culling_.get(); }
+    GPUBufferManager*       gpu_buffer_manager() { return gpu_buffer_manager_.get(); }
+    GPUDrivenPipeline*      gpu_pipeline()       { return gpu_pipeline_.get(); }
+    PipelineProfileManager* profile_manager()    { return profile_manager_.get(); }
+    RenderPassScheduler*    pass_scheduler()     { return pass_scheduler_.get(); }
+    Profiler*               profiler()           { return profiler_.get(); }
+    OverlayRenderer*        overlay()            { return overlay_.get(); }
+    StatsOverlay*           stats_overlay()      { return stats_overlay_.get(); }
+    DataExporter*           data_exporter()      { return data_exporter_.get(); }
+    DataHandler*            data_handler()       { return data_handler_.get(); }
+    GILightingSystem*       gi_system()          { return gi_system_.get(); }
+    GIBakeSystem*           bake_system()        { return bake_system_.get(); }
+    AnimationSystem*        animation_system()   { return animation_system_.get(); }
+
+private:
+    std::unique_ptr<MemorySubsystem>        memory_;
+    std::unique_ptr<SceneRegistry>          scene_;
+    std::unique_ptr<UpdateScheduler>        update_scheduler_;
+    std::unique_ptr<BatchBuilder>           batch_builder_;
+    std::unique_ptr<CullingSystem>          culling_;
+    std::unique_ptr<GPUBufferManager>       gpu_buffer_manager_;
+    std::unique_ptr<GPUDrivenPipeline>      gpu_pipeline_;
+    std::unique_ptr<PipelineProfileManager> profile_manager_;
+    std::unique_ptr<RenderPassScheduler>    pass_scheduler_;
+    std::unique_ptr<Profiler>               profiler_;
+    std::unique_ptr<OverlayRenderer>        overlay_;
+    std::unique_ptr<StatsOverlay>           stats_overlay_;
+    std::unique_ptr<DataExporter>           data_exporter_;
+    std::unique_ptr<DataHandler>            data_handler_;
+    std::unique_ptr<GILightingSystem>       gi_system_;
+    std::unique_ptr<GIBakeSystem>           bake_system_;
+    std::unique_ptr<AnimationSystem>        animation_system_;
+
+    // apply_profile が screen_width/height を要するため保持。
+    uint32_t screen_width_  = 0;
+    uint32_t screen_height_ = 0;
+};
+
+} // namespace pictor

--- a/src/core/gi_facade.cpp
+++ b/src/core/gi_facade.cpp
@@ -1,0 +1,64 @@
+﻿#include "pictor/core/gi_facade.h"
+#include "pictor/core/renderer_subsystem_manager.h"
+
+namespace pictor {
+
+void GIFacade::set_directional_light(const DirectionalLight& light) {
+    if (auto* gi = subsystems_.gi_system()) gi->set_directional_light(light);
+}
+
+void GIFacade::upload_gi_probe_data(const float* sh_data, uint32_t probe_count) {
+    if (auto* gi = subsystems_.gi_system()) gi->upload_probe_data(sh_data, probe_count);
+}
+
+void GIFacade::set_gi_config(const GIConfig& config) {
+    if (auto* gi = subsystems_.gi_system()) gi->set_config(config);
+}
+
+GIBakeResult GIFacade::bake_static_gi() {
+    auto* bake = subsystems_.bake_system();
+    if (!bake) return GIBakeResult{};
+    auto result = bake->bake();
+    result.bake_timestamp = frame_number_;
+    return result;
+}
+
+GIBakeResult GIFacade::bake_static_gi(BakeProgressCallback progress) {
+    auto* bake = subsystems_.bake_system();
+    if (!bake) return GIBakeResult{};
+    auto result = bake->bake(std::move(progress));
+    result.bake_timestamp = frame_number_;
+    return result;
+}
+
+void GIFacade::apply_bake(const GIBakeResult& result) {
+    auto* bake = subsystems_.bake_system();
+    if (!bake) return;
+    bake->apply(result);
+
+    // Notify GI system how many static objects have baked data
+    if (auto* gi = subsystems_.gi_system()) {
+        gi->set_baked_static_count(static_cast<uint32_t>(result.object_ids.size()));
+    }
+}
+
+void GIFacade::invalidate_bake() {
+    if (auto* bake = subsystems_.bake_system()) bake->invalidate();
+    if (auto* gi = subsystems_.gi_system()) gi->set_baked_static_count(0);
+}
+
+bool GIFacade::save_bake(const std::string& path, const GIBakeResult& result) {
+    auto* bake = subsystems_.bake_system();
+    return bake ? bake->save(path, result) : false;
+}
+
+GIBakeResult GIFacade::load_bake(const std::string& path) {
+    auto* bake = subsystems_.bake_system();
+    return bake ? bake->load(path) : GIBakeResult{};
+}
+
+void GIFacade::set_bake_data_provider(IBakeDataProvider* provider) {
+    if (auto* bake = subsystems_.bake_system()) bake->set_bake_data_provider(provider);
+}
+
+} // namespace pictor

--- a/src/core/mobile_lifecycle_controller.cpp
+++ b/src/core/mobile_lifecycle_controller.cpp
@@ -1,0 +1,84 @@
+﻿#include "pictor/core/mobile_lifecycle_controller.h"
+
+namespace pictor {
+
+void MobileLifecycleController::transition_lifecycle_(LifecycleState next) {
+    if (snapshot_.lifecycle == next) return;
+    LifecycleState prev = snapshot_.lifecycle;
+    snapshot_.lifecycle = next;
+    snapshot_.last_change_frame = hooks_.current_frame ? hooks_.current_frame() : 0;
+    if (observer_) {
+        observer_->on_lifecycle_change(prev, next);
+    }
+    // resume 時は frame allocator をフラッシュし、 pause 前フレームの stale ポインタが
+    // 最初の active フレームへ漏れないようにする (end_frame は suppress 中スキップ済)。
+    if (prev != LifecycleState::ACTIVE && next == LifecycleState::ACTIVE &&
+        hooks_.flush_frame_allocator) {
+        hooks_.flush_frame_allocator();
+    }
+}
+
+void MobileLifecycleController::transition_thermal_(ThermalState next) {
+    if (snapshot_.thermal == next) return;
+    ThermalState prev = snapshot_.thermal;
+    snapshot_.thermal = next;
+    snapshot_.last_change_frame = hooks_.current_frame ? hooks_.current_frame() : 0;
+    if (observer_) {
+        observer_->on_thermal_change(prev, next);
+    }
+    // Auto-downgrade: opt-in 時のみ、 閾値を跨いだらプロファイルを入れ替える。
+    if (!policy_.enabled) return;
+
+    const bool hot_enough  = static_cast<uint8_t>(next) >= static_cast<uint8_t>(policy_.downgrade_at);
+    const bool cool_enough = static_cast<uint8_t>(next) <= static_cast<uint8_t>(policy_.restore_below);
+    if (hot_enough && pre_downgrade_profile_.empty()) {
+        pre_downgrade_profile_ = hooks_.active_profile ? hooks_.active_profile() : std::string{};
+        if (!policy_.low_profile_name.empty() && hooks_.switch_profile) {
+            hooks_.switch_profile(policy_.low_profile_name);
+        }
+    } else if (cool_enough && !pre_downgrade_profile_.empty()) {
+        const std::string restore = policy_.high_profile_name.empty()
+            ? pre_downgrade_profile_
+            : policy_.high_profile_name;
+        if (hooks_.switch_profile) hooks_.switch_profile(restore);
+        pre_downgrade_profile_.clear();
+    }
+}
+
+void MobileLifecycleController::on_pause() {
+    if (snapshot_.lifecycle == LifecycleState::SURFACE_LOST) return; // stricter wins
+    transition_lifecycle_(LifecycleState::PAUSED);
+}
+
+void MobileLifecycleController::on_resume() {
+    if (snapshot_.lifecycle == LifecycleState::SURFACE_LOST) return; // wait for regain
+    transition_lifecycle_(LifecycleState::ACTIVE);
+}
+
+void MobileLifecycleController::on_suspend() {
+    transition_lifecycle_(LifecycleState::SUSPENDED);
+}
+
+void MobileLifecycleController::on_surface_lost() {
+    transition_lifecycle_(LifecycleState::SURFACE_LOST);
+}
+
+void MobileLifecycleController::on_surface_regained() {
+    if (snapshot_.lifecycle != LifecycleState::SURFACE_LOST) return;
+    transition_lifecycle_(LifecycleState::ACTIVE);
+}
+
+void MobileLifecycleController::on_low_memory(MemoryPressure level) {
+    if (snapshot_.memory == level) return;
+    snapshot_.memory = level;
+    snapshot_.last_change_frame = hooks_.current_frame ? hooks_.current_frame() : 0;
+    if (observer_) {
+        observer_->on_memory_pressure(level);
+    }
+}
+
+void MobileLifecycleController::on_thermal_state(ThermalState state) {
+    transition_thermal_(state);
+}
+
+} // namespace pictor

--- a/src/core/pictor_renderer.cpp
+++ b/src/core/pictor_renderer.cpp
@@ -13,85 +13,26 @@ void PictorRenderer::initialize() { initialize(RendererConfig{}); }
 void PictorRenderer::initialize(const RendererConfig& config) {
     config_ = config;
 
-    // §12: Initialize backend, memory, profiler, default profile
+    // §12: サブシステムの構築 (所有 + 依存順序) は manager に委譲 (D-1)。
+    subsystems_.initialize(config);
+    sync_subsystem_aliases_();
 
-    // 1. Memory Subsystem
-    memory_ = std::make_unique<MemorySubsystem>(config.memory_config);
+    // モバイル lifecycle コントローラ。 レンダラ操作は Hooks 経由に限定する (D-1)。
+    MobileLifecycleController::Hooks hooks;
+    hooks.current_frame         = [this] { return frame_number_; };
+    hooks.flush_frame_allocator = [this] {
+        if (memory_) { memory_->begin_frame(); memory_->end_frame(); }
+    };
+    hooks.active_profile        = [this] { return current_profile_name(); };
+    hooks.switch_profile        = [this](const std::string& name) { set_profile(name); };
+    mobile_ = std::make_unique<MobileLifecycleController>(
+        std::move(hooks), config.mobile_downgrade);
 
-    // 2. Scene Registry
-    scene_ = std::make_unique<SceneRegistry>(*memory_);
+    // GI / bake 委譲ファサード (subsystems_ 越しに live 参照)。
+    gi_facade_ = std::make_unique<GIFacade>(subsystems_, frame_number_);
 
-    // 3. Update Scheduler
-    update_scheduler_ = std::make_unique<UpdateScheduler>(*scene_, config.update_config);
-
-    // 4. Batch Builder
-    batch_builder_ = std::make_unique<BatchBuilder>(*scene_);
-
-    // 5. Culling System
-    culling_ = std::make_unique<CullingSystem>(*scene_);
-
-    // 6. GPU Buffer Manager
-    gpu_buffer_manager_ = std::make_unique<GPUBufferManager>(memory_->gpu_allocator());
-
-    // 7. Pipeline Profile Manager
-    profile_manager_ = std::make_unique<PipelineProfileManager>();
-    profile_manager_->register_defaults();
-
-    // 8. Apply initial profile
-    if (!config.initial_profile.empty()) {
-        profile_manager_->set_profile(config.initial_profile);
-    }
-    const auto& profile = profile_manager_->current_profile();
-
-    // 9. GPU Driven Pipeline (if enabled)
-    if (profile.gpu_driven_enabled) {
-        gpu_pipeline_ = std::make_unique<GPUDrivenPipeline>(
-            *gpu_buffer_manager_, *scene_, profile.gpu_driven_config);
-    }
-
-    // 10. GI Lighting System (shadow maps + AO + probes)
-    if (profile.gi_config.shadow_enabled || profile.gi_config.ssao_enabled ||
-        profile.gi_config.gi_probes_enabled) {
-        gi_system_ = std::make_unique<GILightingSystem>(
-            *gpu_buffer_manager_, *scene_, profile.gi_config);
-        gi_system_->initialize(
-            profile.gpu_driven_config.max_triangle_count,
-            config.screen_width, config.screen_height);
-
-        // Bake system (depends on GI system)
-        bake_system_ = std::make_unique<GIBakeSystem>(
-            *gpu_buffer_manager_, *scene_, *gi_system_);
-    }
-
-    // 11. Render Pass Scheduler
-    pass_scheduler_ = std::make_unique<RenderPassScheduler>(profile);
-
-    // 12. Profiler
-    profiler_ = std::make_unique<Profiler>();
-    profiler_->set_enabled(config.profiler_enabled);
-    profiler_->set_overlay_mode(config.overlay_mode);
-
-    // 13. Overlay Renderer
-    overlay_ = std::make_unique<OverlayRenderer>();
-    overlay_->initialize(config.screen_width, config.screen_height);
-
-    // 14. Stats Overlay
-    stats_overlay_ = std::make_unique<StatsOverlay>();
-    stats_overlay_->initialize(config.screen_width, config.screen_height);
-
-    // 15. Data Exporter
-    data_exporter_ = std::make_unique<DataExporter>();
-
-    // 16. Animation System (before DataHandler, which depends on it)
-    animation_system_ = std::make_unique<AnimationSystem>(AnimationSystemConfig{});
-
-    // 17. Data Handler
-    data_handler_ = std::make_unique<DataHandler>(
-        memory_->gpu_allocator(), *gpu_buffer_manager_, *animation_system_);
-
-    // 18. Post-Process は host-driven の `PostProcessPipeline` を使う。
-    //     ホストがシーンを HDR ターゲットへ描き、 自前で初期化/record する
-    //     (KuzuSurvivors WorldRenderer 参照)。 managed レンダラは関与しない。
+    // Post-Process は host-driven の `PostProcessPipeline` を使う
+    // (KuzuSurvivors WorldRenderer 参照)。 PictorRenderer は関与しない。
 
     initialized_ = true;
 }
@@ -100,32 +41,38 @@ void PictorRenderer::shutdown() {
     if (!initialized_) return;
 
     // §12: Release all resources, GPU sync
-    animation_system_.reset();
-    data_handler_.reset();
-    data_exporter_.reset();
-    stats_overlay_.reset();
-    overlay_.reset();
-    profiler_.reset();
-    pass_scheduler_.reset();
-    bake_system_.reset();
-    gi_system_.reset();
-    gpu_pipeline_.reset();
-    profile_manager_.reset();
-    gpu_buffer_manager_.reset();
-    culling_.reset();
-    batch_builder_.reset();
-    update_scheduler_.reset();
-    scene_.reset();
-    memory_.reset();
+    gi_facade_.reset();
+    mobile_.reset();
+    subsystems_.shutdown();
+    sync_subsystem_aliases_(); // alias をすべて null 化
 
     initialized_ = false;
 }
 
+void PictorRenderer::sync_subsystem_aliases_() {
+    memory_             = subsystems_.memory();
+    scene_              = subsystems_.scene();
+    update_scheduler_   = subsystems_.update_scheduler();
+    batch_builder_      = subsystems_.batch_builder();
+    culling_            = subsystems_.culling();
+    gpu_buffer_manager_ = subsystems_.gpu_buffer_manager();
+    gpu_pipeline_       = subsystems_.gpu_pipeline();
+    profile_manager_    = subsystems_.profile_manager();
+    pass_scheduler_     = subsystems_.pass_scheduler();
+    profiler_           = subsystems_.profiler();
+    overlay_            = subsystems_.overlay();
+    stats_overlay_      = subsystems_.stats_overlay();
+    data_exporter_      = subsystems_.data_exporter();
+    data_handler_       = subsystems_.data_handler();
+    gi_system_          = subsystems_.gi_system();
+    bake_system_        = subsystems_.bake_system();
+    animation_system_   = subsystems_.animation_system();
+}
+
 bool PictorRenderer::is_frame_work_suppressed_() const {
-    // Any non-ACTIVE lifecycle state suppresses GPU submission.
-    // The scene graph and handles are preserved — only per-frame
-    // work is skipped so resume is cheap.
-    return lifecycle_.lifecycle != LifecycleState::ACTIVE;
+    // ACTIVE 以外の lifecycle 状態では GPU submit を抑制する (scene/handle/GPU
+    // resource は温存)。 詳細は MobileLifecycleController。
+    return mobile_ && mobile_->frame_work_suppressed();
 }
 
 void PictorRenderer::begin_frame(float delta_time) {
@@ -202,7 +149,7 @@ void PictorRenderer::render(const Camera& camera) {
 
     // §11.3 Step 5-6: Encode + Submit
     profiler_->begin_cpu_section(CpuSection::CommandEncode);
-    pass_scheduler_->execute(*batch_builder_, *culling_, gpu_pipeline_.get());
+    pass_scheduler_->execute(*batch_builder_, *culling_, gpu_pipeline_);
     profiler_->end_cpu_section(CpuSection::CommandEncode);
 
     // draw call / triangle 統計はかつて CommandEncoder から記録していたが、
@@ -331,153 +278,40 @@ const std::string& PictorRenderer::current_profile_name() const {
     return profile_manager_->current_profile_name();
 }
 
-// ---- Mobile Lifecycle ----
+// ---- Mobile Lifecycle (MobileLifecycleController へ委譲、 D-1) ----
 
-void PictorRenderer::transition_lifecycle_(LifecycleState next) {
-    if (lifecycle_.lifecycle == next) return;
-    LifecycleState prev = lifecycle_.lifecycle;
-    lifecycle_.lifecycle = next;
-    lifecycle_.last_change_frame = frame_number_;
-    if (lifecycle_observer_) {
-        lifecycle_observer_->on_lifecycle_change(prev, next);
-    }
-    // When resuming, flush the frame allocator so stale pointers
-    // from the last pre-pause frame can't leak into the first
-    // active frame. end_frame() was skipped while suppressed.
-    if (prev != LifecycleState::ACTIVE && next == LifecycleState::ACTIVE && memory_) {
-        memory_->begin_frame();  // resets the frame allocator head
-        memory_->end_frame();
-    }
-}
-
-void PictorRenderer::transition_thermal_(ThermalState next) {
-    if (lifecycle_.thermal == next) return;
-    ThermalState prev = lifecycle_.thermal;
-    lifecycle_.thermal = next;
-    lifecycle_.last_change_frame = frame_number_;
-    if (lifecycle_observer_) {
-        lifecycle_observer_->on_thermal_change(prev, next);
-    }
-    // Auto-downgrade: if opt-in, swap profile on crossing thresholds.
-    const auto& pol = config_.mobile_downgrade;
-    if (!pol.enabled) return;
-
-    const bool hot_enough   = static_cast<uint8_t>(next) >= static_cast<uint8_t>(pol.downgrade_at);
-    const bool cool_enough  = static_cast<uint8_t>(next) <= static_cast<uint8_t>(pol.restore_below);
-    if (hot_enough && pre_downgrade_profile_.empty()) {
-        pre_downgrade_profile_ = current_profile_name();
-        if (!pol.low_profile_name.empty()) {
-            set_profile(pol.low_profile_name);
-        }
-    } else if (cool_enough && !pre_downgrade_profile_.empty()) {
-        const std::string restore = pol.high_profile_name.empty()
-            ? pre_downgrade_profile_
-            : pol.high_profile_name;
-        set_profile(restore);
-        pre_downgrade_profile_.clear();
-    }
-}
-
-void PictorRenderer::on_pause() {
-    if (!initialized_) return;
-    if (lifecycle_.lifecycle == LifecycleState::SURFACE_LOST) return; // stricter wins
-    transition_lifecycle_(LifecycleState::PAUSED);
-}
-
-void PictorRenderer::on_resume() {
-    if (!initialized_) return;
-    if (lifecycle_.lifecycle == LifecycleState::SURFACE_LOST) return; // wait for regain
-    transition_lifecycle_(LifecycleState::ACTIVE);
-}
-
-void PictorRenderer::on_suspend() {
-    if (!initialized_) return;
-    transition_lifecycle_(LifecycleState::SUSPENDED);
-}
-
-void PictorRenderer::on_surface_lost() {
-    if (!initialized_) return;
-    transition_lifecycle_(LifecycleState::SURFACE_LOST);
-}
-
-void PictorRenderer::on_surface_regained() {
-    if (!initialized_) return;
-    if (lifecycle_.lifecycle != LifecycleState::SURFACE_LOST) return;
-    transition_lifecycle_(LifecycleState::ACTIVE);
-}
+void PictorRenderer::on_pause()            { if (mobile_) mobile_->on_pause(); }
+void PictorRenderer::on_resume()           { if (mobile_) mobile_->on_resume(); }
+void PictorRenderer::on_suspend()          { if (mobile_) mobile_->on_suspend(); }
+void PictorRenderer::on_surface_lost()     { if (mobile_) mobile_->on_surface_lost(); }
+void PictorRenderer::on_surface_regained() { if (mobile_) mobile_->on_surface_regained(); }
 
 void PictorRenderer::on_low_memory(MemoryPressure level) {
-    if (!initialized_) return;
-    if (lifecycle_.memory == level) return;
-    lifecycle_.memory = level;
-    lifecycle_.last_change_frame = frame_number_;
-    if (lifecycle_observer_) {
-        lifecycle_observer_->on_memory_pressure(level);
-    }
+    if (mobile_) mobile_->on_low_memory(level);
 }
 
 void PictorRenderer::on_thermal_state(ThermalState state) {
-    if (!initialized_) return;
-    transition_thermal_(state);
+    if (mobile_) mobile_->on_thermal_state(state);
 }
 
 MobileLifecycleSnapshot PictorRenderer::lifecycle_snapshot() const {
-    return lifecycle_;
+    return mobile_ ? mobile_->snapshot() : MobileLifecycleSnapshot{};
 }
 
 void PictorRenderer::set_lifecycle_observer(IMobileLifecycleObserver* observer) {
-    lifecycle_observer_ = observer;
+    if (mobile_) mobile_->set_observer(observer);
 }
 
 void PictorRenderer::set_mobile_downgrade_policy(const MobileAutoDowngradePolicy& policy) {
     config_.mobile_downgrade = policy;
+    if (mobile_) mobile_->set_policy(policy);
 }
 
 void PictorRenderer::apply_profile(const PipelineProfileDef& profile) {
-    // §8.4: Profile switch procedure
-    // 1. Validate new profile (done by ProfileManager)
-
-    // 2. Frame Allocator size change — requires memory reallocation
-    //    (simplified: would recreate MemorySubsystem in production)
-
-    // 3. UpdateScheduler config change
-    update_scheduler_->set_config(profile.update_config);
-
-    // 4. Invalidate all batches
-    batch_builder_->invalidate_all();
-
-    // 5. RenderPassScheduler reconfigure
-    pass_scheduler_->reconfigure(profile);
-
-    // 6. GPU resource reallocation
-    if (profile.gpu_driven_enabled && !gpu_pipeline_) {
-        gpu_pipeline_ = std::make_unique<GPUDrivenPipeline>(
-            *gpu_buffer_manager_, *scene_, profile.gpu_driven_config);
-    } else if (!profile.gpu_driven_enabled) {
-        gpu_pipeline_.reset();
-    } else if (gpu_pipeline_) {
-        gpu_pipeline_->set_config(profile.gpu_driven_config);
-    }
-
-    // 7. GI system reconfigure
-    if (profile.gi_config.shadow_enabled || profile.gi_config.ssao_enabled ||
-        profile.gi_config.gi_probes_enabled) {
-        if (!gi_system_) {
-            gi_system_ = std::make_unique<GILightingSystem>(
-                *gpu_buffer_manager_, *scene_, profile.gi_config);
-            gi_system_->initialize(
-                profile.gpu_driven_config.max_triangle_count,
-                config_.screen_width, config_.screen_height);
-        } else {
-            gi_system_->set_config(profile.gi_config);
-        }
-    } else {
-        gi_system_.reset();
-    }
-
-    // 8. Profiler config
-    profiler_->set_enabled(profile.profiler_config.enabled);
-    profiler_->set_overlay_mode(profile.profiler_config.overlay_mode);
+    // §8.4: 下流サブシステムの再構成は manager に委譲 (D-1)。
+    subsystems_.apply_profile(profile);
+    // gpu_pipeline_ / gi_system_ が再生成・破棄され得るため alias を取り直す。
+    sync_subsystem_aliases_();
 }
 
 // ---- Profiler ----
@@ -582,64 +416,46 @@ void PictorRenderer::unregister_model(ModelHandle handle) {
     data_handler_->unregister_model(handle);
 }
 
-// ---- GI Lighting ----
+// ---- GI Lighting / Bake (GIFacade へ委譲、 D-1) ----
 
 void PictorRenderer::set_directional_light(const DirectionalLight& light) {
-    if (gi_system_) gi_system_->set_directional_light(light);
+    if (gi_facade_) gi_facade_->set_directional_light(light);
 }
 
 void PictorRenderer::upload_gi_probe_data(const float* sh_data, uint32_t probe_count) {
-    if (gi_system_) gi_system_->upload_probe_data(sh_data, probe_count);
+    if (gi_facade_) gi_facade_->upload_gi_probe_data(sh_data, probe_count);
 }
 
 void PictorRenderer::set_gi_config(const GIConfig& config) {
-    if (gi_system_) gi_system_->set_config(config);
+    if (gi_facade_) gi_facade_->set_gi_config(config);
 }
 
-// ---- GI Bake ----
-
 GIBakeResult PictorRenderer::bake_static_gi() {
-    if (!bake_system_) return GIBakeResult{};
-    auto result = bake_system_->bake();
-    result.bake_timestamp = frame_number_;
-    return result;
+    return gi_facade_ ? gi_facade_->bake_static_gi() : GIBakeResult{};
 }
 
 GIBakeResult PictorRenderer::bake_static_gi(BakeProgressCallback progress) {
-    if (!bake_system_) return GIBakeResult{};
-    auto result = bake_system_->bake(std::move(progress));
-    result.bake_timestamp = frame_number_;
-    return result;
+    return gi_facade_ ? gi_facade_->bake_static_gi(std::move(progress)) : GIBakeResult{};
 }
 
 void PictorRenderer::apply_bake(const GIBakeResult& result) {
-    if (!bake_system_) return;
-    bake_system_->apply(result);
-
-    // Notify GI system how many static objects have baked data
-    if (gi_system_) {
-        gi_system_->set_baked_static_count(
-            static_cast<uint32_t>(result.object_ids.size()));
-    }
+    if (gi_facade_) gi_facade_->apply_bake(result);
 }
 
 void PictorRenderer::invalidate_bake() {
-    if (bake_system_) bake_system_->invalidate();
-    if (gi_system_) gi_system_->set_baked_static_count(0);
+    if (gi_facade_) gi_facade_->invalidate_bake();
 }
 
 bool PictorRenderer::save_bake(const std::string& path, const GIBakeResult& result) {
-    if (!bake_system_) return false;
-    return bake_system_->save(path, result);
+    return gi_facade_ ? gi_facade_->save_bake(path, result) : false;
 }
 
 GIBakeResult PictorRenderer::load_bake(const std::string& path) {
-    if (!bake_system_) return GIBakeResult{};
-    return bake_system_->load(path);
+    return gi_facade_ ? gi_facade_->load_bake(path) : GIBakeResult{};
 }
 
 void PictorRenderer::set_bake_data_provider(IBakeDataProvider* provider) {
-    if (bake_system_) bake_system_->set_bake_data_provider(provider);
+    if (gi_facade_) gi_facade_->set_bake_data_provider(provider);
 }
 
 // ---- Data Export ----

--- a/src/core/renderer_subsystem_manager.cpp
+++ b/src/core/renderer_subsystem_manager.cpp
@@ -1,0 +1,157 @@
+﻿#include "pictor/core/renderer_subsystem_manager.h"
+#include "pictor/core/pictor_renderer.h" // RendererConfig
+
+namespace pictor {
+
+RendererSubsystemManager::RendererSubsystemManager() = default;
+RendererSubsystemManager::~RendererSubsystemManager() = default;
+
+void RendererSubsystemManager::initialize(const RendererConfig& config) {
+    screen_width_  = config.screen_width;
+    screen_height_ = config.screen_height;
+
+    // §12: 依存順に構築する (旧 PictorRenderer::initialize)。
+
+    // 1. Memory Subsystem
+    memory_ = std::make_unique<MemorySubsystem>(config.memory_config);
+
+    // 2. Scene Registry
+    scene_ = std::make_unique<SceneRegistry>(*memory_);
+
+    // 3. Update Scheduler
+    update_scheduler_ = std::make_unique<UpdateScheduler>(*scene_, config.update_config);
+
+    // 4. Batch Builder
+    batch_builder_ = std::make_unique<BatchBuilder>(*scene_);
+
+    // 5. Culling System
+    culling_ = std::make_unique<CullingSystem>(*scene_);
+
+    // 6. GPU Buffer Manager
+    gpu_buffer_manager_ = std::make_unique<GPUBufferManager>(memory_->gpu_allocator());
+
+    // 7. Pipeline Profile Manager
+    profile_manager_ = std::make_unique<PipelineProfileManager>();
+    profile_manager_->register_defaults();
+
+    // 8. Apply initial profile
+    if (!config.initial_profile.empty()) {
+        profile_manager_->set_profile(config.initial_profile);
+    }
+    const auto& profile = profile_manager_->current_profile();
+
+    // 9. GPU Driven Pipeline (if enabled)
+    if (profile.gpu_driven_enabled) {
+        gpu_pipeline_ = std::make_unique<GPUDrivenPipeline>(
+            *gpu_buffer_manager_, *scene_, profile.gpu_driven_config);
+    }
+
+    // 10. GI Lighting System (shadow maps + AO + probes)
+    if (profile.gi_config.shadow_enabled || profile.gi_config.ssao_enabled ||
+        profile.gi_config.gi_probes_enabled) {
+        gi_system_ = std::make_unique<GILightingSystem>(
+            *gpu_buffer_manager_, *scene_, profile.gi_config);
+        gi_system_->initialize(
+            profile.gpu_driven_config.max_triangle_count,
+            config.screen_width, config.screen_height);
+
+        // Bake system (depends on GI system)
+        bake_system_ = std::make_unique<GIBakeSystem>(
+            *gpu_buffer_manager_, *scene_, *gi_system_);
+    }
+
+    // 11. Render Pass Scheduler
+    pass_scheduler_ = std::make_unique<RenderPassScheduler>(profile);
+
+    // 12. Profiler
+    profiler_ = std::make_unique<Profiler>();
+    profiler_->set_enabled(config.profiler_enabled);
+    profiler_->set_overlay_mode(config.overlay_mode);
+
+    // 13. Overlay Renderer
+    overlay_ = std::make_unique<OverlayRenderer>();
+    overlay_->initialize(config.screen_width, config.screen_height);
+
+    // 14. Stats Overlay
+    stats_overlay_ = std::make_unique<StatsOverlay>();
+    stats_overlay_->initialize(config.screen_width, config.screen_height);
+
+    // 15. Data Exporter
+    data_exporter_ = std::make_unique<DataExporter>();
+
+    // 16. Animation System (before DataHandler, which depends on it)
+    animation_system_ = std::make_unique<AnimationSystem>(AnimationSystemConfig{});
+
+    // 17. Data Handler
+    data_handler_ = std::make_unique<DataHandler>(
+        memory_->gpu_allocator(), *gpu_buffer_manager_, *animation_system_);
+
+    // 18. Post-Process は host-driven の `PostProcessPipeline` を使う
+    //     (PictorRenderer は関与しない)。
+}
+
+void RendererSubsystemManager::shutdown() {
+    // 構築の逆順で破棄する。
+    animation_system_.reset();
+    data_handler_.reset();
+    data_exporter_.reset();
+    stats_overlay_.reset();
+    overlay_.reset();
+    profiler_.reset();
+    pass_scheduler_.reset();
+    bake_system_.reset();
+    gi_system_.reset();
+    gpu_pipeline_.reset();
+    profile_manager_.reset();
+    gpu_buffer_manager_.reset();
+    culling_.reset();
+    batch_builder_.reset();
+    update_scheduler_.reset();
+    scene_.reset();
+    memory_.reset();
+}
+
+void RendererSubsystemManager::apply_profile(const PipelineProfileDef& profile) {
+    // §8.4: Profile switch procedure
+
+    // 3. UpdateScheduler config change
+    update_scheduler_->set_config(profile.update_config);
+
+    // 4. Invalidate all batches
+    batch_builder_->invalidate_all();
+
+    // 5. RenderPassScheduler reconfigure
+    pass_scheduler_->reconfigure(profile);
+
+    // 6. GPU resource reallocation
+    if (profile.gpu_driven_enabled && !gpu_pipeline_) {
+        gpu_pipeline_ = std::make_unique<GPUDrivenPipeline>(
+            *gpu_buffer_manager_, *scene_, profile.gpu_driven_config);
+    } else if (!profile.gpu_driven_enabled) {
+        gpu_pipeline_.reset();
+    } else if (gpu_pipeline_) {
+        gpu_pipeline_->set_config(profile.gpu_driven_config);
+    }
+
+    // 7. GI system reconfigure
+    if (profile.gi_config.shadow_enabled || profile.gi_config.ssao_enabled ||
+        profile.gi_config.gi_probes_enabled) {
+        if (!gi_system_) {
+            gi_system_ = std::make_unique<GILightingSystem>(
+                *gpu_buffer_manager_, *scene_, profile.gi_config);
+            gi_system_->initialize(
+                profile.gpu_driven_config.max_triangle_count,
+                screen_width_, screen_height_);
+        } else {
+            gi_system_->set_config(profile.gi_config);
+        }
+    } else {
+        gi_system_.reset();
+    }
+
+    // 8. Profiler config
+    profiler_->set_enabled(profile.profiler_config.enabled);
+    profiler_->set_overlay_mode(profile.profiler_config.overlay_mode);
+}
+
+} // namespace pictor


### PR DESCRIPTION
## 背景

PR #76 で分離した設計系の最後の 1 件 **D-1**。前回 (2026-05-30) から Critical 継続していた
**PictorRenderer God Class** (18 サブシステム所有 + ~12 責務 / ~60 public メソッド、初期化順序が
コメントでしか守られていない) を、`review/2026-06-11/REVIEW_DESIGN.md` が「最小コスト」と挙げた
**3 抽出**へ分解する。**公開 API・挙動は不変、純粋な委譲リファクタ**。

## 抽出

| 新クラス | 責務 | 旧 PictorRenderer |
|---|---|---|
| `RendererSubsystemManager` | 18 サブシステムの**所有・構築順序・破棄順序**・`apply_profile` の下流再構成 | `initialize` / `shutdown` / `apply_profile` |
| `MobileLifecycleController` | lifecycle/thermal ステートマシン + 自動ダウングレード | `transition_*` / `on_*` / lifecycle 状態群 |
| `GIFacade` | GI ライティング + 静的ベイクの委譲 | `set_directional_light` 〜 `set_bake_data_provider` |

## 設計上の判断

- **初期化順序の集約**: 旧 `initialize()` の 18 段の依存順序 (コメント依存) を `RendererSubsystemManager::initialize()` の手続きに閉じ込め、`shutdown()` は逆順破棄。`apply_profile` も同マネージャへ (gpu_pipeline / gi_system を profile に応じ生成・破棄)。
- **循環依存の回避**: `MobileLifecycleController` はレンダラ操作を `Hooks` (frame 番号取得 / allocator flush / profile 取得・切替) 経由に限定。
- **stale ポインタ回避**: `GIFacade` は gi/bake の所有を持たず、毎回 manager から live 取得 (profile 切替で再生成・破棄されても安全)。
- **本体の簡潔さ維持**: PictorRenderer は hot path / API 実装のため `subsystems_` への**非所有 alias** を保持し、`initialize` / `apply_profile` 後に `sync_subsystem_aliases_()` で再同期。これにより render() 等の本体コードは無改変、所有・順序管理だけを切り出した。

## 検証

- `pictor.lib` (Release, `PICTOR_ENABLE_RIVE=OFF`) ビルド成功、`ctest` **14/14 pass**。
- **公開 API 不変**のため 9 demo / KuzuSurvivors consumer への影響なし (gi_system()/bake_system() の戻り型・全 public メソッドのシグネチャ維持)。

## 補足 (残課題)

- RendererSubsystemManager に raw-ptr alias を併存させたのは本体改変を最小化しリスクを抑えるため。将来的に本体を accessor 経由へ移せば alias は撤去可能。
- D-3 の GpuTimer per-frame 文字列連結は別 PR (#80 で CPU セクションのみ enum 化済)。

これで PR #76 の設計系フォローアップ (D-1/D-2/D-3) は出揃い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)