### PR TITLE
perf(profiler/surface): GpuTimer 文字列連結撤廃 (D-3 #161) + frames-in-flight 多重化 (Q-3 #162)

### DIFF
--- a/include/pictor/profiler/gpu_timer.h
+++ b/include/pictor/profiler/gpu_timer.h
@@ -12,6 +12,15 @@ namespace pictor {
 
 class VulkanContext;
 
+/// 1 region につき 2 本打つ timestamp の begin/end 識別子。
+/// 以前は `name + "_begin"` / `name + "_end"` の **per-frame 文字列連結**
+/// (長い region 名で SSO 超過 → ヒープ確保) で区別していたが、 enum 化して
+/// per-frame アロケーションを撤廃した (review/2026-06-11 D-3)。
+enum class TimestampKind : uint8_t {
+    Begin = 0,
+    End,
+};
+
 /// GPU timestamp query manager (§13.3).
 ///
 /// 実 Vulkan の `VkQueryPool` で per-pass の GPU 実行時間を計測する。
@@ -75,20 +84,24 @@ public:
     /// Begin a new frame's timing
     void begin_frame(uint32_t frame_index);
 
-    /// Record a timestamp (returns query index)
-    uint32_t write_timestamp(const std::string& label);
+    /// Record a timestamp (returns query index)。
+    /// `region` / `kind` は debug 識別用で hot path では文字列を作らない
+    /// (`const char*` リテラルをそのまま保持)。
+    uint32_t write_timestamp(const char* region, TimestampKind kind);
 
-    /// Begin/end a named timer region
-    void begin_region(const std::string& name);
-    void end_region(const std::string& name);
+    /// Begin/end a named timer region。
+    /// `name` は呼び側が渡す **文字列リテラル** (静的寿命) を想定し、 内部では
+    /// `const char*` のまま保持する (per-frame コピー / alloc なし)。
+    void begin_region(const char* name);
+    void end_region(const char* name);
 
 #ifdef PICTOR_HAS_VULKAN
     /// `cmd` へ実 `vkCmdWriteTimestamp` を発行する計測経路。
     /// `begin_region` は領域開始時 (TOP_OF_PIPE)、 `end_region` は
     /// 領域終了時 (BOTTOM_OF_PIPE) に timestamp を書く。
-    uint32_t write_timestamp(const std::string& label, VkCommandBuffer cmd);
-    void begin_region(const std::string& name, VkCommandBuffer cmd);
-    void end_region(const std::string& name, VkCommandBuffer cmd);
+    uint32_t write_timestamp(const char* region, TimestampKind kind, VkCommandBuffer cmd);
+    void begin_region(const char* name, VkCommandBuffer cmd);
+    void end_region(const char* name, VkCommandBuffer cmd);
 
     /// begin_frame の直後・最初の timestamp を書く前に 1 度呼ぶ。
     /// 今フレームが書き込む query pool を `vkCmdResetQueryPool` する
@@ -100,11 +113,13 @@ public:
     void collect_results();
 
     /// Get elapsed time for a named region (ms)
-    double get_region_ms(const std::string& name) const;
+    double get_region_ms(const char* name) const;
 
-    /// Get all region timings
+    /// Get all region timings。
+    /// `name` は region 登録時に渡された `const char*` リテラルを指す
+    /// (静的寿命なのでコピー不要)。
     struct RegionTiming {
-        std::string name;
+        const char* name;
         double      gpu_ms;
     };
 
@@ -114,14 +129,15 @@ public:
 
 private:
     struct TimestampEntry {
-        std::string label;
-        uint32_t    query_index;
-        uint64_t    value = 0;
-        bool        has_result = false;
+        const char*  region = nullptr;       // 文字列リテラル (debug 識別用)
+        TimestampKind kind  = TimestampKind::Begin;
+        uint32_t     query_index = 0;
+        uint64_t     value = 0;
+        bool         has_result = false;
     };
 
     struct Region {
-        std::string name;
+        const char* name;
         uint32_t    begin_query;
         uint32_t    end_query;
         double      elapsed_ms = 0.0;

--- a/include/pictor/profiler/profiler.h
+++ b/include/pictor/profiler/profiler.h
@@ -87,9 +87,11 @@ public:
     void begin_cpu_section(CpuSection section);
     void end_cpu_section(CpuSection section);
 
-    /// Record GPU timestamps
-    void begin_gpu_section(const std::string& name);
-    void end_gpu_section(const std::string& name);
+    /// Record GPU timestamps。
+    /// `name` は文字列リテラル想定 (GpuTimerManager が `const char*` のまま保持し
+    /// per-frame の文字列確保をしない)。
+    void begin_gpu_section(const char* name);
+    void end_gpu_section(const char* name);
 
     /// Update draw stats
     void record_draw_calls(uint32_t count) { current_stats_.draw_call_count += count; }

--- a/include/pictor/surface/vulkan_context.h
+++ b/include/pictor/surface/vulkan_context.h
@@ -27,6 +27,13 @@ struct VulkanContextConfig {
     /// パス専用)。 default_render_pass() / framebuffers() は VK_NULL_HANDLE を
     /// 返すので、 これらに依存するコンポーネントは同居できない。
     bool        create_default_render_pass = true;
+
+    /// CPU が GPU に先行できる同時フレーム数 (frames-in-flight、 Q-3)。
+    /// 1 = 完全直列 (旧挙動、 acquire ごとに前フレームの GPU 完了を待つ)。
+    /// 2 以上で CPU 側の記録と GPU 実行を重ねられる。 fence / image-available
+    /// セマフォを flight 単位に多重化する (render-finished は swapchain image
+    /// 単位)。
+    uint32_t    frames_in_flight = 2;
 };
 
 /// Manages the Vulkan instance, physical/logical device, queue,
@@ -82,10 +89,21 @@ public:
     VkCommandBuffer begin_single_time_commands();
     void            end_single_time_commands(VkCommandBuffer cmd);
 
-    // Per-frame sync objects
-    VkSemaphore image_available_semaphore() const { return image_available_sem_; }
-    VkSemaphore render_finished_semaphore() const { return render_finished_sem_; }
-    VkFence     in_flight_fence()           const { return in_flight_fence_; }
+    // Per-frame sync objects (frames-in-flight, Q-3)。
+    //   image_available / in_flight_fence は **現在の flight** のオブジェクトを返す。
+    //   render_finished は **直近に acquire した swapchain image** のセマフォを返す
+    //   (consumer は acquire_next_image() の後に submit を組むので image index は確定済)。
+    // これにより consumer 側のコード (acquire → submit(accessor) → present) は無変更で
+    // 多重 flight 化できる。
+    VkSemaphore image_available_semaphore() const { return image_available_sems_[current_frame_]; }
+    VkSemaphore render_finished_semaphore() const { return render_finished_sems_[last_acquired_image_]; }
+    VkFence     in_flight_fence()           const { return in_flight_fences_[current_frame_]; }
+
+    /// 同時フレーム数 (frames-in-flight)。 consumer が flight 単位の per-frame
+    /// リソース (uniform ring 等) を確保するときの段数に使える。
+    uint32_t    frames_in_flight() const { return frames_in_flight_; }
+    /// 現在の flight index (0..frames_in_flight()-1)。 present のたびに進む。
+    uint32_t    current_frame()    const { return current_frame_; }
 
     // Optional extension features that the device was created with. Pictor
     // probes these during device creation and enables whichever are
@@ -145,9 +163,17 @@ private:
     VkCommandPool            command_pool_       = VK_NULL_HANDLE;
     std::vector<VkCommandBuffer> command_buffers_;
 
-    VkSemaphore              image_available_sem_ = VK_NULL_HANDLE;
-    VkSemaphore              render_finished_sem_ = VK_NULL_HANDLE;
-    VkFence                  in_flight_fence_     = VK_NULL_HANDLE;
+    // frames-in-flight 同期 (Q-3)。 image_available / in_flight_fence は flight
+    // 単位、 render_finished は swapchain image 単位で多重化する。 images_in_flight_
+    // は「その image を最後に使った flight の fence」を借用保持し (所有しない)、
+    // acquire 時に command buffer / image の再利用衝突を防ぐ。
+    uint32_t                 frames_in_flight_    = 2;
+    uint32_t                 current_frame_       = 0;
+    uint32_t                 last_acquired_image_ = 0;
+    std::vector<VkSemaphore> image_available_sems_;  // [frames_in_flight_]
+    std::vector<VkSemaphore> render_finished_sems_;  // [swapchain image count]
+    std::vector<VkFence>     in_flight_fences_;       // [frames_in_flight_]
+    std::vector<VkFence>     images_in_flight_;       // [swapchain image count], 借用
 
     bool has_fragment_shader_interlock_             = false;
     bool has_rasterization_order_attachment_access_ = false;

--- a/src/profiler/gpu_timer.cpp
+++ b/src/profiler/gpu_timer.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstring>
 
 #ifdef PICTOR_HAS_VULKAN
 #include "pictor/surface/vulkan_context.h"
@@ -105,24 +106,24 @@ void GpuTimerManager::begin_frame(uint32_t frame_index) {
 #endif
 }
 
-uint32_t GpuTimerManager::write_timestamp(const std::string& label) {
+uint32_t GpuTimerManager::write_timestamp(const char* region, TimestampKind kind) {
     if (current_query_ >= config_.max_queries) {
         return UINT32_MAX;
     }
     uint32_t query_index = current_query_++;
-    timestamps_.push_back({label, query_index, 0, false});
+    timestamps_.push_back({region, kind, query_index, 0, false});
     return query_index;
 }
 
-void GpuTimerManager::begin_region(const std::string& name) {
-    uint32_t begin_query = write_timestamp(name + "_begin");
+void GpuTimerManager::begin_region(const char* name) {
+    uint32_t begin_query = write_timestamp(name, TimestampKind::Begin);
     regions_.push_back({name, begin_query, UINT32_MAX, 0.0});
 }
 
-void GpuTimerManager::end_region(const std::string& name) {
-    uint32_t end_query = write_timestamp(name + "_end");
+void GpuTimerManager::end_region(const char* name) {
+    uint32_t end_query = write_timestamp(name, TimestampKind::End);
     for (auto& region : regions_) {
-        if (region.name == name && region.end_query == UINT32_MAX) {
+        if (region.end_query == UINT32_MAX && std::strcmp(region.name, name) == 0) {
             region.end_query = end_query;
             break;
         }
@@ -140,9 +141,9 @@ void GpuTimerManager::reset_pool(VkCommandBuffer cmd) {
     reset_done_ = true;
 }
 
-uint32_t GpuTimerManager::write_timestamp(const std::string& label,
+uint32_t GpuTimerManager::write_timestamp(const char* region, TimestampKind kind,
                                           VkCommandBuffer cmd) {
-    uint32_t query_index = write_timestamp(label);
+    uint32_t query_index = write_timestamp(region, kind);
     if (!vulkan_ready_ || query_index == UINT32_MAX) return query_index;
     // 念のため: 最初の timestamp 前に reset を済ませる (呼び側が
     // reset_pool を忘れても安全側に倒す)。
@@ -152,9 +153,9 @@ uint32_t GpuTimerManager::write_timestamp(const std::string& label,
     return query_index;
 }
 
-void GpuTimerManager::begin_region(const std::string& name,
+void GpuTimerManager::begin_region(const char* name,
                                    VkCommandBuffer cmd) {
-    uint32_t begin_query = write_timestamp(name + "_begin");
+    uint32_t begin_query = write_timestamp(name, TimestampKind::Begin);
     regions_.push_back({name, begin_query, UINT32_MAX, 0.0});
     if (!vulkan_ready_ || begin_query == UINT32_MAX) return;
     reset_pool(cmd);
@@ -163,11 +164,11 @@ void GpuTimerManager::begin_region(const std::string& name,
                         query_pools_[current_flight_], begin_query);
 }
 
-void GpuTimerManager::end_region(const std::string& name,
+void GpuTimerManager::end_region(const char* name,
                                  VkCommandBuffer cmd) {
-    uint32_t end_query = write_timestamp(name + "_end");
+    uint32_t end_query = write_timestamp(name, TimestampKind::End);
     for (auto& region : regions_) {
-        if (region.name == name && region.end_query == UINT32_MAX) {
+        if (region.end_query == UINT32_MAX && std::strcmp(region.name, name) == 0) {
             region.end_query = end_query;
             break;
         }
@@ -253,9 +254,9 @@ void GpuTimerManager::collect_results() {
     resolved_regions_ = regions_;
 }
 
-double GpuTimerManager::get_region_ms(const std::string& name) const {
+double GpuTimerManager::get_region_ms(const char* name) const {
     for (const auto& region : resolved_regions_) {
-        if (region.name == name) return region.elapsed_ms;
+        if (std::strcmp(region.name, name) == 0) return region.elapsed_ms;
     }
     return 0.0;
 }

--- a/src/profiler/profiler.cpp
+++ b/src/profiler/profiler.cpp
@@ -95,12 +95,12 @@ void Profiler::end_cpu_section(CpuSection section) {
     cpu_section_timers_[static_cast<size_t>(section)].stop();
 }
 
-void Profiler::begin_gpu_section(const std::string& name) {
+void Profiler::begin_gpu_section(const char* name) {
     if (!enabled_) return;
     gpu_timer_.begin_region(name);
 }
 
-void Profiler::end_gpu_section(const std::string& name) {
+void Profiler::end_gpu_section(const char* name) {
     if (!enabled_) return;
     gpu_timer_.end_region(name);
 }

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -40,6 +40,7 @@ bool VulkanContext::initialize(ISurfaceProvider* provider,
     provider_ = provider;
 
     create_default_rp_on_init_ = cfg.create_default_render_pass;
+    frames_in_flight_          = std::max<uint32_t>(1, cfg.frames_in_flight);
 
     if (!create_instance(cfg))              return false;
     if (!create_surface())                  return false;
@@ -67,10 +68,14 @@ void VulkanContext::shutdown() {
 
     vkDeviceWaitIdle(device_);
 
-    // Sync objects
-    if (render_finished_sem_) vkDestroySemaphore(device_, render_finished_sem_, nullptr);
-    if (image_available_sem_) vkDestroySemaphore(device_, image_available_sem_, nullptr);
-    if (in_flight_fence_)     vkDestroyFence(device_, in_flight_fence_, nullptr);
+    // Sync objects (per-flight + per-image)。 images_in_flight_ は借用なので破棄しない。
+    for (VkSemaphore s : render_finished_sems_) if (s) vkDestroySemaphore(device_, s, nullptr);
+    for (VkSemaphore s : image_available_sems_) if (s) vkDestroySemaphore(device_, s, nullptr);
+    for (VkFence     f : in_flight_fences_)      if (f) vkDestroyFence(device_, f, nullptr);
+    render_finished_sems_.clear();
+    image_available_sems_.clear();
+    in_flight_fences_.clear();
+    images_in_flight_.clear();
 
     // Command pool (frees command buffers implicitly)
     if (command_pool_) vkDestroyCommandPool(device_, command_pool_, nullptr);
@@ -106,12 +111,15 @@ bool VulkanContext::recreate_swapchain() {
 }
 
 uint32_t VulkanContext::acquire_next_image() {
-    VK_CHECK(vkWaitForFences(device_, 1, &in_flight_fence_, VK_TRUE, UINT64_MAX));
+    // 現在の flight の fence を待つ — これが「CPU が GPU に対して何フレーム
+    // 先行できるか」を frames_in_flight_ 段に制限する (Q-3)。
+    VkFence flight_fence = in_flight_fences_[current_frame_];
+    VK_CHECK(vkWaitForFences(device_, 1, &flight_fence, VK_TRUE, UINT64_MAX));
 
     uint32_t index = 0;
     VkResult result = VK_CHECK(vkAcquireNextImageKHR(
         device_, swapchain_, UINT64_MAX,
-        image_available_sem_, VK_NULL_HANDLE, &index));
+        image_available_sems_[current_frame_], VK_NULL_HANDLE, &index));
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         // No queue submit will follow this frame, so the fence must stay
@@ -129,17 +137,29 @@ uint32_t VulkanContext::acquire_next_image() {
         return UINT32_MAX;
     }
 
-    // Image acquired; a submit signaling in_flight_fence_ will follow, so it is
+    // この image を最後に使った flight がまだ GPU 実行中なら待つ。 frames_in_flight_
+    // が swapchain image 数と一致しない場合に、 同一 image の command buffer /
+    // framebuffer を前 flight と同時使用してしまうのを防ぐ (images-in-flight 追跡)。
+    if (images_in_flight_[index] != VK_NULL_HANDLE &&
+        images_in_flight_[index] != flight_fence) {
+        VK_CHECK(vkWaitForFences(device_, 1, &images_in_flight_[index], VK_TRUE, UINT64_MAX));
+    }
+    images_in_flight_[index] = flight_fence;
+    last_acquired_image_     = index;
+
+    // Image acquired; a submit signaling flight_fence will follow, so it is
     // safe to reset the fence now (must happen before that submit).
-    VK_CHECK(vkResetFences(device_, 1, &in_flight_fence_));
+    VK_CHECK(vkResetFences(device_, 1, &flight_fence));
     return index;
 }
 
 bool VulkanContext::present(uint32_t image_index) {
+    // present は「その image を描き終えた」render-finished セマフォ (image 単位) を待つ。
+    VkSemaphore wait_sem    = render_finished_sems_[image_index];
     VkPresentInfoKHR info{};
     info.sType              = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     info.waitSemaphoreCount = 1;
-    info.pWaitSemaphores    = &render_finished_sem_;
+    info.pWaitSemaphores    = &wait_sem;
     info.swapchainCount     = 1;
     info.pSwapchains        = &swapchain_;
     info.pImageIndices      = &image_index;
@@ -148,6 +168,10 @@ bool VulkanContext::present(uint32_t image_index) {
     if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR) {
         recreate_swapchain();
     }
+
+    // 次の flight へ進める (present を発行したフレームのみ — acquire が
+    // UINT32_MAX を返して submit/present を skip したフレームでは進めない)。
+    current_frame_ = (current_frame_ + 1u) % std::max<uint32_t>(1, frames_in_flight_);
     return result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR;
 }
 
@@ -728,12 +752,37 @@ bool VulkanContext::create_sync_objects() {
     fence_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     fence_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
-    if (vkCreateSemaphore(device_, &sem_info, nullptr, &image_available_sem_) != VK_SUCCESS ||
-        vkCreateSemaphore(device_, &sem_info, nullptr, &render_finished_sem_) != VK_SUCCESS ||
-        vkCreateFence(device_, &fence_info, nullptr, &in_flight_fence_) != VK_SUCCESS) {
-        fprintf(stderr, "[Pictor] Failed to create sync objects\n");
-        return false;
+    // flight 単位: image-available セマフォ + in-flight fence。
+    const uint32_t flights = std::max<uint32_t>(1, frames_in_flight_);
+    frames_in_flight_ = flights;
+    image_available_sems_.assign(flights, VK_NULL_HANDLE);
+    in_flight_fences_.assign(flights, VK_NULL_HANDLE);
+    for (uint32_t i = 0; i < flights; ++i) {
+        if (vkCreateSemaphore(device_, &sem_info, nullptr, &image_available_sems_[i]) != VK_SUCCESS ||
+            vkCreateFence(device_, &fence_info, nullptr, &in_flight_fences_[i]) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create per-flight sync objects\n");
+            return false;
+        }
     }
+
+    // swapchain image 単位: render-finished セマフォ (present 待ち)。 present の
+    // 待機セマフォを flight 単位にすると、 再 signal 時に前回 present の wait と
+    // 衝突し得る (validation 警告)。 image 単位なら acquire→submit→present が
+    // 同一 image に紐づくので安全。 image 数は recreate_swapchain でも不変前提
+    // (command_buffers_ も同様の前提でリサイズしていない)。
+    const size_t image_count = swapchain_images_.size();
+    render_finished_sems_.assign(image_count, VK_NULL_HANDLE);
+    for (size_t i = 0; i < image_count; ++i) {
+        if (vkCreateSemaphore(device_, &sem_info, nullptr, &render_finished_sems_[i]) != VK_SUCCESS) {
+            fprintf(stderr, "[Pictor] Failed to create render-finished semaphore\n");
+            return false;
+        }
+    }
+    // image→flight fence マッピング (借用ハンドル、 所有しない)。
+    images_in_flight_.assign(image_count, VK_NULL_HANDLE);
+
+    current_frame_       = 0;
+    last_acquired_image_ = 0;
     return true;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PICTOR_TESTS
     unit_pipeline_registries_test
     unit_parser_dos_test
     unit_gpu_ring_flight_test
+    unit_gpu_timer_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_gpu_timer_test.cpp
+++ b/tests/unit_gpu_timer_test.cpp
@@ -1,0 +1,49 @@
+// GpuTimerManager の region API (const char* / TimestampKind) を headless で検証する。
+//
+// D-3 (review/2026-06-11): per-frame の `name + "_begin"` 文字列連結を撤廃し、
+// region 名は `const char*` リテラルのまま保持、 begin/end は TimestampKind enum で
+// 区別する。 ここでは Vulkan を初期化しない (= シミュレーション経路) ので実 GPU
+// 時間は出ないが、 region の登録 / 突合 / 公開 API の構造を固定する。
+
+#include "pictor/profiler/gpu_timer.h"
+#include "test_common.h"
+
+#include <cstring>
+
+using namespace pictor_test;
+
+int main() {
+    pictor::GpuTimerManager gt;
+
+    // 1 フレーム分: 2 region を順に計測する。
+    gt.begin_frame(0);
+    gt.begin_region("scene_hdr");
+    gt.end_region("scene_hdr");
+    gt.begin_region("postprocess");
+    gt.end_region("postprocess");
+
+    // region あたり begin/end の 2 本 → 計 4 timestamp。
+    PT_ASSERT_OP(gt.query_count(), ==, 4u, "2 region = 4 timestamps");
+
+    // collect_results (sim 経路) が resolved_regions_ を確定する。
+    gt.collect_results();
+
+    const auto timings = gt.get_all_timings();
+    PT_ASSERT_OP(timings.size(), ==, 2u, "2 regions resolved");
+    if (timings.size() == 2) {
+        // const char* リテラルがそのまま保持されている (連結された別文字列でない)。
+        PT_ASSERT(std::strcmp(timings[0].name, "scene_hdr") == 0,  "region 0 名が一致");
+        PT_ASSERT(std::strcmp(timings[1].name, "postprocess") == 0, "region 1 名が一致");
+    }
+
+    // 既知 region は名前で突合できる (sim 経路では実時間 0ms)。
+    PT_ASSERT_OP(gt.get_region_ms("scene_hdr"), ==, 0.0, "sim 経路は実時間 0");
+    // 未知 region は 0 を返す (クラッシュしない / nullptr 突合しない)。
+    PT_ASSERT_OP(gt.get_region_ms("nonexistent"), ==, 0.0, "未知 region は 0");
+
+    // 次フレームで begin_frame が記録をリセットする。
+    gt.begin_frame(1);
+    PT_ASSERT_OP(gt.query_count(), ==, 0u, "begin_frame で timestamps クリア");
+
+    return report("unit_gpu_timer_test");
+}


### PR DESCRIPTION
Memoria タスク #161 (D-3) と #162 (Q-3) の Fable 開発実装。両者は独立・コード非重複で、同一セッションの一括実装のため 1 PR に集約。

## #161 GpuTimer per-frame 文字列連結の enum 化 (review/2026-06-11 D-3)
`begin_region`/`end_region` が毎フレーム `name + "_begin"` / `"_end"` を連結しており、長い region 名 (`decal_compose_begin` 等) は SSO を超えてヒープ確保していた。`compiled_graph.h` の「hot path に string ゼロ」不変条件と矛盾。

- 連結を撤廃。begin/end は `TimestampKind` enum で区別。
- region 名は `std::string` コピーをやめ `const char*` リテラルのまま保持 → **per-frame alloc ゼロ**。
- 公開 API (`begin_region`/`end_region`/`get_region_ms`/`RegionTiming.name`、`Profiler::begin_gpu_section`/`end_gpu_section`) を `const char*` 化。呼び側は全て文字列リテラルを渡すため暗黙変換でソース互換。
- **設計判断**: KS は `"scene_hdr"` 等の動的 region 名 + `get_all_timings()` を Ergo render_pipeline へ relay している。`CpuSection` 流の固定 enum にすると KS の per-pass relay が壊れるため、固定 enum 化ではなく「連結の enum 化 + 名前の const char* 化」で目的 (per-frame アロケ削減) を達成。
- headless 単体テスト `unit_gpu_timer_test` を追加。

## #162 frames-in-flight の per-flight fence/semaphore 化 (Q-3)
frames-in-flight が単一 fence/semaphore で **1 固定 = 完全直列** (acquire ごとに前フレームの GPU 完了を待つ) だった。

- in-flight fence と image-available semaphore を **flight 単位**に多重化。
- render-finished semaphore は **swapchain image 単位** (present 待ちセマフォを flight 単位にすると再 signal 時に前回 present の wait と競合し validation 警告 → image 単位で回避)。
- **images-in-flight 追跡**で command buffer / image の前 flight との同時使用を防止 (Vulkan Tutorial 標準パターン)。
- `VulkanContextConfig.frames_in_flight` (既定 2) で段数指定。`frames_in_flight()` / `current_frame()` を公開。
- アクセサ (`image_available_semaphore`/`render_finished_semaphore`/`in_flight_fence`) は現在 flight / 直近 acquire image のオブジェクトを返すので **consumer (全 demo + KS) は無変更**。

## 検証
- Pictor: `pictor.lib` + `pictor_demo` ビルド緑、`ctest` **15/15 pass** (新規 `unit_gpu_timer_test` 含む)。
- 消費者リンクテスト (KS Release、API 変更の影響先): `kuzusurvivors` / `kuzu_visus_preview` / `kuzu_rive_player` いずれもビルド成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)