### PR TITLE
docs: spec↔code レビュー + GitHub Pages サイト (概要/グラフ/API/レビュー)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy docs to GitHub Pages
+
+# Publishes the static documentation site in /docs to GitHub Pages.
+# Enable once in repo Settings → Pages → "Build and deployment" → Source: "GitHub Actions".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload docs/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Pictorは、描画オブジェクトの一元管理と最適な描画パイプラインの自動選択を行うレンダリングパイプラインモジュールです。特定のインタフェースを通じてオブジェクト記述子(ObjectDescriptor)を受け付け、データ駆動設計(DOD)に基づく高効率なレンダリングを実行します。
 
+> 📘 **ドキュメントサイト** (GitHub Pages): [https://ludiars.github.io/pictor/](https://ludiars.github.io/pictor/)
+> — サービスの役割・特徴・設計の概要、ドメイン/機能の[グラフビュー](https://ludiars.github.io/pictor/graph.html)、
+> トグル展開できる[API リファレンス](https://ludiars.github.io/pictor/api.html)、[spec↔code レビュー](https://ludiars.github.io/pictor/review.html)。
+> ソースは [`/docs`](docs/) 配下。Pages は Settings → Pages → Source: **GitHub Actions** で有効化。
+
 ---
 
 ## セットアップ

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pictor — API リファレンス</title>
+<link rel="stylesheet" href="assets/pictor.css">
+</head>
+<body>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="brand" href="index.html"><span class="logo">Pc</span> Pictor
+      <span class="tag">Data-Driven Rendering Pipeline</span></a>
+    <nav class="links">
+      <a href="index.html">概要</a>
+      <a href="graph.html">グラフ</a>
+      <a href="api.html" class="active">API</a>
+      <a href="review.html">レビュー</a>
+      <a href="https://github.com/ludiars/pictor">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="hero" style="padding-bottom:1.2rem">
+    <h1>API リファレンス</h1>
+    <p class="sub">公開 API（<code>include/pictor/</code>、<code>pictor.h</code> 集約）をドメイン別に整理。
+      各エントリは<strong>トグルで展開</strong>し、ヘッダ・目的・メソッドシグネチャ・パラメータを確認できる。</p>
+  </div>
+
+  <div class="toolbar">
+    <input type="search" id="search" placeholder="クラス・メソッド・型を検索（例: register_object, GIConfig, bake）">
+    <button class="btn" id="expand">すべて展開</button>
+    <button class="btn" id="collapse">すべて折りたたむ</button>
+  </div>
+  <div id="domnav" class="badges" style="margin-bottom:1.5rem"></div>
+
+  <div id="content"></div>
+  <p id="noresult" class="muted" style="display:none">該当する API がありません。</p>
+</main>
+
+<footer>
+  Pictor API · 出典: <code>include/pictor/*.h</code> ・ <code>docs/api/classes.md</code> ・ <code>docs/api/interfaces.md</code>。
+  シグネチャは公開ヘッダ準拠（簡略表記を含む）。正確な型は各ヘッダを参照。
+</footer>
+
+<script>
+// ── API model ─────────────────────────────────────────────────
+// method: [returnType, "name(params)", "description"]
+const DOMAINS = [
+ { id:"core", title:"Core / Renderer", items:[
+   { name:"PictorRenderer", header:"pictor/core/pictor_renderer.h",
+     purpose:"パイプライン全体を統括するエントリポイント。サブシステム初期化・フレーム駆動・プロファイル切替を行う。",
+     methods:[
+      ["void","initialize(const RendererConfig& config)","レンダラ初期化（サブシステム構築）"],
+      ["void","shutdown()","全リソース解放"],
+      ["ObjectId","register_object(const ObjectDescriptor& desc)","シーンへオブジェクト登録（flags で自動分類）"],
+      ["void","unregister_object(ObjectId id)","オブジェクト除去"],
+      ["void","update_transform(ObjectId id, const float4x4& transform)","Dynamic オブジェクトの transform 更新"],
+      ["void","begin_frame(float delta_time)","フレーム開始: fence 待機 + allocator reset"],
+      ["void","render(const Camera& camera)","シーン描画"],
+      ["void","end_frame()","GPU submit + present"],
+      ["bool","set_profile(const std::string& name)","レンダープロファイル切替（Lite/Standard/Ultra 等）"],
+      ["bool","load_profile_from_file(const std::string& path, std::string* error=nullptr)","JSON プロファイルを読込・適用"],
+      ["void","reload_active_profile()","アクティブプロファイルを再適用"],
+      ["void","set_directional_light(const DirectionalLight& light)","ディレクショナルライト設定"],
+      ["GIBakeResult","bake_static_gi(BakeProgressCallback progress=nullptr)","静的 GI ベイク実行"],
+      ["void","set_update_callback(IUpdateCallback*)","カスタム更新コールバック登録"],
+      ["void","set_culling_provider(ICullingProvider*)","カスタムカリング差替"],
+      ["void","set_batch_policy(IBatchPolicy*)","カスタムバッチ方針差替"],
+      ["void","register_custom_pass(ICustomRenderPass*)","カスタムレンダーパス登録"],
+      ["AnimationSystem&","animation()","アニメーションシステム取得"],
+      ["Profiler&","profiler()","プロファイラ取得"],
+      ["void","on_pause() / on_resume() / on_low_memory(MemoryPressure)","モバイルライフサイクル通知"],
+     ]},
+   { name:"RendererConfig", header:"pictor/core/pictor_renderer.h", kind:"struct",
+     purpose:"レンダラ初期化パラメータ。",
+     fields:[["std::string","initial_profile = \"Standard\"","初期プロファイル名"],
+       ["MemoryConfig","memory_config","メモリ設定"],
+       ["UpdateConfig","update_config","更新設定"],
+       ["uint32_t","screen_width / screen_height","画面解像度"],
+       ["bool","profiler_enabled = true","プロファイラ有効化"],
+       ["OverlayMode","overlay_mode","オーバーレイ表示モード"]]},
+   { name:"ObjectDescriptor", header:"pictor/core/types.h", kind:"struct",
+     purpose:"すべての描画対象を表す統一入力フォーマット。",
+     fields:[["MeshHandle","mesh","メッシュ ID"],["MaterialHandle","material","マテリアル ID"],
+       ["float4x4","transform","ワールド変換（64B, cache-line 整列）"],["AABB","bounds","バウンディングボックス（24B）"],
+       ["uint16_t","flags","分類・属性フラグ（STATIC/DYNAMIC/GPU_DRIVEN/…）"],
+       ["uint64_t","shaderKey","レンダーステート識別子（ソートキー）"],
+       ["uint32_t","materialKey","マテリアル・テクスチャ識別子"],["uint8_t","lodLevel","LOD レベル (0-255)"],
+       ["ShaderHandle","customShader","カスタムシェーダ override（INVALID_SHADER でなし）"]]},
+   { name:"Camera", header:"pictor/core/types.h", kind:"struct",
+     purpose:"ビュー/プロジェクションとカリング用 frustum。",
+     fields:[["float4x4","view","ビュー行列"],["float4x4","projection","プロジェクション行列"],
+       ["float3","position","カメラ位置"],["Frustum","frustum","6 平面 frustum"]]},
+   { name:"ObjectFlags / 列挙型", header:"pictor/core/types.h", kind:"enum",
+     purpose:"属性フラグと主要 enum。",
+     fields:[["flags","STATIC|DYNAMIC|GPU_DRIVEN|CAST_SHADOW|RECEIVE_SHADOW|TRANSPARENT|TWO_SIDED|INSTANCED|LAYER(8-9)","ObjectFlags ビット"],
+       ["RenderingPath","FORWARD / FORWARD_PLUS / DEFERRED / HYBRID","描画パス"],
+       ["PassType","DEPTH_ONLY/OPAQUE/TRANSPARENT/SHADOW/POST_PROCESS/COMPUTE/CUSTOM","パス種別"],
+       ["PoolType","STATIC / DYNAMIC / GPU_DRIVEN","プール種別"],
+       ["TextureFormat","RGBA8_UNORM/SRGB, RGBA16F, BC1/3/5/7, DEPTH_32F …","テクスチャ形式"]]},
+ ]},
+
+ { id:"data", title:"Data — アセット管理", items:[
+   { name:"DataHandler", header:"pictor/data/data_handler.h",
+     purpose:"テクスチャ・メッシュ・モデルの統合管理ファサード。",
+     methods:[
+      ["TextureHandle","register_texture(const TextureDescriptor& desc)","テクスチャ登録（即時/遅延アップロード）"],
+      ["bool","upload_texture_data(TextureHandle, const void* data, size_t size, uint32_t mip=0, uint32_t layer=0)","テクスチャデータ転送"],
+      ["MeshHandle","register_mesh(const MeshDataDescriptor& desc)","柔軟な頂点レイアウトでメッシュ登録"],
+      ["bool","upload_vertex_data(MeshHandle, const void* data, size_t size)","頂点データ転送"],
+      ["bool","update_vertex_region(MeshHandle, size_t offset, const void* data, size_t size)","部分更新"],
+      ["ModelHandle","register_model(const ModelDescriptor& desc)","3D モデル登録"],
+      ["TextureRegistry&","textures()","テクスチャレジストリ取得"],
+      ["VertexDataUploader&","meshes()","メッシュレジストリ取得"],
+     ]},
+   { name:"DataQueryAPI", header:"pictor/data/data_query_api.h",
+     purpose:"レベルエディタ・アセットブラウザ等の外部ツール向け読み取り専用クエリ。",
+     methods:[
+      ["DataSummary","get_summary()","集計（件数・GPU バイト）取得"],
+      ["std::vector<TextureInfo>","get_all_textures()","全テクスチャ情報"],
+      ["void","for_each_texture(std::function<void(const TextureInfo&)>)","テクスチャ反復"],
+      ["std::vector<TextureInfo>","get_textures_by_format(TextureFormat)","形式でフィルタ"],
+      ["MeshInfo","find_mesh(const std::string& name)","名前で検索"],
+      ["std::string","export_json()","ツール連携用 JSON エクスポート"],
+     ]},
+   { name:"TextureDescriptor / MeshDataDescriptor", header:"pictor/data/…", kind:"struct",
+     purpose:"登録時の記述子。",
+     fields:[["TextureDescriptor","name / width / height / format / type / initial_data","テクスチャ記述"],
+       ["MeshDataDescriptor","name / layout(VertexLayout) / vertex_data / vertex_count / index_data / index_32bit","メッシュ記述"],
+       ["VertexLayout","attributes[]{semantic,type,offset} + stride","柔軟な頂点レイアウト"]]},
+ ]},
+
+ { id:"material", title:"Material — PBR マテリアル", items:[
+   { name:"BaseMaterialBuilder", header:"pictor/material/base_material_builder.h",
+     purpose:"Fluent API で PBR マテリアルを構築し、パス別バリアントを自動生成（fluent: すべて self& を返す）。",
+     methods:[
+      ["BaseMaterialBuilder&","albedo(TextureHandle) / normal_map(...) / metallic_map(...) / roughness_map(...) / ao_map(...) / emissive_map(...)","テクスチャマップ設定"],
+      ["BaseMaterialBuilder&","base_color(r,g,b,a) / emissive_color(r,g,b)","色値設定"],
+      ["BaseMaterialBuilder&","metallic_value(float) / roughness_value(float) / alpha_cutoff(float)","スカラ値設定"],
+      ["BaseMaterialBuilder&","enable_two_sided(bool) / enable_alpha_test(bool) / enable_vertex_color(bool)","フィーチャートグル"],
+      ["BaseMaterialBuilder&","set_pass_features(PassType pass, uint32_t features)","パス別フィーチャー上書き"],
+      ["BuiltMaterial","build(MaterialHandle handle)","バリアント付きマテリアル生成"],
+     ]},
+   { name:"MaterialRegistry", header:"pictor/material/base_material_builder.h",
+     purpose:"BuiltMaterial の一元管理・O(1) ルックアップ。",
+     methods:[
+      ["bool","register_material(BuiltMaterial&& mat)","マテリアル登録"],
+      ["const BuiltMaterial*","get(MaterialHandle)","O(1) ルックアップ"],
+      ["const PassMaterialVariant*","variant_for(MaterialHandle, PassType)","パスバリアント取得"],
+      ["MaterialHandle","allocate_handle()","ハンドル払い出し"],
+     ]},
+   { name:"パス別バリアント", header:"pictor/material/material_property.h", kind:"enum",
+     purpose:"登録時にパスごとに不要なバインディング/フラグをストリップしパーミュテーション最小化。",
+     fields:[["Shadow / Depth-Only","ALPHA_TEST, TWO_SIDED のみ","深度系パス"],
+       ["GI","ALBEDO_MAP, EMISSIVE_MAP, ALPHA_TEST, TWO_SIDED, VERTEX_COLOR","GI パス"],
+       ["Opaque / Transparent","全フィーチャー","通常パス"]]},
+ ]},
+
+ { id:"gi", title:"GI — グローバルイルミネーション", items:[
+   { name:"GILightingSystem", header:"pictor/gi/gi_lighting_system.h",
+     purpose:"マテリアルシェーダから独立した GI プリパス（CSM シャドウ / SSAO / Light Probe）。",
+     methods:[
+      ["void","initialize(uint32_t max_objects, uint32_t width, uint32_t height)","GPU リソース確保"],
+      ["void","execute(const float4x4& view, const float4x4& projection)","GI パス実行"],
+      ["void","set_directional_light(const DirectionalLight& light)","太陽光設定"],
+      ["void","set_config(const GIConfig& config)","GI 全体再設定"],
+      ["void","set_shadow_enabled(bool) / set_ssao_enabled(bool) / set_gi_probes_enabled(bool)","フィーチャートグル"],
+      ["void","upload_probe_data(const float* sh_data, uint32_t probe_count)","Probe SH 係数アップロード"],
+     ]},
+   { name:"GIBakeSystem", header:"pictor/gi/gi_bake.h",
+     purpose:"静的オブジェクトのオフライン GI ベイク（Shadow/AO/Irradiance/Lightmap）。",
+     methods:[
+      ["void","set_config(const GIBakeConfig& config)","ベイク設定"],
+      ["GIBakeResult","bake(BakeProgressCallback progress=nullptr)","ベイク実行（プログレス可、false でキャンセル）"],
+      ["void","apply(const GIBakeResult& result)","結果を GPU へ適用"],
+      ["bool","save(const std::string& path, const GIBakeResult&)","ファイル保存"],
+      ["GIBakeResult","load(const std::string& path)","ファイル読込"],
+     ]},
+   { name:"GIConfig / ShadowMapConfig / SSAOConfig / GIProbeConfig", header:"pictor/gi/…", kind:"struct",
+     purpose:"GI 設定構造体（JSON プロファイルからも設定可能）。",
+     fields:[["ShadowMapConfig","cascade_count / resolution / depth_bias / filter_mode(NONE/PCF/PCSS) / pcss_*","シャドウ"],
+       ["SSAOConfig","sample_count / radius / bias / intensity / falloff_* / blur_enabled","SSAO"],
+       ["GIProbeConfig","grid_origin / grid_spacing / grid_x/y/z / gi_intensity","Probe グリッド"],
+       ["BakeTarget","SHADOW_MAP / AMBIENT_OCCLUSION / PROBE_IRRADIANCE / LIGHTMAP / ALL","ベイク対象"]]},
+   { name:"IBakeDataProvider", header:"pictor/gi/gi_bake.h", kind:"interface",
+     purpose:"ベイク入力の追加供給（追加ライト・emissive サーフェス）。",
+     methods:[["std::vector<PointLight>","get_bake_point_lights()","追加ライト"],
+       ["std::vector<ObjectId>","get_emissive_objects()","emissive オブジェクト"],
+       ["void","on_bake_begin() / on_bake_complete(const GIBakeResult&)","フック"]]},
+ ]},
+
+ { id:"surface", title:"Surface — ウィンドウ / Vulkan", items:[
+   { name:"ISurfaceProvider", header:"pictor/surface/surface_provider.h", kind:"interface",
+     purpose:"Pictor をウィンドウシステムから分離する抽象。ホストが実装、または GlfwSurfaceProvider を使用。",
+     methods:[
+      ["NativeWindowHandle","get_native_handle()","VkSurfaceKHR 生成用ハンドル（必須）"],
+      ["SwapchainConfig","get_swapchain_config()","希望スワップチェーン設定（必須）"],
+      ["void","on_swapchain_created(uint32_t w, uint32_t h)","作成/再作成通知"],
+      ["void","poll_events()","毎フレームのイベントポーリング"],
+      ["bool","should_close()","終了判定"],
+      ["uint32_t","get_required_instance_extensions(const char** out, uint32_t max)","必要な Vulkan 拡張"],
+     ]},
+   { name:"VulkanContext", header:"pictor/surface/vulkan_context.h",
+     purpose:"Vulkan インスタンス・デバイス・スワップチェーン管理（PICTOR_HAS_VULKAN 時）。",
+     methods:[
+      ["bool","initialize(ISurfaceProvider* provider, const VulkanContextConfig& cfg={})","コンテキスト生成"],
+      ["uint32_t","acquire_next_image()","スワップチェーンイメージ取得"],
+      ["bool","present(uint32_t image_index)","画面提示"],
+      ["bool","recreate_swapchain()","リサイズ対応"],
+      ["VkDevice","device() / instance() / physical_device() / graphics_queue()","Vulkan ハンドル取得"],
+     ]},
+   { name:"GlfwSurfaceProvider / NativeWindowHandle", header:"pictor/surface/glfw_surface_provider.h",
+     purpose:"デモ・ツール向け GLFW 実装。対応: Win32 / Xlib / XCB / Wayland / Cocoa / Android / iOS。",
+     methods:[["bool","create(const GlfwWindowConfig& config={})","GLFW ウィンドウ生成"],
+       ["GLFWwindow*","glfw_window()","GLFW ハンドル取得"],
+       ["—","NativeWindowHandle{type, union{win32/xlib/xcb/wayland/cocoa/android/ios}}","プラットフォーム別ハンドル"]]},
+ ]},
+
+ { id:"pipeline", title:"Pipeline / 拡張点", items:[
+   { name:"PipelineProfileManager", header:"pictor/pipeline/pipeline_profile.h",
+     purpose:"組込み（Lite/Standard/Ultra）・カスタムプロファイルの管理（系統A）。",
+     methods:[["void","register_profile(const PipelineProfileDef& def)","カスタム登録"],
+       ["bool","set_profile(const std::string& name)","アクティブ化"],
+       ["const PipelineProfileDef*","get_profile(const std::string& name)","名前で取得"],
+       ["std::vector<std::string>","profile_names()","一覧"],
+       ["static PipelineProfileDef","create_lite_profile() / create_standard_profile() / create_ultra_profile()","C++ ファクトリ"]]},
+   { name:"プロファイル JSON シリアライザ", header:"pictor/pipeline/pipeline_profile_serializer.h",
+     purpose:"PipelineProfileDef ⇄ JSON。preset シード版は差分のみ記述可。",
+     methods:[["std::string","to_pipeline_profile_json(const PipelineProfileDef&)","→ JSON"],
+       ["bool","from_pipeline_profile_json(const std::string& json, PipelineProfileDef& out, std::string* err=nullptr)","JSON →"],
+       ["bool","load_pipeline_profile_file(path, PipelineProfileDef& out, ...)","ファイル読込"],
+       ["bool","save_pipeline_profile_file(path, const PipelineProfileDef&, ...)","ファイル保存"]]},
+   { name:"RenderPassScheduler", header:"pictor/pipeline/render_pass_scheduler.h",
+     purpose:"プロファイル定義順にレンダーパスを実行。",
+     methods:[["void","reconfigure(const PipelineProfileDef& profile)","再設定"],
+       ["void","register_custom_pass(ICustomRenderPass* pass)","カスタムパス登録"],
+       ["void","execute(const BatchBuilder&, const CullingSystem&, GPUDrivenPipeline*)","全パス実行"],
+       ["const std::vector<RenderPassDef>&","pass_order()","実行順取得"]]},
+   { name:"ICustomRenderPass", header:"pictor/pipeline/…", kind:"interface",
+     purpose:"カスタムレンダーパス拡張点。pass_name が一致すれば execute() が実駆動。",
+     methods:[["const char*","name()","パス識別子"],["PassType","type()","パス種別"],
+       ["std::vector<std::string>","required_streams()","SoA ストリームヒント"],
+       ["void","execute(const std::vector<RenderBatch>& batches)","描画実装"]]},
+   { name:"IUpdateCallback / ICullingProvider / IBatchPolicy / IJobDispatcher", header:"pictor/update · culling · batch", kind:"interface",
+     purpose:"更新・カリング・バッチ・ジョブの差替インタフェース（Interface Segregation）。",
+     methods:[["IUpdateCallback","on_pre_update(PoolType,count) / on_post_update(...) / on_compute_dispatch(count)","更新フック"],
+       ["ICullingProvider","cull(const AABB*, uint8_t* vis, uint32_t count, const Frustum&)","カスタムカリング"],
+       ["IBatchPolicy","should_merge(uint64_t key_a, uint64_t key_b)","バッチ境界判定"],
+       ["IJobDispatcher","dispatch(count, chunk, JobFunction) / wait_all() / worker_count()","並列ジョブ"]]},
+   { name:"ShaderRegistry", header:"pictor/shader/shader_registry.h",
+     purpose:"カスタムシェーダ登録 + Vulkan pipeline 生成（Visus CUSTOM kind の seam）。",
+     methods:[["ShaderHandle","register_shader(const CustomShaderDef& def)","シェーダ登録（vert/frag/comp + VertexLayout）"],
+       ["void","build_pipelines(...)","VkPipeline 生成"],
+       ["VkPipeline","pipeline(ShaderHandle handle)","pipeline 取得（is_custom() で分岐）"]]},
+ ]},
+
+ { id:"scene", title:"Scene / Culling / Batch / Update", items:[
+   { name:"SceneRegistry", header:"pictor/scene/scene_registry.h",
+     purpose:"Static/Dynamic/GPU-Driven プールを横断するオブジェクト管理（SoA store）。",
+     methods:[["ObjectId","register_object(const ObjectDescriptor&)","登録（flags で自動分類）"],
+       ["void","unregister_object(ObjectId)","除去（swap-and-pop）"],
+       ["void","update_transform(ObjectId, const float4x4&)","Dynamic transform 更新"],
+       ["void","change_pool(ObjectId, PoolType)","プール間移動"],
+       ["ObjectPool&","static_pool() / dynamic_pool() / gpu_driven_pool()","プール取得"],
+       ["ObjectLocation","find_object(ObjectId)","逆引き"]]},
+   { name:"CullingSystem", header:"pictor/culling/culling_system.h",
+     purpose:"WorldPartition 広域 → FlatBVH 詳細 → GPU Hi-Z の多段カリング。",
+     methods:[["void","configure_partition(const WorldPartitionConfig&)","グリッド設定"],
+       ["void","build_static_bvh(PoolAllocator&)","静的 BVH（SAH）構築"],
+       ["void","refit_dynamic_bvh()","動的 BVH refit"],
+       ["void","cull(const Frustum&, FrameAllocator&)","全段カリング実行"],
+       ["Stats","get_stats()","total/visible/culled/cull_ratio"]]},
+   { name:"BatchBuilder", header:"pictor/batch/batch_builder.h",
+     purpose:"ソート済 SoA から RenderBatch を生成（間接インデックス参照）。",
+     methods:[["void","build(FrameAllocator& allocator)","全プールのバッチ構築"],
+       ["void","invalidate_all() / invalidate_pool(PoolType)","バッチ無効化"],
+       ["const std::vector<RenderBatch>&","batches()","生成バッチ"],
+       ["const uint32_t*","sorted_indices()","ソート済インデックス"]]},
+   { name:"UpdateScheduler", header:"pictor/update/update_scheduler.h",
+     purpose:"プール別に CPU並列 / Non-Temporal / GPU compute を自動選択。",
+     methods:[["void","update(float delta_time)","全プール更新"],
+       ["void","set_config(const UpdateConfig&)","設定（chunk_size / nt_store_*）"],
+       ["void","set_job_dispatcher(IJobDispatcher*)","カスタムジョブ系"]]},
+ ]},
+
+ { id:"memory", title:"Memory / GPU", items:[
+   { name:"MemorySubsystem", header:"pictor/memory/memory_subsystem.h",
+     purpose:"CPU frame(bump) / pool(SoA) / GPU の統合メモリ管理。",
+     methods:[["void","initialize(const MemoryConfig&)","アロケータ初期化"],
+       ["FrameAllocator&","frame_allocator()","フレーム bump アロケータ"],
+       ["PoolAllocator&","pool_allocator()","永続プールアロケータ"],
+       ["GpuMemoryAllocator&","gpu_allocator()","GPU VRAM アロケータ"]]},
+   { name:"GpuMemoryAllocator", header:"pictor/memory/gpu_memory_allocator.h",
+     purpose:"自前サブアロケータ（VMA 非依存）。4 プール = mesh / ssbo / instance / staging。",
+     methods:[["GpuAllocation","allocate_mesh(size, align=256)","メッシュプール"],
+       ["GpuAllocation","allocate_ssbo(size, align=256)","SSBO プール（indirect もここから）"],
+       ["GpuAllocation","allocate_instance(size, align=16)","インスタンスプール"],
+       ["GpuAllocation","allocate_staging(size, align=16)","ステージングプール"]]},
+   { name:"GPUDrivenPipeline / GPUBufferManager", header:"pictor/gpu/…",
+     purpose:"GPU 駆動 compute（update→cull→LOD→indirect compaction）とバッファ管理。",
+     methods:[["void","GPUDrivenPipeline::execute(const Frustum&, FrameAllocator&)","compute パス実行"],
+       ["GpuAllocation","GPUBufferManager::allocate_ssbo/ubo/vbo/ibo(size_t)","バッファ確保"],
+       ["void","upload_to_buffer(const GpuAllocation&, const void* data, size_t size, size_t offset=0)","アップロード"]]},
+ ]},
+
+ { id:"postprocess", title:"PostProcess", items:[
+   { name:"PostProcessPipeline", header:"pictor/postprocess/postprocess_pipeline.h",
+     purpose:"実 Vulkan host-driven post-process チェーン（Bloom/ToneMapping/Vignette/ColorGrading/DoF）。",
+     methods:[["void","set_config(const PostProcessConfig&)","エフェクトパラメータ設定"],
+       ["bool","initialize_vulkan(VulkanContext&, shader_dir, w, h, output_format, output_views, config, lut…)","組込みチェーンで初期化"],
+       ["bool","initialize_chain(…, const PostProcessChain&, …)","任意 pass チェーンで初期化"],
+       ["VkRenderPass","scene_render_pass()","ホストが 3D シーンを描く先"],
+       ["void","record(VkCommandBuffer cmd)","エフェクトチェーン記録"]]},
+   { name:"build_post_process_config（ブリッジ）", header:"pictor/postprocess/postprocess_config_bridge.h",
+     purpose:"系統A の post_process スタックを実描画用 PostProcessConfig へ畳み込む。",
+     methods:[["PostProcessConfig","build_post_process_config(const std::vector<PostProcessDef>& stack, const PostProcessConfig& base={})","スタック → config"],
+       ["PostProcessConfig","build_post_process_config(const PipelineProfileDef& profile, const PostProcessConfig& base={})","プロファイル → config"]]},
+   { name:"PostProcessChain / PostProcessPassDef", header:"pictor/postprocess/postprocess_chain.h", kind:"struct",
+     purpose:"汎用ポストプロセスチェーン（1 pass = fullscreen triangle + 入出力論理ターゲット + push 定数）。",
+     fields:[["PostProcessPassDef","vert/frag SPIR-V + input names[] + output name + push layout/data","汎用パス記述"],
+       ["予約名","__scene__ / __output__ / __lut__","scene HDR / swapchain / LUT"],
+       ["PostProcessChain","build_post_process_chain(config, extra) で構築","実行順 passes[]"]]},
+ ]},
+
+ { id:"profiler", title:"Profiler", items:[
+   { name:"Profiler", header:"pictor/profiler/profiler.h",
+     purpose:"低オーバーヘッドの per-frame CPU/GPU 計測・ドローコール統計・メモリ追跡。",
+     methods:[["void","set_enabled(bool) / set_overlay_mode(OverlayMode)","有効化・表示モード"],
+       ["void","begin_cpu_section(CpuSection) / end_cpu_section(CpuSection)","CPU 計測（enum index, 非 alloc）"],
+       ["void","begin_gpu_section(const char*) / end_gpu_section(const char*)","GPU 計測（実 VkQueryPool）"],
+       ["void","record_draw_calls(uint32_t) / record_triangles(uint64_t) / record_visible(uint32_t,uint32_t)","統計記録"],
+       ["const FrameStats&","get_current_stats() / get_previous_stats()","フレーム統計取得"]]},
+   { name:"DataExporter", header:"pictor/profiler/data_exporter.h",
+     purpose:"プロファイル結果を JSON / Chrome Tracing / CSV へエクスポート。",
+     methods:[["bool","export_json(path) / export_chrome_tracing(path) / export_csv(path)","ファイル出力"],
+       ["std::string","get_json_string() / get_csv_string()","文字列取得"]]},
+ ]},
+
+ { id:"text", title:"Text", items:[
+   { name:"FontLoader", header:"pictor/text/font_loader.h",
+     purpose:"TTF/OTF を自前パース（FreeType/stb 非依存、big-endian、cmap format 4/12）。",
+     methods:[["FontHandle","load_from_file(const std::string& path)","ファイルから読込"],
+       ["bool","get_glyph_metrics(FontHandle, uint32_t codepoint, float size, GlyphMetrics& out)","グリフメトリクス"],
+       ["int16_t","get_kerning(FontHandle, uint32_t left, uint32_t right)","カーニング"]]},
+   { name:"TextRasterizer", header:"pictor/text/text_rasterizer.h",
+     purpose:"経路A: グリフをマルチページ atlas へラスタライズ（shelf-pack）+ quad 頂点生成。高頻度 UI/HUD 向け。",
+     methods:[["bool","build_atlas(FontHandle, CharSet, const Config&)","atlas 焼込"],
+       ["const ImageBuffer*","get_page(uint32_t page_index)","GPU upload 元ページ"],
+       ["std::vector<TextVertex>","generate_vertices(const std::string&, const TextStyle&, float x, float y)","quad 頂点生成"]]},
+   { name:"TextImageRenderer / TextSvgRenderer", header:"pictor/text/…",
+     purpose:"経路B: RGBA ImageBuffer へラスタライズ（効果付き）。経路C: グリフ輪郭を SVG path として抽出。",
+     methods:[["ImageBuffer","TextImageRenderer::render_text(FontHandle, const std::string&, const TextStyle&)","画像化"],
+       ["TextExtent","TextImageRenderer::measure_text(...)","寸法計測"],
+       ["std::string","TextSvgRenderer::render_text_svg(FontHandle, const std::string&, const TextStyle&)","SVG 文字列化"]]},
+ ]},
+
+ { id:"animation", title:"Animation / Vector", items:[
+   { name:"AnimationSystem", header:"pictor/animation/animation_system.h",
+     purpose:"Skeleton/clip/IK/FK + 2D/Rive/Lottie を統括するアニメーション基盤。",
+     methods:[["void","initialize(const AnimationSystemConfig&)","初期化"],
+       ["SkeletonHandle","register_skeleton(const SkeletonDescriptor&)","スケルトン登録"],
+       ["AnimationClipHandle","register_clip(const AnimationClipDescriptor&)","クリップ登録"],
+       ["AnimationStateHandle","create_instance(ObjectId, SkeletonHandle)","インスタンス生成"],
+       ["void","play(AnimationStateHandle, AnimationClipHandle, float weight=1, float speed=1, AnimBlendMode=OVERRIDE)","再生"],
+       ["void","update(float delta_time)","全インスタンス更新"]]},
+   { name:"RiveRenderer", header:"pictor/vector/rive_renderer.h",
+     purpose:"Rive Renderer 統合ラッパー（PICTOR_ENABLE_RIVE 時）。",
+     methods:[["bool","initialize(VulkanContext&, const Options&)","初期化"],
+       ["bool","load_asset(const std::string& path)",".riv 読込"],
+       ["void","set_artboard(const std::string&) / set_state_machine(const std::string&)","アートボード/SM 選択"],
+       ["void","advance(float time_seconds)","アニメ更新"],
+       ["void","draw(VkImage target, uint32_t width, uint32_t height)","イメージへ描画"]]},
+   { name:"importer / 2D / Lottie", header:"pictor/animation/…",
+     purpose:"その他のアニメーション機能。",
+     methods:[["—","FBXImporter / BVHImporter","モデル・モーション読込"],
+       ["—","Animation2D","2D スプライト/フレームアニメ"],
+       ["—","LottieAnimation / VectorAnimation","Lottie JSON / 汎用ベクター"],
+       ["—","IKSolver","FABRIK / CCD 逆運動学"]]},
+ ]},
+
+ { id:"capi", title:"C API（ABI 安定エクスポート）", items:[
+   { name:"pictor_c_api（ライフサイクル / シーン）", header:"pictor/c_api.h",
+     purpose:"WASM / N-API / Capacitor 等の上位向け C ABI。opaque ハンドル経由。1 シーン = 1 PictorRenderer。",
+     methods:[["PictorRenderer*","pictor_create_renderer_webgl(const char* canvas_dom_id)","WebGL2(Emscripten) 生成"],
+       ["PictorRenderer*","pictor_create_renderer_vulkan(void* native_window, void* vk_instance)","Vulkan native 生成"],
+       ["void","pictor_destroy_renderer(PictorRenderer*) / pictor_set_size(r, w, h)","破棄・リサイズ"],
+       ["void","pictor_begin_scene(r, uint32_t clear_color) / pictor_end_scene(r)","シーン開始/終了"],
+       ["void","pictor_render_frame(r, double dt_seconds)","フレーム描画"]]},
+   { name:"pictor_c_api（オブジェクト / テクスチャ / 診断）", header:"pictor/c_api.h",
+     purpose:"submit/update/remove は O(1)。文字列は UTF-8 NUL 終端。",
+     methods:[["PictorObjectHandle","pictor_submit_object(r, const PictorObjectDescriptor*)","追加（失敗 0）"],
+       ["void","pictor_update_object(r, handle, const PictorObjectDescriptor*)","更新"],
+       ["void","pictor_remove_object(r, handle)","除去"],
+       ["uint64_t","pictor_create_texture_rgba8(r, const uint8_t* pixels, int w, int h)","RGBA8 テクスチャ"],
+       ["const char*","pictor_last_error()","最終エラー（Pictor 所有）"],
+       ["uint32_t","pictor_c_api_version()","ABI バージョン（現状 1）"]]},
+   { name:"PictorObjectDescriptor / Kind", header:"pictor/c_api.h", kind:"struct",
+     purpose:"2D プリミティブ記述子。",
+     fields:[["PictorObjectKind","CIRCLE=1 / LINE=2 / QUAD=3 / TEXT=4 / IMAGE=5","種別"],
+       ["uint32_t","color (0xRRGGBBAA)","色"],["float","x, y","位置"],
+       ["float","a,b,c,d","円:r / 線:x2,y2,width / 四角:w,h,rotate / テキスト:font size"],
+       ["const char*","text (nullable) / uint64_t texture_id","リソース参照"]]},
+ ]},
+
+ { id:"webgl", title:"WebGL2 Backend", items:[
+   { name:"WebGLRenderer", header:"pictor/webgl/webgl_renderer.h",
+     purpose:"Emscripten 向け WebGL2 代替バックエンド（Vulkan と並行・非抽象、PICTOR_BUILD_WEBGL 時）。",
+     methods:[["bool","initialize(const WebGLRendererConfig& ={})","コンテキスト・シェーダ初期化"],
+       ["ObjectId","register_object(const ObjectDescriptor&)","オブジェクト登録"],
+       ["void","update_transform(ObjectId, const float4x4&) / update_color(ObjectId, r,g,b,a)","更新"],
+       ["void","render(const float* view, const float* projection)","行列指定で描画"],
+       ["const WebGLFrameStats&","get_stats()","FPS / draw_calls / visible / culled"]]},
+ ]},
+];
+
+// ── render ────────────────────────────────────────────────────
+const content = document.getElementById("content");
+const domnav = document.getElementById("domnav");
+function esc(s){ return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
+
+DOMAINS.forEach(dom=>{
+  const a=document.createElement("a"); a.href="#"+dom.id; a.className="badge";
+  a.textContent=dom.title; a.style.cursor="pointer"; domnav.appendChild(a);
+
+  const sec=document.createElement("section"); sec.id=dom.id; sec.className="api-group";
+  sec.innerHTML=`<h2>${dom.title}</h2>`;
+  dom.items.forEach(it=>{
+    const d=document.createElement("details"); d.className="api";
+    const kind = it.kind? `<span class="pill info">${it.kind}</span>` : "";
+    let body = `<div class="body"><div class="small muted">ヘッダ: <code>${it.header}</code> ${kind}</div>`;
+    if(it.methods){
+      body += `<h4>メソッド</h4><table><tbody>`;
+      it.methods.forEach(m=>{
+        body += `<tr><td class="mono" style="white-space:nowrap;color:var(--fg-dim)">${esc(m[0])}</td>`+
+                `<td class="mono"><span class="sig">${esc(m[1])}</span></td>`+
+                `<td class="small">${m[2]}</td></tr>`;
+      });
+      body += `</tbody></table>`;
+    }
+    if(it.fields){
+      body += `<h4>フィールド / 値</h4><table><tbody>`;
+      it.fields.forEach(f=>{
+        body += `<tr><td class="mono" style="white-space:nowrap;color:var(--fg-dim)">${esc(f[0])}</td>`+
+                `<td class="mono"><span class="sig">${esc(f[1])}</span></td>`+
+                `<td class="small">${f[2]}</td></tr>`;
+      });
+      body += `</tbody></table>`;
+    }
+    body += `</div>`;
+    d.innerHTML = `<summary><span class="sig">${esc(it.name)}</span>`+
+      `<span class="blurb">${it.purpose}</span></summary>${body}`;
+    d.dataset.search = (it.name+" "+it.purpose+" "+it.header+" "+
+      JSON.stringify(it.methods||"")+" "+JSON.stringify(it.fields||"")).toLowerCase();
+    sec.appendChild(d);
+  });
+  content.appendChild(sec);
+});
+
+// search
+const search=document.getElementById("search");
+const noresult=document.getElementById("noresult");
+search.addEventListener("input", ()=>{
+  const q=search.value.trim().toLowerCase(); let any=false;
+  document.querySelectorAll("details.api").forEach(d=>{
+    const hit = !q || d.dataset.search.includes(q);
+    d.style.display = hit?"":"none"; if(hit) any=true;
+    d.open = q && hit;
+  });
+  document.querySelectorAll("section.api-group").forEach(s=>{
+    const visible=[...s.querySelectorAll("details.api")].some(d=>d.style.display!=="none");
+    s.style.display=visible?"":"none";
+  });
+  noresult.style.display = any?"none":"";
+});
+document.getElementById("expand").onclick=()=>document.querySelectorAll("details.api").forEach(d=>d.open=true);
+document.getElementById("collapse").onclick=()=>document.querySelectorAll("details.api").forEach(d=>d.open=false);
+</script>
+</body>
+</html>

--- a/docs/assets/pictor.css
+++ b/docs/assets/pictor.css
@@ -1,0 +1,195 @@
+/* Pictor documentation site — shared styles
+ * Self-contained, no external dependencies (works on GitHub Pages as-is). */
+
+:root {
+  --bg:        #0d1117;
+  --bg-soft:   #161b22;
+  --bg-card:   #1b2230;
+  --border:    #2b3444;
+  --fg:        #e6edf3;
+  --fg-dim:    #9aa7b6;
+  --accent:    #58a6ff;
+  --accent-2:  #79c0ff;
+  --ok:        #3fb950;
+  --warn:      #d29922;
+  --bad:       #f85149;
+  --chip:      #1f6feb33;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", "Helvetica Neue",
+          "Hiragino Kaku Gothic ProN", "Noto Sans JP", Meiryo, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code, pre, .mono { font-family: var(--mono); }
+code {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 0.1em 0.4em;
+  font-size: 0.88em;
+}
+pre {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+pre code { background: none; border: none; padding: 0; }
+
+/* ── top nav ────────────────────────────────────────── */
+header.topnav {
+  position: sticky; top: 0; z-index: 50;
+  background: rgba(13,17,23,0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+.topnav-inner {
+  max-width: 1180px; margin: 0 auto;
+  display: flex; align-items: center; gap: 1.4rem;
+  padding: 0.7rem 1.4rem;
+}
+.brand { display: flex; align-items: center; gap: 0.6rem; font-weight: 700; font-size: 1.05rem; }
+.brand .logo {
+  width: 28px; height: 28px; border-radius: 7px;
+  background: linear-gradient(135deg, #58a6ff, #a371f7);
+  display: grid; place-items: center; color: #fff; font-weight: 800; font-size: 0.85rem;
+}
+.brand .tag { color: var(--fg-dim); font-weight: 500; font-size: 0.8rem; }
+nav.links { display: flex; gap: 0.3rem; margin-left: auto; flex-wrap: wrap; }
+nav.links a {
+  padding: 0.35rem 0.75rem; border-radius: 7px; color: var(--fg-dim);
+  font-size: 0.9rem; font-weight: 500;
+}
+nav.links a:hover { background: var(--bg-card); color: var(--fg); text-decoration: none; }
+nav.links a.active { background: var(--chip); color: var(--accent-2); }
+
+/* ── layout ─────────────────────────────────────────── */
+main { max-width: 1180px; margin: 0 auto; padding: 2.2rem 1.4rem 5rem; }
+.hero {
+  padding: 2.6rem 0 1.4rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+.hero h1 { font-size: 2.3rem; margin: 0 0 0.5rem; letter-spacing: -0.02em; }
+.hero .sub { font-size: 1.15rem; color: var(--fg-dim); margin: 0 0 1rem; max-width: 760px; }
+.badges { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.badge {
+  font-size: 0.78rem; font-family: var(--mono);
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 999px; padding: 0.25rem 0.7rem; color: var(--fg-dim);
+}
+
+h2 { font-size: 1.5rem; margin: 2.6rem 0 1rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); }
+h3 { font-size: 1.15rem; margin: 1.8rem 0 0.7rem; }
+section { scroll-margin-top: 70px; }
+
+p { margin: 0.7rem 0; }
+ul, ol { padding-left: 1.3rem; }
+li { margin: 0.25rem 0; }
+
+/* ── cards ──────────────────────────────────────────── */
+.grid { display: grid; gap: 1rem; }
+.grid.cols-2 { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.grid.cols-3 { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+.card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 12px; padding: 1.1rem 1.2rem;
+}
+.card h3 { margin-top: 0; }
+.card .icon { font-size: 1.3rem; }
+.muted { color: var(--fg-dim); }
+.small { font-size: 0.86rem; }
+
+/* ── tables ─────────────────────────────────────────── */
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.9rem; }
+th, td { text-align: left; padding: 0.55rem 0.7rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+th { color: var(--fg-dim); font-weight: 600; background: var(--bg-soft); }
+tr:hover td { background: var(--bg-soft); }
+
+/* ── status pills ───────────────────────────────────── */
+.pill { display: inline-block; font-size: 0.76rem; font-weight: 700; border-radius: 999px;
+        padding: 0.12rem 0.6rem; white-space: nowrap; }
+.pill.ok   { background: #3fb95022; color: var(--ok);   border: 1px solid #3fb95055; }
+.pill.warn { background: #d2992222; color: var(--warn); border: 1px solid #d2992255; }
+.pill.bad  { background: #f8514922; color: var(--bad);  border: 1px solid #f8514955; }
+.pill.info { background: var(--chip); color: var(--accent-2); border: 1px solid #1f6feb55; }
+
+/* ── API toggle (details/summary) ───────────────────── */
+.api-group { margin: 1.4rem 0; }
+details.api {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: 10px; margin: 0.55rem 0; overflow: hidden;
+}
+details.api[open] { border-color: #34507a; }
+details.api > summary {
+  cursor: pointer; list-style: none; padding: 0.75rem 1rem;
+  display: flex; align-items: center; gap: 0.7rem; user-select: none;
+}
+details.api > summary::-webkit-details-marker { display: none; }
+details.api > summary::before {
+  content: "▶"; color: var(--accent); font-size: 0.7rem; transition: transform 0.15s;
+}
+details.api[open] > summary::before { transform: rotate(90deg); }
+details.api > summary:hover { background: var(--bg-soft); }
+.api .sig { font-family: var(--mono); font-weight: 600; color: var(--accent-2); font-size: 0.92rem; }
+.api .ret { color: var(--fg-dim); font-weight: 400; }
+.api .blurb { color: var(--fg-dim); font-size: 0.85rem; margin-left: auto; max-width: 45%; text-align: right; }
+.api .body { padding: 0.2rem 1.1rem 1rem; border-top: 1px solid var(--border); }
+.api .body h4 { margin: 0.9rem 0 0.4rem; font-size: 0.82rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg-dim); }
+
+.toolbar { display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: center; margin: 1rem 0; }
+.toolbar input[type=search] {
+  flex: 1; min-width: 200px; background: var(--bg-soft); border: 1px solid var(--border);
+  color: var(--fg); border-radius: 8px; padding: 0.5rem 0.8rem; font-size: 0.92rem;
+}
+.btn {
+  background: var(--bg-card); border: 1px solid var(--border); color: var(--fg);
+  border-radius: 8px; padding: 0.45rem 0.85rem; cursor: pointer; font-size: 0.85rem;
+}
+.btn:hover { background: var(--bg-soft); border-color: var(--accent); }
+
+/* ── graph page ─────────────────────────────────────── */
+.graph-wrap { display: grid; grid-template-columns: 1fr 320px; gap: 1rem; align-items: start; }
+#graph { width: 100%; height: 74vh; min-height: 540px; background: radial-gradient(circle at 50% 40%, #131a26, #0d1117 70%);
+         border: 1px solid var(--border); border-radius: 14px; }
+.legend .card { position: sticky; top: 80px; }
+.legend h3 { margin-top: 0; }
+.legend-item { display: flex; align-items: center; gap: 0.55rem; margin: 0.3rem 0; font-size: 0.88rem; cursor: pointer; }
+.legend-item:hover { color: var(--accent-2); }
+.swatch { width: 13px; height: 13px; border-radius: 4px; flex: none; }
+#node-info { margin-top: 1rem; min-height: 60px; font-size: 0.9rem; }
+#node-info .nm { font-weight: 700; font-size: 1.05rem; }
+.node-edge-list { font-size: 0.82rem; color: var(--fg-dim); }
+@media (max-width: 880px) {
+  .graph-wrap { grid-template-columns: 1fr; }
+  .legend .card { position: static; }
+  nav.links { display: none; }
+}
+
+footer { border-top: 1px solid var(--border); color: var(--fg-dim); font-size: 0.84rem;
+         padding: 2rem 1.4rem; max-width: 1180px; margin: 0 auto; }
+.kbd { font-family: var(--mono); background: var(--bg-soft); border: 1px solid var(--border);
+       border-bottom-width: 2px; border-radius: 5px; padding: 0.05em 0.4em; font-size: 0.8em; }
+.callout {
+  border-left: 3px solid var(--accent); background: var(--bg-soft);
+  border-radius: 0 8px 8px 0; padding: 0.8rem 1rem; margin: 1.1rem 0;
+}
+.callout.warn { border-left-color: var(--warn); }

--- a/docs/graph.html
+++ b/docs/graph.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pictor — ドメイン / 機能 グラフビュー</title>
+<link rel="stylesheet" href="assets/pictor.css">
+</head>
+<body>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="brand" href="index.html"><span class="logo">Pc</span> Pictor
+      <span class="tag">Data-Driven Rendering Pipeline</span></a>
+    <nav class="links">
+      <a href="index.html">概要</a>
+      <a href="graph.html" class="active">グラフ</a>
+      <a href="api.html">API</a>
+      <a href="review.html">レビュー</a>
+      <a href="https://github.com/ludiars/pictor">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="hero" style="padding-bottom:1rem">
+    <h1>ドメイン / 機能 グラフビュー</h1>
+    <p class="sub">Pictor の各サブシステム（ドメイン）と機能、その関連（フレームデータフロー・依存）を
+      インタラクティブに俯瞰する。ノードをクリックすると関連と説明を表示。</p>
+  </div>
+
+  <div class="toolbar">
+    <button class="btn" id="btn-flow">▶ フレームデータフローを強調</button>
+    <button class="btn" id="btn-reset">⟳ リセット</button>
+    <span class="muted small">ノードをドラッグで移動 / クリックで詳細 / ホバーで関連ハイライト</span>
+  </div>
+
+  <div class="graph-wrap">
+    <svg id="graph" viewBox="0 0 1000 720" preserveAspectRatio="xMidYMid meet"></svg>
+    <div class="legend">
+      <div class="card">
+        <h3>グループ</h3>
+        <div id="legend-list"></div>
+        <hr style="border-color:var(--border);margin:1rem 0">
+        <div class="small muted">
+          <b>実線（青系）</b> = フレームデータフロー<br>
+          <b>点線（灰）</b> = 依存 / 利用<br>
+          ● が大きいノードは公開 API を持つドメイン
+        </div>
+        <div id="node-info">
+          <div class="nm muted">ノードを選択してください</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <p class="small muted" style="margin-top:1.5rem">
+    関連の定義元: <code>spec/subsystem/README.md</code>（フレームパイプライン順）、
+    <code>README.md</code>（サブシステム一覧）、<code>include/pictor/pictor.h</code>（集約ヘッダ）。
+  </p>
+</main>
+
+<footer>
+  Pictor ドキュメント · グラフビューは外部ライブラリ非依存（vanilla JS + SVG）で描画。
+</footer>
+
+<script>
+// ── domain / feature graph data ───────────────────────────────
+const GROUPS = {
+  frontend:  { c:"#58a6ff", label:"フロントエンド (登録・分類・更新)" },
+  geometry:  { c:"#a371f7", label:"ジオメトリ処理 (カリング・バッチ・GPU駆動)" },
+  backend:   { c:"#f778ba", label:"バックエンド (パス実行・コマンド)" },
+  pass:      { c:"#3fb950", label:"描画パス機能 (GI/デカール/PP/マテリアル/シェーダ)" },
+  foundation:{ c:"#d29922", label:"基盤 (Renderer/メモリ/サーフェス/計測)" },
+  content:   { c:"#ff7b72", label:"コンテンツ (テキスト・アニメ・ベクター)" },
+  iface:     { c:"#56d4dd", label:"境界 (C API / WebGL / Visus / UI)" },
+};
+
+const NODES = [
+  // foundation
+  {id:"core",   label:"PictorRenderer", g:"foundation", api:1, big:1, doc:"api.html#core",
+   desc:"パイプライン全体を統括するエントリポイント。サブシステムの初期化・フレーム駆動・プロファイル切替を行う。"},
+  {id:"memory", label:"Memory",  g:"foundation", api:1, doc:"review.html#memory",
+   desc:"Frame(bump) / Pool(SoA) / GPU サブアロケータ。DoD レイアウトを支える横断基盤。"},
+  {id:"surface",label:"Surface / Vulkan", g:"foundation", api:1, doc:"api.html#surface",
+   desc:"ISurfaceProvider でウィンドウ系を抽象化 + VulkanContext (instance/device/swapchain)。"},
+  {id:"profiler",label:"Profiler", g:"foundation", api:1, doc:"api.html#profiler",
+   desc:"FPS・パス別 CPU/GPU 時間・メモリ統計・オーバーレイ。実 Vulkan GPU timestamp 対応。"},
+
+  // frontend flow
+  {id:"data",   label:"Data / アセット", g:"frontend", api:1, doc:"api.html#data",
+   desc:"テクスチャ/メッシュ/モデル(FBX) のライフサイクル。DataHandler ファサード + 読取専用 DataQueryAPI。"},
+  {id:"scene",  label:"Scene (SoA store)", g:"frontend", api:1, doc:"api.html#scene",
+   desc:"SceneRegistry + ObjectPool。SoA ストリームで全オブジェクトを並列配列管理。"},
+  {id:"update", label:"Update", g:"frontend", api:1, doc:"api.html#scene",
+   desc:"per-frame transform 更新スケジューラ。CPU並列 / Non-Temporal / GPU compute を自動選択。"},
+
+  // geometry flow
+  {id:"culling",label:"Culling", g:"geometry", api:1, doc:"api.html#scene",
+   desc:"WorldPartition 広域 → FlatBVH 詳細 → GPU Hi-Z の多段カリング。"},
+  {id:"batch",  label:"Batch", g:"geometry", api:1, doc:"api.html#scene",
+   desc:"BatchBuilder + Radix Sort O(n) で draw batch / indirect 生成。key-index ペアのみソート。"},
+  {id:"gpu",    label:"GPU-Driven", g:"geometry", api:1, doc:"api.html#memory",
+   desc:"compute update → cull → LOD → indirect compaction の GPU 駆動パイプライン + バッファ管理。"},
+
+  // backend
+  {id:"pipeline",label:"Pipeline / Scheduler", g:"backend", api:1, doc:"review.html#pipeline",
+   desc:"PipelineProfile に基づき RenderPass 実行順を決定（系統A）。JSON プロファイルで外部設定可能。"},
+  {id:"command",label:"CommandEncoder", g:"backend", api:0, doc:"review.html#pipeline",
+   desc:"DrawCommand 生成と VkCommandBuffer 記録（系統B、一部ハードコード）。"},
+
+  // pass features
+  {id:"material",label:"Material", g:"pass", api:1, doc:"api.html#material",
+   desc:"BaseMaterialBuilder の Fluent API で PBR マテリアル構築。パス別バリアントを自動生成。"},
+  {id:"shader", label:"Shader Registry", g:"pass", api:1, doc:"api.html#pipeline",
+   desc:"Visus カスタムシェーダ登録 + Vulkan pipeline 生成（SPIR-V 事前コンパイル前提）。"},
+  {id:"gi",     label:"GI (影/AO/Probe)", g:"pass", api:1, doc:"api.html#gi",
+   desc:"GILightingSystem (CSM/SSAO/Probe) ランタイム + GIBakeSystem オフラインベイク。"},
+  {id:"decal",  label:"Decal", g:"pass", api:0, doc:"review.html#decal",
+   desc:"投影デカール。depth から world 復元 + OBB 投影。"},
+  {id:"postprocess",label:"PostProcess", g:"pass", api:1, doc:"api.html#postprocess",
+   desc:"実 Vulkan host-driven チェーン（Bloom/ToneMapping/Vignette/ColorGrading/DoF）。汎用 pass 挿入対応。"},
+
+  // content
+  {id:"text",   label:"Text", g:"content", api:1, doc:"api.html#text",
+   desc:"自前 TTF/OTF パース + 3 描画経路 (atlas / image / SVG)。外部フォントライブラリ非依存。"},
+  {id:"animation",label:"Animation", g:"content", api:1, doc:"api.html#animation",
+   desc:"Skeleton/IK/clip + FBX/BVH importer + 2D/Rive/Lottie/Vector。AnimationSystem が統括。"},
+  {id:"vector", label:"Vector / Rive", g:"content", api:1, doc:"api.html#animation",
+   desc:"Rive Renderer 統合ラッパー（PICTOR_ENABLE_RIVE）。.riv をアートボード/ステートマシンで再生。"},
+
+  // interface
+  {id:"visus",  label:"Visus", g:"iface", api:0, doc:"api.html#pipeline",
+   desc:"ObjectDescriptor 生成の記述子。CUSTOM kind がカスタムシェーダ差込の seam。"},
+  {id:"c_api",  label:"C API", g:"iface", api:1, doc:"api.html#capi",
+   desc:"ABI 安定な C エクスポート。WASM / N-API / Capacitor 等の上位向け窓口。"},
+  {id:"webgl",  label:"WebGL2 Backend", g:"iface", api:1, doc:"api.html#webgl",
+   desc:"Emscripten 向け WebGL2 代替バックエンド。Vulkan と並行・非抽象。"},
+  {id:"ui",     label:"UI", g:"iface", api:0, doc:"api.html",
+   desc:"オーバーレイ等の内部 UI 描画ヘルパ。"},
+];
+
+// type: "flow" = per-frame data flow ; "dep" = dependency / uses
+const LINKS = [
+  // per-frame data flow
+  ["data","scene","flow"],["scene","update","flow"],["update","culling","flow"],
+  ["culling","batch","flow"],["batch","gpu","flow"],["gpu","pipeline","flow"],
+  ["pipeline","command","flow"],
+  ["pipeline","gi","flow"],["pipeline","decal","flow"],["pipeline","postprocess","flow"],
+  // dependencies / uses
+  ["material","batch","dep"],["material","pipeline","dep"],["shader","pipeline","dep"],
+  ["visus","shader","dep"],["visus","core","dep"],
+  ["memory","scene","dep"],["memory","update","dep"],["memory","culling","dep"],
+  ["memory","batch","dep"],["memory","gpu","dep"],
+  ["surface","pipeline","dep"],["surface","postprocess","dep"],["surface","vector","dep"],
+  ["core","data","dep"],["core","scene","dep"],["core","pipeline","dep"],["core","memory","dep"],
+  ["core","surface","dep"],["core","profiler","dep"],["core","gi","dep"],["core","animation","dep"],
+  ["animation","scene","dep"],["animation","data","dep"],["animation","vector","dep"],
+  ["text","data","dep"],["text","material","dep"],
+  ["profiler","pipeline","dep"],
+  ["c_api","core","dep"],["c_api","webgl","dep"],["webgl","scene","dep"],
+  ["gi","pipeline","dep"],
+];
+
+// ── render legend ─────────────────────────────────────────────
+const legendList = document.getElementById("legend-list");
+for (const [k,v] of Object.entries(GROUPS)) {
+  const d = document.createElement("div");
+  d.className = "legend-item"; d.dataset.group = k;
+  d.innerHTML = `<span class="swatch" style="background:${v.c}"></span>${v.label}`;
+  d.onclick = () => highlightGroup(k);
+  legendList.appendChild(d);
+}
+
+// ── force-directed layout (self-contained) ────────────────────
+const W=1000, H=720, svg=document.getElementById("graph");
+const NS="http://www.w3.org/2000/svg";
+const byId = Object.fromEntries(NODES.map(n=>[n.id,n]));
+NODES.forEach(n=>{ n.x=W/2+(Math.random()-.5)*400; n.y=H/2+(Math.random()-.5)*400; n.vx=0; n.vy=0; });
+const adj = {}; NODES.forEach(n=>adj[n.id]=new Set());
+LINKS.forEach(([a,b])=>{ adj[a].add(b); adj[b].add(a); });
+
+const gLinks=document.createElementNS(NS,"g");
+const gNodes=document.createElementNS(NS,"g");
+svg.appendChild(gLinks); svg.appendChild(gNodes);
+
+const linkEls = LINKS.map(([a,b,t])=>{
+  const l=document.createElementNS(NS,"line");
+  l.setAttribute("stroke", t==="flow" ? "#3b6ea5" : "#39414e");
+  l.setAttribute("stroke-width", t==="flow" ? 2 : 1.2);
+  if(t==="dep") l.setAttribute("stroke-dasharray","4 4");
+  l.dataset.a=a; l.dataset.b=b; l.dataset.t=t;
+  gLinks.appendChild(l); return l;
+});
+
+const nodeEls = NODES.map(n=>{
+  const g=document.createElementNS(NS,"g"); g.style.cursor="pointer";
+  const r=n.big?22:(n.api?14:10);
+  const c=document.createElementNS(NS,"circle");
+  c.setAttribute("r",r); c.setAttribute("fill",GROUPS[n.g].c);
+  c.setAttribute("stroke","#0d1117"); c.setAttribute("stroke-width",2);
+  c.setAttribute("opacity", n.api?1:0.7);
+  const t=document.createElementNS(NS,"text");
+  t.textContent=n.label; t.setAttribute("font-size",n.big?13:11);
+  t.setAttribute("fill","#e6edf3"); t.setAttribute("text-anchor","middle");
+  t.setAttribute("dy", r+13); t.setAttribute("paint-order","stroke");
+  t.setAttribute("stroke","#0d1117"); t.setAttribute("stroke-width","3");
+  g.appendChild(c); g.appendChild(t); g.dataset.id=n.id;
+  gNodes.appendChild(g);
+  g.addEventListener("pointerdown", e=>startDrag(e,n));
+  g.addEventListener("mouseenter", ()=>hoverNode(n.id));
+  g.addEventListener("mouseleave", ()=>{ if(!selected) clearHighlight(); });
+  g.addEventListener("click", ()=>selectNode(n.id));
+  n._g=g; n._c=c; n._r=r; return g;
+});
+
+function tick(){
+  // repulsion
+  for(let i=0;i<NODES.length;i++)for(let j=i+1;j<NODES.length;j++){
+    const a=NODES[i],b=NODES[j]; let dx=a.x-b.x,dy=a.y-b.y; let d2=dx*dx+dy*dy||1;
+    const f=2600/d2; const d=Math.sqrt(d2); dx/=d;dy/=d;
+    a.vx+=dx*f;a.vy+=dy*f;b.vx-=dx*f;b.vy-=dy*f;
+  }
+  // springs
+  LINKS.forEach(([ai,bi])=>{
+    const a=byId[ai],b=byId[bi]; let dx=b.x-a.x,dy=b.y-a.y; const d=Math.sqrt(dx*dx+dy*dy)||1;
+    const f=(d-120)*0.02; dx/=d;dy/=d;
+    a.vx+=dx*f;a.vy+=dy*f;b.vx-=dx*f;b.vy-=dy*f;
+  });
+  // center gravity + integrate
+  NODES.forEach(n=>{
+    n.vx+=(W/2-n.x)*0.002; n.vy+=(H/2-n.y)*0.002;
+    n.vx*=0.86; n.vy*=0.86;
+    if(n!==dragging){ n.x+=n.vx; n.y+=n.vy; }
+    n.x=Math.max(40,Math.min(W-40,n.x)); n.y=Math.max(36,Math.min(H-50,n.y));
+    n._g.setAttribute("transform",`translate(${n.x},${n.y})`);
+  });
+  linkEls.forEach(l=>{
+    const a=byId[l.dataset.a],b=byId[l.dataset.b];
+    l.setAttribute("x1",a.x);l.setAttribute("y1",a.y);
+    l.setAttribute("x2",b.x);l.setAttribute("y2",b.y);
+  });
+}
+let frames=0;
+function loop(){ tick(); if(frames++<100000) requestAnimationFrame(loop); }
+loop();
+
+// ── interaction ───────────────────────────────────────────────
+let dragging=null, selected=null;
+function startDrag(e,n){ dragging=n; e.target.setPointerCapture?.(e.pointerId);
+  svg.addEventListener("pointermove",onMove); svg.addEventListener("pointerup",endDrag); }
+function pt(e){ const r=svg.getBoundingClientRect();
+  return [ (e.clientX-r.left)/r.width*W, (e.clientY-r.top)/r.height*H ]; }
+function onMove(e){ if(!dragging)return; const [x,y]=pt(e); dragging.x=x;dragging.y=y;dragging.vx=0;dragging.vy=0; }
+function endDrag(){ dragging=null; svg.removeEventListener("pointermove",onMove); svg.removeEventListener("pointerup",endDrag); }
+
+function setDim(ids){
+  nodeEls.forEach(g=>{ g.style.opacity = (!ids||ids.has(g.dataset.id))?1:0.15; });
+  linkEls.forEach(l=>{ const on=!ids||(ids.has(l.dataset.a)&&ids.has(l.dataset.b));
+    l.style.opacity=on?1:0.06; });
+}
+function hoverNode(id){ const s=new Set([id,...adj[id]]); setDim(s); }
+function clearHighlight(){ setDim(null); }
+function highlightGroup(g){ selected=null; const s=new Set(NODES.filter(n=>n.g===g).map(n=>n.id)); setDim(s);
+  showInfo(null,`グループ: ${GROUPS[g].label}`); }
+
+function selectNode(id){
+  selected=id; const n=byId[id]; const s=new Set([id,...adj[id]]); setDim(s);
+  showInfo(n);
+}
+function showInfo(n,title){
+  const box=document.getElementById("node-info");
+  if(!n){ box.innerHTML=`<div class="nm">${title||""}</div>`; return; }
+  const rel=[...adj[n.id]].map(x=>byId[x].label);
+  box.innerHTML = `<div class="nm" style="color:${GROUPS[n.g].c}">${n.label}`+
+    (n.api?` <span class="pill ok">API</span>`:` <span class="pill info">internal</span>`)+`</div>`+
+    `<p class="small">${n.desc}</p>`+
+    `<div class="node-edge-list"><b>関連:</b> ${rel.join(" · ")}</div>`+
+    `<p><a href="${n.doc}">→ ドキュメントを開く</a></p>`;
+}
+
+document.getElementById("btn-flow").onclick=()=>{
+  selected=null;
+  const flowIds=new Set(); LINKS.forEach(([a,b,t])=>{ if(t==="flow"){flowIds.add(a);flowIds.add(b);} });
+  setDim(flowIds);
+  showInfo(null,"フレームデータフロー: data → scene → update → culling → batch → gpu → pipeline → passes");
+};
+document.getElementById("btn-reset").onclick=()=>{ selected=null; clearHighlight();
+  showInfo(null,"ノードを選択してください"); };
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pictor — Data-Driven Rendering Pipeline Module</title>
+<link rel="stylesheet" href="assets/pictor.css">
+</head>
+<body>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="brand" href="index.html"><span class="logo">Pc</span> Pictor
+      <span class="tag">Data-Driven Rendering Pipeline</span></a>
+    <nav class="links">
+      <a href="index.html" class="active">概要</a>
+      <a href="graph.html">グラフ</a>
+      <a href="api.html">API</a>
+      <a href="review.html">レビュー</a>
+      <a href="https://github.com/ludiars/pictor">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="hero">
+    <h1>Pictor</h1>
+    <p class="sub">ObjectDescriptor を入力に、最適な描画パスを<strong>自動選択</strong>する
+      データ駆動レンダリングパイプライン基盤。C++20 / AVX2 / Vulkan。
+      システムレイヤの最下層に位置するレンダリング基盤モジュール。</p>
+    <div class="badges">
+      <span class="badge">C++20</span>
+      <span class="badge">AVX2 SIMD</span>
+      <span class="badge">Vulkan / WebGL2</span>
+      <span class="badge">Data-Oriented Design</span>
+      <span class="badge">v2.1 · LUDIARS: Pc</span>
+    </div>
+  </div>
+
+  <nav class="grid cols-3" style="margin-bottom:1rem">
+    <a class="card" href="graph.html"><h3>🕸 ドメイン / 機能グラフ</h3>
+      <p class="small muted">サブシステムと機能の関連をインタラクティブに俯瞰</p></a>
+    <a class="card" href="api.html"><h3>📘 API リファレンス</h3>
+      <p class="small muted">公開 API をトグル展開で詳細・パラメータ確認</p></a>
+    <a class="card" href="review.html"><h3>✅ spec ↔ code レビュー</h3>
+      <p class="small muted">設計資料と実装の対応検証結果</p></a>
+  </nav>
+
+  <h2 id="role">サービスの役割</h2>
+  <p>Pictor は、<b>描画オブジェクトの一元管理</b>と<b>最適な描画パイプラインの自動選択</b>を担う
+    レンダリングパイプラインモジュール。consumer（上位アプリ／ゲーム）は、描画したいものを
+    <code>ObjectDescriptor</code> という統一フォーマットで登録するだけでよい。Pictor が内部で
+    Static / Dynamic / GPU-Driven へ分類し、カリング・ソート・バッチング・パス実行までを
+    高効率（DoD）に実行する。</p>
+
+  <div class="grid cols-3">
+    <div class="card"><div class="icon">🎯</div><h3>統一入力</h3>
+      <p class="small">すべての描画対象を <code>ObjectDescriptor</code> で受理。consumer は内部レイアウトを
+        意識しない（境界 API は OOP、内部は DoD）。</p></div>
+    <div class="card"><div class="icon">🧭</div><h3>自動パス選択</h3>
+      <p class="small"><code>PipelineProfile</code> により Forward / Forward+ / Deferred / Hybrid を切替。
+        プロファイルは JSON で外部設定可能。</p></div>
+    <div class="card"><div class="icon">⚙️</div><h3>最下層基盤</h3>
+      <p class="small">Vulkan / GLFW / 標準ライブラリのみに依存。上位ライブラリを取り込まない
+        レイヤ規律を保つ。</p></div>
+  </div>
+
+  <h2 id="features">主な特徴</h2>
+  <div class="grid cols-2">
+    <div class="card"><h3>Data-Oriented Design (DoD)</h3>
+      <p class="small">全オブジェクトデータは構造体でなく、同一インデックスで紐付く並列配列
+        （<b>SoA ストリーム</b>）で保持。hot path は flat array + cache-line 整列
+        （<code>alignas(64)</code>）。scatter（map / 個別 new / pointer chase）を排除。</p></div>
+    <div class="card"><h3>多段カリング</h3>
+      <p class="small">WorldPartition 広域グリッド → FlatBVH（binned SAH + van Emde Boas レイアウト）詳細 →
+        GPU Hi-Z occlusion。CPU 側は外部数学ライブラリ非依存。</p></div>
+    <div class="card"><h3>O(n) バッチング</h3>
+      <p class="small"><code>shaderKey</code> から Radix Sort で draw batch / indirect を生成。
+        実データ移動なし（key-index ペアのみソート）。</p></div>
+    <div class="card"><h3>GPU-Driven パイプライン</h3>
+      <p class="small">compute update → cull → LOD select → indirect compaction。GPU がドローコマンドを生成。</p></div>
+    <div class="card"><h3>グローバルイルミネーション</h3>
+      <p class="small">ランタイム GI（CSM シャドウ / SSAO / Light Probe）と、静的オブジェクトの
+        オフライン GI ベイク（Shadow / AO / Irradiance / Lightmap）。</p></div>
+    <div class="card"><h3>マテリアル & ポストプロセス</h3>
+      <p class="small">Fluent API の PBR マテリアル（パス別バリアント自動生成）。実 Vulkan の
+        host-driven post-process チェーン（Bloom / ToneMapping / Vignette / ColorGrading / DoF）。</p></div>
+    <div class="card"><h3>テキスト & アニメーション</h3>
+      <p class="small">自前 TTF/OTF パース + 3 描画経路（atlas / image / SVG）。
+        Skeleton/IK + FBX/BVH import + 2D/Rive/Lottie/Vector アニメ。</p></div>
+    <div class="card"><h3>マルチバックエンド / 移植性</h3>
+      <p class="small">Vulkan（Win32/X11/XCB/Wayland/macOS/Android）に加え、Emscripten 向け WebGL2 代替
+        バックエンドと、WASM/N-API 向け C ABI エクスポート。</p></div>
+  </div>
+
+  <h2 id="design">設計</h2>
+
+  <h3>3 層パイプライン</h3>
+  <p>レイヤ間のデータ受け渡しは SoA ストリームの参照（ポインタ + count）で行い、コピーを最小化する。</p>
+  <pre><code>┌─────────────────────────────────────────────────────────┐
+│  Front-End Layer (オブジェクト管理)                      │
+│  ObjectClassifier → 分類 → Pool配置 (Static/Dynamic/GPU)│
+└───────────────────────┬─────────────────────────────────┘
+                        │ SoA ストリーム参照
+┌───────────────────────▼─────────────────────────────────┐
+│  Middle Layer (バッチング・ソーティング)                  │
+│  shaderKey読取 → Radix Sort O(n) → RenderBatch生成       │
+└───────────────────────┬─────────────────────────────────┘
+                        │ RenderBatch
+┌───────────────────────▼─────────────────────────────────┐
+│  Back-End Layer (コマンド発行)                            │
+│  PipelineProfile → RenderPass実行順決定 → DrawCommand発行 │
+└─────────────────────────────────────────────────────────┘</code></pre>
+
+  <h3>フレーム実行フロー</h3>
+  <pre><code>data(asset) → scene(SoA store) → update(transform) → culling → batch → gpu(driven)
+            → render passes [ gi(shadow/AO/probe) → decal → post-process ]
+surface / memory / shader / text は横断基盤、webgl は Vulkan と並行の代替バックエンド</code></pre>
+  <ol>
+    <li><b>BeginFrame</b> — GPU Fence 待機、Frame Allocator リセット</li>
+    <li><b>UpdateScheduler</b> — プール種別に応じ CPU並列 / Non-Temporal / GPU Compute を選択</li>
+    <li><b>CullingSystem</b> — 広域 → BVH → GPU Hi-Z の多段カリング</li>
+    <li><b>BatchBuilder</b> — sortKey 生成 → Radix Sort → RenderBatch 構築</li>
+    <li><b>RenderPassScheduler</b> — プロファイルに基づくパス実行と DrawCommand 発行</li>
+    <li><b>EndFrame</b> — GPU submit + present、プロファイラ統計集約</li>
+  </ol>
+
+  <h3>設計原則（OOP 境界 + DoD 内部 + SOLID）</h3>
+  <div class="grid cols-2">
+    <div class="card"><h3>境界は OOP / 内部は DoD</h3>
+      <p class="small">公開 API は class + virtual interface（Handle / Material / RenderPath）で
+        「データ表現の自由度」を保ち、consumer に内部レイアウトを漏らさない。内部実装は SoA の DoD。</p></div>
+    <div class="card"><h3>Open/Closed — Registry で拡張</h3>
+      <p class="small">新しい描画パス / Material kind は既存 switch への case 追加ではなく、
+        継承 + Registry 登録で増やす。</p></div>
+    <div class="card"><h3>Interface Segregation</h3>
+      <p class="small">太い IRenderer ではなく <code>ICuller</code> / <code>IShader</code> /
+        <code>ICustomRenderPass</code> / <code>IBatchPolicy</code> 等に分離。</p></div>
+    <div class="card"><h3>Dependency Inversion</h3>
+      <p class="small">consumer は Pictor の抽象 interface に依存。Vulkan handle / GLFW を直叩きさせず
+        Pictor 内部で wrap。</p></div>
+  </div>
+
+  <div class="callout">
+    <b>正直な系統分離。</b> Pictor の spec は「宣言データ（系統A）」と「実描画（系統B）」を明確に区別し、
+    未配線の領域を誇張せず記述する。詳細は <a href="review.html#pipeline">レビュー: 系統A/系統B の補足</a>。
+  </div>
+
+  <h2 id="quickstart">クイックスタート</h2>
+  <pre><code>#include &lt;pictor/pictor.h&gt;
+
+RendererConfig config;
+config.initial_profile  = "Standard";
+config.profiler_enabled = true;
+
+pictor::PictorRenderer renderer;
+renderer.initialize(config);
+
+// オブジェクト登録
+ObjectId id = renderer.register_object(desc);
+
+// 毎フレーム
+renderer.begin_frame(delta_time);
+renderer.render(camera);
+renderer.end_frame();</code></pre>
+  <p class="small muted">ビルド: <code>cmake -B build</code> → <code>cmake --build build</code>
+    （要 CMake 3.20+ / C++20 / AVX2、Vulkan SDK は GPU 機能に推奨）。
+    用途別ビルドは <code>spec/setup/</code> 参照。</p>
+</main>
+
+<footer>
+  Pictor — Data-Driven Rendering Pipeline Module · このサイトは <code>/docs</code> 配下で GitHub Pages 公開。
+  出典: <code>README.md</code> / <code>spec/</code> / <code>plan.md</code> / <code>include/pictor/</code>。
+</footer>
+</body>
+</html>

--- a/docs/review.html
+++ b/docs/review.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pictor — spec ↔ code 対応レビュー</title>
+<link rel="stylesheet" href="assets/pictor.css">
+</head>
+<body>
+<header class="topnav">
+  <div class="topnav-inner">
+    <a class="brand" href="index.html"><span class="logo">Pc</span> Pictor
+      <span class="tag">Data-Driven Rendering Pipeline</span></a>
+    <nav class="links">
+      <a href="index.html">概要</a>
+      <a href="graph.html">グラフ</a>
+      <a href="api.html">API</a>
+      <a href="review.html" class="active">レビュー</a>
+      <a href="https://github.com/ludiars/pictor">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="hero">
+    <h1>spec ↔ code 対応レビュー</h1>
+    <p class="sub"><code>spec/</code> 配下の設計資料が実際の <code>include/pictor/</code> ・ <code>src/</code>
+      の実装と対応しているかを検証した結果。クラス名・API シグネチャ・構造体・enum・file:line 参照を突合。</p>
+    <div class="badges">
+      <span class="badge">対象: spec/subsystem ×13 + spec/pipeline ×2 + extensibility + setup ×4</span>
+      <span class="badge">検証日: 2026-06</span>
+    </div>
+  </div>
+
+  <div class="callout">
+    <b>総評 — 高い対応度。</b> 検証した 20 件の spec 文書のうち大半が実装と一致しており、
+    file:line 参照も spot-check した範囲で正確。spec は「設計済みだが未配線の領域」（系統A / 系統B）を
+    <em>自覚的かつ正直に</em>区別して記述している点が際立つ。実装と乖離する記述は <b>3 点</b>に留まる
+    （うち機能影響のあるものは Memory の 1 点）。
+  </div>
+
+  <h2>サマリー</h2>
+  <table>
+    <thead><tr><th>spec 文書</th><th>対象実装</th><th>判定</th><th>要点</th></tr></thead>
+    <tbody>
+      <tr><td><code>subsystem/surface.md</code></td><td>surface/</td><td><span class="pill ok">一致</span></td><td>ISurfaceProvider / VulkanContext / NativeWindowHandle すべて対応</td></tr>
+      <tr><td><code>subsystem/memory.md</code></td><td>memory/</td><td><span class="pill warn">要修正</span></td><td>GPU プール数の記述ずれ（5→実 4、<code>allocate_indirect()</code> 不在）</td></tr>
+      <tr><td><code>subsystem/data.md</code></td><td>data/</td><td><span class="pill ok">一致</span></td><td>DataHandler / TextureRegistry / VertexDataUploader / DataQueryAPI 対応</td></tr>
+      <tr><td><code>subsystem/scene.md</code></td><td>scene/</td><td><span class="pill ok">一致</span></td><td>SceneRegistry / ObjectPool の SoA ストリーム対応</td></tr>
+      <tr><td><code>subsystem/update.md</code></td><td>update/</td><td><span class="pill ok">一致</span></td><td>UpdateScheduler の戦略自動選択・JobDispatcher 対応</td></tr>
+      <tr><td><code>subsystem/culling.md</code></td><td>culling/</td><td><span class="pill ok">一致</span></td><td>CullingSystem / FlatBVH / WorldPartition、BVHNode 32B 等まで正確</td></tr>
+      <tr><td><code>subsystem/batch.md</code></td><td>batch/</td><td><span class="pill ok">一致</span></td><td>BatchBuilder / RadixSort 対応</td></tr>
+      <tr><td><code>subsystem/gpu.md</code></td><td>gpu/</td><td><span class="pill ok">一致</span></td><td>GPUDrivenPipeline / GPUBufferManager 対応</td></tr>
+      <tr><td><code>subsystem/shader.md</code></td><td>shader/ · visus/</td><td><span class="pill ok">一致</span></td><td>ShaderRegistry / CustomShaderDef / VertexLayout 対応</td></tr>
+      <tr><td><code>subsystem/gi.md</code></td><td>gi/</td><td><span class="pill ok">一致</span></td><td>GILightingSystem / GIBakeSystem、config 構造体まで対応</td></tr>
+      <tr><td><code>subsystem/decal.md</code></td><td>decal/</td><td><span class="pill info">軽微</span></td><td><code>kMaxDecals=64</code> が公開ヘッダでなく .cpp にある（文書精度のみ）</td></tr>
+      <tr><td><code>subsystem/text.md</code></td><td>text/</td><td><span class="pill ok">一致</span></td><td>FontLoader / 3 描画経路（atlas/image/SVG）対応</td></tr>
+      <tr><td><code>subsystem/webgl.md</code></td><td>webgl/</td><td><span class="pill ok">一致</span></td><td>WebGL2 代替バックエンド対応</td></tr>
+      <tr><td><code>pipeline-profile-config.md</code></td><td>pipeline/</td><td><span class="pill ok">一致</span></td><td>PipelineProfileDef / serializer / loader / 5 preset 対応、系統A/B を明記</td></tr>
+      <tr><td><code>pipeline-system-b-config.md</code></td><td>pipeline/</td><td><span class="pill ok">一致</span></td><td>AttachmentRegistry / RenderPassRegistry / PipelineCompiler / CompiledGraph 対応</td></tr>
+      <tr><td><code>rendering-extensibility-design.md</code></td><td>shader/ postprocess/ profiler/</td><td><span class="pill ok">一致</span></td><td>phase1/2 の実装状況表が実コードと一致</td></tr>
+      <tr><td><code>setup/README · build · build-options · integration</code></td><td>CMakeLists.txt</td><td><span class="pill ok">一致</span></td><td>ビルドオプション・file:line とも正確。C API の未配線も自覚的に記載</td></tr>
+    </tbody>
+  </table>
+
+  <h2>是正提案（3 点）</h2>
+
+  <section id="memory">
+  <h3>1. Memory — GPU プール数の記述ずれ <span class="pill warn">要修正</span></h3>
+  <p><code>spec/subsystem/memory.md</code> は GPU アロケータを「用途別 <b>4+1 プール</b>」とし、表に
+    <code>indirect</code>（16MB / ring / per-frame reset）を 5 番目のプールとして掲げ、暗に
+    <code>allocate_indirect()</code> 相当を期待させる。一方、実装
+    <code>include/pictor/memory/gpu_memory_allocator.h</code> のプールは <b>4 本</b>のみ：</p>
+  <pre><code>// gpu_memory_allocator.h
+GpuAllocation allocate_mesh(...);      Pool mesh_pool_;
+GpuAllocation allocate_ssbo(...);      Pool ssbo_pool_;
+GpuAllocation allocate_instance(...);  Pool instance_pool_;
+GpuAllocation allocate_staging(...);   Pool staging_pool_;
+// allocate_indirect() / indirect_pool_ は存在しない</code></pre>
+  <p>indirect draw buffer は専用プールではなく <code>allocate_ssbo()</code>（SSBO プール）から確保される。
+    なお <code>Config::indirect_buffer_size = 16MB</code> フィールドだけは残っており、専用プールに
+    結び付いていない。</p>
+  <p><b>提案:</b> spec を実装に合わせ「4 プール（mesh / ssbo / instance / staging）。indirect は SSBO プールから
+    サブアロケート」と訂正するか、逆に実装側へ <code>indirect_pool_</code> + <code>allocate_indirect()</code> を
+    追加して config フィールドと整合させる。前者（ドキュメント訂正）が低リスク。</p>
+  </section>
+
+  <section id="decal">
+  <h3>2. Decal — 定数の配置 <span class="pill info">軽微</span></h3>
+  <p><code>spec/subsystem/decal.md</code> はコンパイル時定数 <code>kMaxDecals = 64</code> に言及するが、
+    実体は公開ヘッダではなく <code>src/decal/decal_system.cpp</code> 内に定義されている。
+    機能上の問題はなく、文書の精度上の指摘に留まる。consumer が上限を参照したい場合は
+    ヘッダへ昇格すると良い。</p>
+  </section>
+
+  <section id="capi">
+  <h3>3. C API — README とビルド設定の不整合 <span class="pill warn">要修正</span></h3>
+  <p><code>README.md</code> はビルドオプション表に <code>PICTOR_BUILD_C_API</code>（C ABI エクスポート）を
+    列挙しているが、<code>CMakeLists.txt</code> には対応する <code>option()</code> もターゲット定義も無い。
+    実体 <code>include/pictor/c_api.h</code> と <code>src/c_api/c_api.cpp</code> は存在するため、
+    <b>「ソースはあるがビルド配線が無い」</b>状態。</p>
+  <p>この乖離は <code>spec/setup/build-options.md</code> が既に正直に注記しており、spec の自己整合性は高い。
+    <b>提案:</b> README から当該行を外すか、CMakeLists に <code>option(PICTOR_BUILD_C_API ...)</code> +
+    <code>pictor_c_api</code> ターゲットを追加して README に合わせる。</p>
+  </section>
+
+  <h2 id="pipeline">系統A / 系統B についての補足</h2>
+  <p>レビューで特筆すべきは、spec が Pictor のレンダリングパイプラインを <b>2 系統</b>に分けて
+    正直に記述している点。これは「誇張しない」設計姿勢の表れであり、レビュー対象としても健全：</p>
+  <div class="grid cols-2">
+    <div class="card">
+      <h3>系統A — 宣言データ</h3>
+      <p class="small"><code>PipelineProfileDef</code>（pass 列 / post_process / shadow / GI / memory 等）。
+        <code>*.profile.json</code> で完全に外部化済み・ツール編集可。プロファイル選択・pass 順序・
+        メモリ/更新/GI/GPU駆動/プロファイラの設定値は実ランタイムに反映される。</p>
+    </div>
+    <div class="card">
+      <h3>系統B — 実描画</h3>
+      <p class="small">実 <code>VkRenderPass</code> チェーン / framebuffer / draw 記録。一部は依然ハードコード。
+        post-process の既存エフェクトのパラメータ・on/off は <code>build_post_process_config()</code>
+        ブリッジ経由で実描画に届く。Phase 3 で scene 側 attachment の汎用化が進行中。</p>
+    </div>
+  </div>
+  <p class="small muted">spec はこの A↔B の「未配線」領域を各所で明示している
+    （例: <code>shader_override</code> / <code>render_targets</code> は構造体に格納されるが scheduler 未消費）。
+    レビュー上、これらは「バグ」ではなく「設計上の段階的実装の宣言」として扱った。</p>
+
+  <h2>検証方法</h2>
+  <ul>
+    <li>各 spec が主張するクラス・interface・struct・enum・file:line 参照を抽出。</li>
+    <li><code>include/pictor/&lt;name&gt;/</code> ・ <code>src/&lt;name&gt;/</code> ・ <code>CMakeLists.txt</code> を
+      Glob/Grep/Read で突合。</li>
+    <li>シンボルの存在・シグネチャ・構造体フィールド・enum 値・既定値・CMake オプション行番号を確認。</li>
+    <li>判定: <span class="pill ok">一致</span> / <span class="pill info">軽微</span> /
+      <span class="pill warn">要修正</span>。</li>
+  </ul>
+</main>
+
+<footer>
+  Pictor ドキュメント · 本レビューは静的コード/spec 突合に基づく（実行・ベンチマークは含まない）。
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## 概要

`spec/` 配下の設計資料が実コード (`include/pictor/`・`src/`・`CMakeLists.txt`) と対応しているかをレビューし、その結果と、サービスの役割/特徴/設計をまとめた **静的ドキュメントサイト**を `/docs` 配下に構築しました。GitHub Pages で公開できます。

## 成果物 (`/docs`)

| ページ | 内容 |
|---|---|
| [`index.html`](docs/index.html) | サービスの**役割 / 特徴 / 設計**の概要 |
| [`graph.html`](docs/graph.html) | **ドメイン / 機能リストとその関連**を示すインタラクティブ**グラフビュー**（フレームデータフロー強調・ノードクリックで詳細）。外部ライブラリ非依存の vanilla JS + SVG force layout |
| [`api.html`](docs/api.html) | **API があるものを別ページに集約**。各エントリを**トグル展開**して詳細・パラメータを確認（検索 / 全展開・折りたたみ対応） |
| [`review.html`](docs/review.html) | **spec↔code 対応レビュー**結果 |

- `docs/assets/pictor.css`（共通スタイル）、`docs/.nojekyll`
- `.github/workflows/pages.yml`（`/docs` を Pages へデプロイ）

## レビュー結果（要約）

検証した 20 件の spec 文書のうち大半が実装と一致。file:line 参照も spot-check した範囲で正確で、spec は「系統A（宣言データ）/ 系統B（実描画）」の未配線領域を**正直に**区別して記述しています。実装と乖離する点は **3 点**：

1. **Memory（要修正）** — `spec/subsystem/memory.md` は GPU を「4+1 プール」とし `indirect` を 5 番目のプール（+ `allocate_indirect()` 相当）として記述するが、実装 (`gpu_memory_allocator.h`) のプールは **4 本**（mesh/ssbo/instance/staging）のみ。indirect draw buffer は SSBO プールから確保され、`indirect_buffer_size` config は専用プールに未結合。
2. **Decal（軽微）** — `kMaxDecals=64` が公開ヘッダでなく `src/decal/decal_system.cpp` に定義（文書精度のみ）。
3. **C API（要修正）** — `README.md` がビルドオプション `PICTOR_BUILD_C_API` を列挙するが `CMakeLists.txt` に `option()`/ターゲットが無い。実体 (`c_api.h` + `src/c_api/c_api.cpp`) はあるため「ソースはあるがビルド未配線」。※ `spec/setup/build-options.md` は既にこれを正直に注記済み。

## 公開方法

リポジトリの **Settings → Pages → Build and deployment → Source: GitHub Actions** を一度有効化すると、`main` への push（`docs/**` 変更時）で `pages.yml` が `/docs` を公開します。公開 URL: `https://ludiars.github.io/pictor/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B12f7cXt7hr3aJBAoZ6Huw

---
_Generated by [Claude Code](https://claude.ai/code/session_01B12f7cXt7hr3aJBAoZ6Huw)_