### PR TITLE
feat(profiler): per-object/batch 性能 & DoD キャッシュ可視化 PerfQueryAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(PICTOR_ENABLE_PROFILER     "Enable built-in profiler"        ON)
 option(PICTOR_USE_LARGE_PAGES     "Enable large page support"       OFF)
 option(PICTOR_BUILD_WEBGL         "Build WebGL2 backend (Emscripten)" OFF)
 option(PICTOR_ENABLE_RIVE         "Enable Rive Renderer integration (requires prebuilt rive-runtime; see cmake/FindRive.cmake)" OFF)
+option(PICTOR_ENABLE_HW_COUNTERS  "Enable Intel PCM hardware counters (perf C 層, requires PICTOR_PCM_DIR)" OFF)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -151,6 +152,11 @@ add_library(pictor STATIC
     src/profiler/data_exporter.cpp
     src/profiler/bitmap_text_renderer.cpp
 
+    # Perf Introspection (per-object/batch 性能 & DoD キャッシュ可視化)
+    src/profiler/perf_query_api.cpp
+    src/profiler/batch_gpu_timer.cpp
+    src/profiler/hardware_counters.cpp
+
     # Surface Abstraction
     # (glfw / android / ios の各プロバイダはプラットフォーム別に
     #  add_library 直後の target_sources で条件付き追加する)
@@ -251,6 +257,28 @@ endif()
 
 if(PICTOR_USE_LARGE_PAGES)
     target_compile_definitions(pictor PRIVATE PICTOR_LARGE_PAGES=1)
+endif()
+
+# ─── Hardware perf counters (perf C 層, optional) ─────────────
+# Intel PCM をプロセス内から呼んで L2/L3 ミス・DRAM 帯域・IPC を読む。
+#   git clone https://github.com/intel/pcm
+#   cmake -DPICTOR_ENABLE_HW_COUNTERS=ON -DPICTOR_PCM_DIR=/path/to/pcm ...
+# 要求されたのに PCM が見つからない場合は黙って無効化せず FATAL_ERROR で落とす
+# (無言フォールバック禁止)。OFF のときは NullHardwareCounterProvider が理由付きで
+# available=false を返す。
+if(PICTOR_ENABLE_HW_COUNTERS)
+    target_compile_definitions(pictor PUBLIC PICTOR_ENABLE_HW_COUNTERS=1)
+    if(NOT DEFINED PICTOR_PCM_DIR)
+        message(FATAL_ERROR "PICTOR_ENABLE_HW_COUNTERS=ON には PICTOR_PCM_DIR (Intel PCM のパス) が必要")
+    endif()
+    target_include_directories(pictor PRIVATE ${PICTOR_PCM_DIR}/src ${PICTOR_PCM_DIR})
+    find_library(PCM_LIB
+        NAMES pcm PCM libpcm
+        HINTS ${PICTOR_PCM_DIR} ${PICTOR_PCM_DIR}/build/lib ${PICTOR_PCM_DIR}/lib)
+    if(NOT PCM_LIB)
+        message(FATAL_ERROR "PICTOR_ENABLE_HW_COUNTERS=ON だが PCM ライブラリが見つからない (PICTOR_PCM_DIR=${PICTOR_PCM_DIR})")
+    endif()
+    target_link_libraries(pictor PUBLIC ${PCM_LIB})
 endif()
 
 # ─── Rive Renderer (optional) ────────────────────────────────

--- a/include/pictor/core/pictor_renderer.h
+++ b/include/pictor/core/pictor_renderer.h
@@ -15,6 +15,7 @@
 #include "pictor/profiler/overlay_renderer.h"
 #include "pictor/profiler/stats_overlay.h"
 #include "pictor/profiler/data_exporter.h"
+#include "pictor/profiler/perf_query_api.h"
 #include "pictor/data/data_handler.h"
 #include "pictor/data/data_query_api.h"
 #include "pictor/gi/gi_lighting_system.h"
@@ -197,6 +198,16 @@ public:
 
     /// Create a read-only query API for external tools/editors
     DataQueryAPI create_query_api() const { return DataQueryAPI(*data_handler_); }
+
+    /// Create a read-only performance / DoD-cache introspection API for external
+    /// tools (Ergo の pictor_perf プラグイン)。レンダーループには触れず、既存
+    /// サブシステムの状態を読むだけ (spec/subsystem/perf_introspection.md)。
+    PerfQueryAPI create_perf_query_api() const {
+        return PerfQueryAPI(*scene_, *memory_, *batch_builder_, *profiler_);
+    }
+
+    /// Read-only access to the batch builder (per-batch 計測 / 適格性照合用)。
+    const BatchBuilder& batch_builder() const { return *batch_builder_; }
 
     // ---- GI Lighting ----
 

--- a/include/pictor/profiler/batch_gpu_timer.h
+++ b/include/pictor/profiler/batch_gpu_timer.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "pictor/core/types.h"
+#include "pictor/profiler/perf_introspection.h"
+#include <vector>
+#include <string>
+
+#ifdef PICTOR_HAS_VULKAN
+#include <vulkan/vulkan.h>
+#endif
+
+namespace pictor {
+
+class GpuTimerManager;
+
+/// per-batch GPU 時間の host-bracket ヘルパ。
+///
+/// Pictor の managed path は大半が host-driven (per-batch の `vkCmdDraw*` は
+/// host が発行する) なので、per-batch GPU 時間は **host がコマンドバッファを
+/// 握る箇所でしか計測できない**。本ヘルパは `GpuTimerManager` を per-batch の
+/// 安定した region 名でラップし、解決済み GPU 時間をバッチメタデータと突き合わせる。
+///
+/// Pictor が draw を出さないバッチの時間をでっち上げることはしない —
+/// 未計測バッチは `gpu_ms = 0` / `measured = false` のまま返す
+/// (spec §1 の正直さ原則 / [[feedback_no_silent_fallback]])。
+///
+/// 使い方 (host = Ergo render layer 等):
+///   BatchGpuTimer bt(renderer.profiler().gpu_timer());
+///   毎フレーム:
+///     bt.begin_frame(batches);            // 今フレームのバッチ列を渡す
+///     for (i, batch) :
+///       bt.begin_batch(i, cmd);
+///       ... そのバッチの draw cmd ...
+///       bt.end_batch(i, cmd);
+///     ... submit ...
+///     auto timings = bt.timings();        // 1〜数フレーム前の解決済み GPU 時間
+class BatchGpuTimer {
+public:
+    explicit BatchGpuTimer(GpuTimerManager& gpu);
+
+    /// フレーム頭で今フレームに描くバッチ列を登録する。region 名のための
+    /// 安定領域を必要数まで伸長し、各バッチのメタ (pool/mesh/count) を控える。
+    void begin_frame(const std::vector<RenderBatch>& batches);
+
+#ifdef PICTOR_HAS_VULKAN
+    /// `cmd` へ実 timestamp を打ってバッチ region を開始/終了する。
+    void begin_batch(uint32_t batch_index, VkCommandBuffer cmd);
+    void end_batch(uint32_t batch_index, VkCommandBuffer cmd);
+#endif
+    /// Vulkan 無効ビルド / ヘッドレス用 (timestamp は書かれない)。
+    void begin_batch(uint32_t batch_index);
+    void end_batch(uint32_t batch_index);
+
+    /// 直近に解決できたフレームの per-batch GPU 時間。
+    /// 各 batch_index につき GpuTimerManager から region 時間を引く
+    /// (`measured` は region 名が結果に存在したかで決まる)。
+    std::vector<BatchTimingInfo> timings() const;
+
+    /// このフレームで bracket 対象として登録したバッチ数。
+    uint32_t batch_count() const { return static_cast<uint32_t>(meta_.size()); }
+
+private:
+    /// batch_index 用の安定した region 名 ("batch_<index>") を返す。
+    const char* region_name_(uint32_t index);
+
+    GpuTimerManager&         gpu_;
+    std::vector<std::string> names_;  // region 名の安定ストレージ (const char* の寿命保証)
+    std::vector<BatchTimingInfo> meta_; // batch_index / pool / mesh / object_count
+};
+
+} // namespace pictor

--- a/include/pictor/profiler/hardware_counters.h
+++ b/include/pictor/profiler/hardware_counters.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+// ============================================================
+// C 層: Hardware performance counters (CPU cache / memory controller).
+//
+// 真の L2/L3 ヒット率・DRAM 帯域・IPC は OS/プロセス内から毎フレーム
+// 安価には取れないため、ベンダ計測基盤 (Intel PCM) を opt-in で配線する。
+// ビルドフラグ PICTOR_ENABLE_HW_COUNTERS=ON かつ PCM 連携時のみ実値。
+// それ以外は NullHardwareCounterProvider が **理由付きで** available=false
+// を返す (無言フォールバック禁止 — [[feedback_no_silent_fallback]])。
+// ============================================================
+
+namespace pictor {
+
+/// 1 サンプル区間 ([begin_sample, end_sample]) のカウンタ差分。
+/// 取得不能なカウンタは負値 (-1.0) / 0 で返す。
+struct HwCounterSample {
+    bool        available = false;
+    std::string source;             // "Intel PCM" / "disabled"
+    std::string unavailable_reason; // available==false のとき理由
+
+    double   l2_hit_ratio = -1.0;   // 0..1
+    double   l3_hit_ratio = -1.0;   // 0..1
+    uint64_t l2_misses    = 0;
+    uint64_t l3_misses    = 0;
+    double   bytes_read_mc  = 0.0;  // メモリコントローラ read バイト
+    double   bytes_write_mc = 0.0;  // メモリコントローラ write バイト
+    double   instructions_retired = 0.0;
+    double   ipc = -1.0;            // instructions per cycle
+};
+
+/// HW カウンタ provider (Open/Closed: backend 追加は派生のみ、consumer 無改変)。
+///   - NullHardwareCounterProvider : 常に available=false + 理由
+///   - PcmHardwareCounterProvider  : Intel PCM (PICTOR_ENABLE_HW_COUNTERS=ON)
+class IHardwareCounterProvider {
+public:
+    virtual ~IHardwareCounterProvider() = default;
+
+    /// 実カウンタが読めるか (host/build 依存)。
+    virtual bool available() const = 0;
+
+    /// backend 名 ("Intel PCM" / "disabled")。
+    virtual const char* source() const = 0;
+
+    /// 取得不能時の理由 (available()==true なら空)。
+    virtual const char* unavailable_reason() const = 0;
+
+    /// 計測区間の開始 (カウンタ状態をラッチ)。
+    virtual void begin_sample() = 0;
+
+    /// 計測区間の終了 — begin_sample からの差分を返す。
+    virtual HwCounterSample end_sample() = 0;
+};
+
+/// Factory — PICTOR_ENABLE_HW_COUNTERS かつ host 対応時は PCM-backed を、
+/// それ以外は理由付き null provider を返す (決して無言で偽値を返さない)。
+std::unique_ptr<IHardwareCounterProvider> create_hardware_counter_provider();
+
+} // namespace pictor

--- a/include/pictor/profiler/perf_introspection.h
+++ b/include/pictor/profiler/perf_introspection.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "pictor/core/types.h"
+#include <cstdint>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+// ============================================================
+// Perf Introspection — read-only data structures returned by
+// PerfQueryAPI (spec/subsystem/perf_introspection.md).
+//
+// 純データのみ。Vulkan / 内部クラスに依存しない (境界 API は OOP、
+// consumer に内部 layout を漏らさない — Pictor CLAUDE.md)。
+// ============================================================
+
+namespace pictor {
+
+// ------------------------------------------------------------
+// A. Memory layout / cache-efficiency (構造的)
+// ------------------------------------------------------------
+
+/// 1 本の SoA stream の物理レイアウト・スナップショット。
+struct StreamLayoutInfo {
+    std::string name;                   // "bounds", "transforms", ...
+    std::string group;                  // "A:culling" / "B:sort" / "C:transform" / "D:meta" / "id"
+    PoolType    pool          = PoolType::DYNAMIC;
+
+    size_t      element_size  = 0;      // bytes / element
+    size_t      element_count = 0;      // live elements
+    size_t      capacity_elements = 0;  // reserved elements
+    size_t      used_bytes    = 0;      // element_size * element_count
+    size_t      capacity_bytes = 0;     // element_size * capacity_elements
+
+    // 先頭ポインタのアライメント (PoolAllocator は 64B 保証 — その裏取り用)。
+    uintptr_t   base_address  = 0;
+    size_t      base_alignment = 0;     // base_address を割り切る最大 2^k (4096 で頭打ち)
+    bool        base_cache_aligned = false;  // base_address % 64 == 0
+
+    // キャッシュライン充填特性。
+    bool        element_straddles_line = false; // 64 % element_size != 0 → 要素がライン跨ぎ
+    size_t      cache_lines_touched = 0;        // ceil(used_bytes / 64)
+    double      line_utilization_pct = 0.0;     // used_bytes / (cache_lines_touched*64) * 100
+    double      elements_per_line = 0.0;        // 64.0 / element_size
+};
+
+/// 1 つの ObjectPool の集計レイアウト。
+struct PoolLayoutInfo {
+    PoolType pool          = PoolType::DYNAMIC;
+    uint32_t object_count  = 0;
+    size_t   live_bytes    = 0;   // Σ stream.used_bytes
+    size_t   reserved_bytes = 0;  // Σ stream.capacity_bytes
+    std::vector<StreamLayoutInfo> streams;
+};
+
+/// コンパイル時 DoD 不変条件を UI へそのまま供給するためのレコード
+/// (編集者が sizeof を再導出しないで済むように)。
+struct DoDInvariant {
+    std::string name;       // "float4x4", "AABB", "PICTOR_CACHE_LINE_SIZE"
+    size_t      actual   = 0;
+    size_t      expected = 0;
+    bool        ok       = false;
+    std::string note;
+};
+
+struct MemoryLayoutReport {
+    size_t cache_line_size = 0;
+    std::vector<PoolLayoutInfo> pools;
+
+    // アロケータ断片化 (reallocate_array は旧配列を解放しないため死にバイトが溜まる)。
+    size_t pool_allocator_total_bytes = 0;  // PoolAllocator::total_allocated()
+    size_t soa_reserved_bytes = 0;          // Σ 全 stream の capacity_bytes (現生存分)
+    size_t soa_used_bytes     = 0;          // Σ 全 stream の used_bytes
+    size_t unaccounted_bytes  = 0;          // total - soa_reserved (死に realloc + 非SoA利用)
+    double fragmentation_pct  = 0.0;        // unaccounted / total * 100
+
+    std::vector<DoDInvariant> invariants;
+};
+
+// ------------------------------------------------------------
+// B. Cache traffic model (per-pass)
+// ------------------------------------------------------------
+
+struct CacheTrafficInfo {
+    std::string pass_name;            // "Culling" / "Sort" / "BatchBuild" / "DataUpdate"
+    double      cpu_ms = 0.0;         // 実測 (Profiler FrameStats)
+    size_t      streamed_bytes = 0;   // そのパスが読み書きする stream の element_size*count 合計
+    double      effective_gbps = 0.0; // streamed_bytes / cpu_ms
+    double      line_utilization_pct = 0.0; // touch する stream のライン利用率 (バイト加重平均)
+};
+
+// ------------------------------------------------------------
+// Batch eligibility (per-object → per-batch)
+// ------------------------------------------------------------
+
+/// オブジェクト集合が 1 GPU バッチへ畳めない理由。
+enum class BatchSplitReason : uint8_t {
+    None = 0,            // 単一バッチ — 完全に畳める
+    DifferentMesh,
+    DifferentMaterial,
+    DifferentShader,
+    Transparent,         // 透過は back-to-front ソートで自由に畳めない
+    CustomShader,
+    DifferentPool,
+};
+
+const char* to_string(BatchSplitReason reason);
+
+struct BatchEligibilityGroup {
+    PoolType    pool         = PoolType::DYNAMIC;
+    MeshHandle  mesh         = INVALID_MESH;
+    uint64_t    shader_key   = 0;
+    uint32_t    material_key = 0;
+
+    uint32_t    object_count = 0;
+    uint32_t    actual_batches = 0;   // この集合が生成した RenderBatch 数
+    uint32_t    ideal_batches  = 0;   // 完全に畳めるなら 1
+    bool        gpu_batchable  = false; // MDI / instanced へ畳めるか
+    std::vector<BatchSplitReason> reasons;
+};
+
+struct BatchEligibilityReport {
+    uint32_t total_objects  = 0;
+    uint32_t total_batches  = 0;
+    uint32_t ideal_batches  = 0;          // Σ group.ideal_batches
+    double   batch_efficiency_pct = 0.0;  // ideal/actual * 100 (高いほど良く畳めている)
+    std::vector<BatchEligibilityGroup> groups;
+};
+
+// ------------------------------------------------------------
+// Per-batch timing (host-bracketed GPU time)
+// ------------------------------------------------------------
+
+struct BatchTimingInfo {
+    uint32_t   batch_index  = 0;
+    PoolType   pool         = PoolType::DYNAMIC;
+    MeshHandle mesh         = INVALID_MESH;
+    uint32_t   object_count = 0;     // RenderBatch::count (instanceCount)
+    double     gpu_ms       = 0.0;   // BatchGpuTimer 計測値 (未計測なら 0)
+    double     per_object_us = 0.0;  // gpu_ms*1000 / object_count
+    bool       measured     = false; // host が bracket して実測したか
+};
+
+} // namespace pictor

--- a/include/pictor/profiler/perf_introspection.h
+++ b/include/pictor/profiler/perf_introspection.h
@@ -94,8 +94,9 @@ struct CacheTrafficInfo {
 // ------------------------------------------------------------
 
 /// オブジェクト集合が 1 GPU バッチへ畳めない理由。
+/// (`None` は X11 `Xlib.h` のマクロと衝突するため `Mergeable` を使う。)
 enum class BatchSplitReason : uint8_t {
-    None = 0,            // 単一バッチ — 完全に畳める
+    Mergeable = 0,       // 単一バッチ — 完全に畳める / 畳む対象なし
     DifferentMesh,
     DifferentMaterial,
     DifferentShader,

--- a/include/pictor/profiler/perf_query_api.h
+++ b/include/pictor/profiler/perf_query_api.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "pictor/profiler/perf_introspection.h"
+#include "pictor/profiler/hardware_counters.h"
+#include <string>
+#include <vector>
+
+namespace pictor {
+
+class SceneRegistry;
+class MemorySubsystem;
+class BatchBuilder;
+class Profiler;
+
+/// 性能 & DoD キャッシュ可視化のための read-only facade
+/// (`DataQueryAPI` と同じパターン — 非破壊・内部 layout 非公開)。
+///
+/// レンダーループには一切触れず、既存サブシステムの状態を**読むだけ**で
+/// A (構造的レイアウト) / B (パス毎キャッシュトラフィック) / バッチ適格性 /
+/// per-batch 時間 / C (HW カウンタ) を集約する。
+///
+/// 構築 (Ergo 等の host 側):
+///   PerfQueryAPI perf = renderer.create_perf_query_api();
+///   std::string json = perf.export_json();
+///
+/// HW カウンタ (C 層) は `set_hardware_counter_provider()` で注入する
+/// (未注入なら hw_counters() は available=false を返す)。
+/// per-batch GPU 時間は `BatchGpuTimer` 側で host が計測した結果を
+/// `set_batch_timings()` で渡す (Pictor が draw を出さないため)。
+class PerfQueryAPI {
+public:
+    PerfQueryAPI(const SceneRegistry& scene,
+                 const MemorySubsystem& memory,
+                 const BatchBuilder& batches,
+                 const Profiler& profiler);
+    ~PerfQueryAPI();
+
+    // ---- A. メモリレイアウト / キャッシュ効率 (構造的) ----
+
+    MemoryLayoutReport memory_layout_report() const;
+
+    // ---- B. パス毎キャッシュトラフィック (モデル推定) ----
+
+    std::vector<CacheTrafficInfo> cache_traffic() const;
+
+    // ---- バッチ適格性 (per-object → per-batch) ----
+
+    BatchEligibilityReport batch_eligibility_report() const;
+
+    // ---- per-batch GPU 時間 ----
+
+    /// host (BatchGpuTimer) が計測した per-batch 時間を取り込む。
+    void set_batch_timings(std::vector<BatchTimingInfo> timings);
+    const std::vector<BatchTimingInfo>& batch_timings() const { return batch_timings_; }
+
+    // ---- C. HW カウンタ ----
+
+    /// HW カウンタ provider を注入 (所有しない)。
+    void set_hardware_counter_provider(IHardwareCounterProvider* provider) {
+        hw_provider_ = provider;
+    }
+    /// 直近の HW カウンタサンプルを取得 (provider 未注入/不可なら理由付き unavailable)。
+    HwCounterSample hw_counters() const;
+
+    // ---- JSON export (Ergo plugin 契約 — spec §5) ----
+
+    std::string export_json() const;
+    std::string export_memory_json() const;
+    std::string export_batches_json() const;
+
+private:
+    const SceneRegistry&  scene_;
+    const MemorySubsystem& memory_;
+    const BatchBuilder&   batches_;
+    const Profiler&       profiler_;
+
+    IHardwareCounterProvider*  hw_provider_ = nullptr;
+    std::vector<BatchTimingInfo> batch_timings_;
+};
+
+} // namespace pictor

--- a/include/pictor/scene/object_pool.h
+++ b/include/pictor/scene/object_pool.h
@@ -4,6 +4,7 @@
 #include "pictor/scene/soa_stream.h"
 #include "pictor/memory/pool_allocator.h"
 #include <unordered_map>
+#include <vector>
 
 namespace pictor {
 
@@ -49,6 +50,22 @@ public:
 
     // Stream Group: ID mapping
     SoAStream<ObjectId>&       object_ids()       { return object_ids_; }
+
+    // ---- Introspection (read-only, for perf / cache tooling) ----
+
+    /// 1 本の SoA stream の軽量な物理ビュー (Vulkan 非依存・非所有)。
+    /// perf_query_api がレイアウト / キャッシュ効率を導出するための口。
+    struct StreamView {
+        const char* name         = "";
+        const char* group        = "";   // "A:culling" / "B:sort" / "C:transform" / "D:meta" / "id"
+        size_t      element_size = 0;
+        const void* base         = nullptr;
+        size_t      count        = 0;     // live elements
+        size_t      capacity     = 0;     // reserved elements
+    };
+
+    /// この pool の全 SoA stream を列挙する (レイアウト / キャッシュ introspection 用)。
+    std::vector<StreamView> stream_views() const;
 
     // ---- Properties ----
 

--- a/spec/subsystem/perf_introspection.md
+++ b/spec/subsystem/perf_introspection.md
@@ -1,0 +1,82 @@
+# Perf Introspection — per-object/batch 性能 & DoD キャッシュ可視化
+
+> 対象: `include/pictor/profiler/perf_introspection.h` /
+> `perf_query_api.h` / `hardware_counters.h` / `batch_gpu_timer.h`。
+> consumer は Ergo の `pictor_perf` プラグイン (web)。
+
+## 1. 目的と重視点 (RULE_CODE 第 I 部)
+
+Ergo から Pictor を **per-object / per-batch** で性能観測し、かつ
+**DoD のメモリアライメントが効いているか / キャッシュ効率が落ちていないか**
+を視認可能にする。Pictor は最下層なので上位 (Ergo) を取り込まず
+([[feedback_pictor_no_upper_dep]])、`DataQueryAPI` と同じ **read-only query API**
+パターンで「内部 layout を漏らさず観測値だけ返す」(境界 API は OOP)。
+
+重視点:
+1. **正直さ (無言フォールバック禁止 [[feedback_no_silent_fallback]])** — 計測できない値を
+   でっち上げない。per-batch GPU 時間は Pictor が draw を発行しない host-driven 経路では
+   `gpu_ms = 0` のまま返し「未計測」と明示する。HW カウンタは取得不能なら
+   `available=false` + 理由文字列を返す。
+2. **hot path を汚さない** — 観測 API は既存状態 (pools / Profiler / BatchBuilder /
+   allocator stats) を**読むだけ**。レンダーループに分岐を増やさない。
+3. **DoD 不変条件を機械で見せる** — `sizeof(float4x4)==64` 等を `DoDInvariant` として
+   そのまま UI へ供給し、編集者が再導出しなくて済む。
+
+## 2. 三層のキャッシュ可視化
+
+| 層 | 何を見るか | 取得方法 | HW 依存 |
+|---|---|---|---|
+| **A 構造的** | stream 毎の要素サイズ / 先頭ptr アライメント / used・capacity / **キャッシュライン跨ぎ** / ライン利用率 / アロケータ断片化 | `MemoryLayoutReport` (pools/allocator を走査) | なし |
+| **B モデル推定** | パス毎の streamed bytes と実測 ms から **実効帯域 GB/s** とライン利用率 | `CacheTrafficInfo` (Profiler FrameStats × stream サイズ) | なし |
+| **C ハードウェア** | 真の L2/L3 ヒット率・DRAM 帯域・IPC | `IHardwareCounterProvider` (Intel PCM) | あり (opt-in) |
+
+A+B は常時・全環境。C は `PICTOR_ENABLE_HW_COUNTERS=ON` かつ PCM 連携時のみ実値、
+それ以外は null provider が理由付きで `available=false`。
+
+## 3. per-object → per-batch の読み替え (設計判断)
+
+Pictor は SoA + バッチ + GPU-driven で、**個別オブジェクトの draw call は存在しない**
+(static=MDI / dynamic=instanced / gpu-driven=GPU 生成)。よって:
+
+- **GPU 時間はバッチ単位** (`BatchTimingInfo`)。1 オブジェクト按分 = `gpu_ms / object_count`。
+- **バッチ適格性** (`BatchEligibilityReport`): `(pool, mesh, shaderKey, materialKey)` で
+  グルーピングし `should_merge` 相当の判定で「N 個 → 1 バッチにできる / M バッチに割れた・
+  その理由 (mesh差/material差/transparent/customShader/pool差)」を出す。これが
+  「GPU でバッチ対象か」の答え。
+- per-batch GPU 時間は `BatchGpuTimer` で **host が draw cmd を bracket** して計測する
+  (Pictor の managed path は host-driven のため。§1 の正直さ原則)。
+
+## 4. API 配置 (SRP / ファイル分割)
+
+| ファイル | 責務 |
+|---|---|
+| `perf_introspection.h` | 戻り値の純データ struct 群 (Vulkan 非依存) |
+| `hardware_counters.h/.cpp` | C 層: `IHardwareCounterProvider` + Null / PCM 実装 + factory |
+| `batch_gpu_timer.h/.cpp` | per-batch GPU 時間の host-bracket ヘルパ (`GpuTimerManager` ラップ) |
+| `perf_query_api.h/.cpp` | A/B/batch を集約する read-only facade `PerfQueryAPI` + JSON export |
+| `scene/object_pool.h` | `StreamView` + `stream_views()` (stream の物理 introspection 口) |
+| `core/pictor_renderer.h` | `create_perf_query_api()` / `batch_builder()` 公開口 |
+
+## 5. JSON 契約 (Ergo plugin が消費)
+
+`PerfQueryAPI::export_json()` が 1 オブジェクトを返す:
+```jsonc
+{
+  "memory": { "cacheLineSize":64, "fragmentationPct":..., "invariants":[...], "pools":[...] },
+  "cacheTraffic": [ {"pass":"Culling","cpuMs":..,"streamedBytes":..,"gbps":..,"lineUtilPct":..} ],
+  "batches": { "totalObjects":.., "totalBatches":.., "batchEfficiencyPct":.., "groups":[...] },
+  "batchTimings": [ {"batchIndex":0,"mesh":..,"objectCount":..,"gpuMs":..,"perObjectUs":..} ],
+  "hwCounters": { "available":false, "source":"disabled", "reason":"PICTOR_ENABLE_HW_COUNTERS=OFF" }
+}
+```
+
+## 6. テスト (RULE_TEST)
+
+`tests/unit_perf_introspection_test.cpp` (headless, Vulkan 不要):
+- stream 先頭 ptr が 64B 整列していること (PoolAllocator 保証の裏取り)。
+- `AABB` ストリームの `element_straddles_line == true` (24B = 64 の非約数) を検出すること。
+- `transforms` (float4x4=64B) は跨がず `elements_per_line==1`、`line_utilization==100%`。
+- 同一 mesh/material の N オブジェクトが 1 グループ・`gpu_batchable==true`、
+  mesh 違いで別グループ・理由 `DifferentMesh` になること。
+- HW counter null provider が `available=false` + 非空 reason を返すこと。
+- DoD invariants (`float4x4==64`, `AABB==24`) が全て `ok==true`。

--- a/src/profiler/batch_gpu_timer.cpp
+++ b/src/profiler/batch_gpu_timer.cpp
@@ -1,0 +1,76 @@
+#include "pictor/profiler/batch_gpu_timer.h"
+#include "pictor/profiler/gpu_timer.h"
+
+#include <cstdio>
+
+namespace pictor {
+
+BatchGpuTimer::BatchGpuTimer(GpuTimerManager& gpu) : gpu_(gpu) {}
+
+const char* BatchGpuTimer::region_name_(uint32_t index) {
+    // 必要数まで安定ストレージを伸長する。GpuTimerManager は const char* を
+    // strcmp 照合するので、寿命さえ保てばポインタ自体は毎フレーム同じでよい。
+    if (index >= names_.size()) {
+        const size_t old = names_.size();
+        names_.resize(index + 1);
+        for (size_t i = old; i < names_.size(); ++i) {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "batch_%zu", i);
+            names_[i] = buf;
+        }
+    }
+    return names_[index].c_str();
+}
+
+void BatchGpuTimer::begin_frame(const std::vector<RenderBatch>& batches) {
+    meta_.clear();
+    meta_.reserve(batches.size());
+    for (uint32_t i = 0; i < batches.size(); ++i) {
+        const RenderBatch& b = batches[i];
+        region_name_(i); // 名前ストレージを確保しておく
+
+        BatchTimingInfo info;
+        info.batch_index  = i;
+        info.mesh         = b.mesh;
+        info.object_count = b.count;
+        // pool は shaderKey の CUSTOM ビット等からは判別できないため、
+        // 呼び出し側が batch を pool 別に渡す運用。ここでは DYNAMIC 既定。
+        info.pool         = PoolType::DYNAMIC;
+        meta_.push_back(info);
+    }
+}
+
+#ifdef PICTOR_HAS_VULKAN
+void BatchGpuTimer::begin_batch(uint32_t batch_index, VkCommandBuffer cmd) {
+    gpu_.begin_region(region_name_(batch_index), cmd);
+}
+
+void BatchGpuTimer::end_batch(uint32_t batch_index, VkCommandBuffer cmd) {
+    gpu_.end_region(region_name_(batch_index), cmd);
+}
+#endif
+
+void BatchGpuTimer::begin_batch(uint32_t batch_index) {
+    gpu_.begin_region(region_name_(batch_index));
+}
+
+void BatchGpuTimer::end_batch(uint32_t batch_index) {
+    gpu_.end_region(region_name_(batch_index));
+}
+
+std::vector<BatchTimingInfo> BatchGpuTimer::timings() const {
+    std::vector<BatchTimingInfo> out = meta_;
+    for (auto& info : out) {
+        // region 名は const ストレージ。const メソッドだが names_ は確保済み。
+        const std::string& name = names_[info.batch_index];
+        const double ms = gpu_.get_region_ms(name.c_str());
+        info.gpu_ms = ms;
+        info.measured = (ms > 0.0);
+        info.per_object_us = (info.object_count > 0)
+            ? (ms * 1000.0) / static_cast<double>(info.object_count)
+            : 0.0;
+    }
+    return out;
+}
+
+} // namespace pictor

--- a/src/profiler/hardware_counters.cpp
+++ b/src/profiler/hardware_counters.cpp
@@ -1,0 +1,132 @@
+#include "pictor/profiler/hardware_counters.h"
+
+// ============================================================
+// C 層 HW カウンタの実装。
+//
+//   - NullHardwareCounterProvider : 常に利用不可 (理由付き)。HW 連携無効ビルドの既定。
+//   - PcmHardwareCounterProvider  : Intel PCM (PICTOR_ENABLE_HW_COUNTERS=ON)。
+//
+// PCM はプロセス内から CPU の L2/L3 ミス・DRAM 帯域・IPC を読む。program()
+// が失敗 (権限不足 / 他プロセスが MSR を専有 / 非対応 CPU) したら、その理由を
+// そのまま乗せて available=false で返す (無言フォールバック禁止)。
+// ============================================================
+
+namespace pictor {
+
+namespace {
+
+/// HW カウンタが使えない場合の正直な provider。理由を必ず返す。
+class NullHardwareCounterProvider final : public IHardwareCounterProvider {
+public:
+    explicit NullHardwareCounterProvider(std::string reason)
+        : reason_(std::move(reason)) {}
+
+    bool available() const override { return false; }
+    const char* source() const override { return "disabled"; }
+    const char* unavailable_reason() const override { return reason_.c_str(); }
+
+    void begin_sample() override {}
+    HwCounterSample end_sample() override {
+        HwCounterSample s;
+        s.available = false;
+        s.source = "disabled";
+        s.unavailable_reason = reason_;
+        return s;
+    }
+
+private:
+    std::string reason_;
+};
+
+} // namespace
+
+#ifdef PICTOR_ENABLE_HW_COUNTERS
+
+} // namespace pictor
+
+#include <cpucounters.h>   // Intel PCM (PICTOR_PCM_DIR で include/link を指す)
+
+namespace pictor {
+
+namespace {
+
+/// Intel PCM-backed provider。program() 成否を握って正直に報告する。
+class PcmHardwareCounterProvider final : public IHardwareCounterProvider {
+public:
+    PcmHardwareCounterProvider() {
+        pcm_ = pcm::PCM::getInstance();
+        const pcm::PCM::ErrorCode status = pcm_->program();
+        switch (status) {
+            case pcm::PCM::Success:
+                ok_ = true;
+                break;
+            case pcm::PCM::MSRAccessDenied:
+                reason_ = "PCM: MSR access denied (要 administrator/権限、または MSR ドライバ未導入)";
+                break;
+            case pcm::PCM::PMUBusy:
+                reason_ = "PCM: PMU busy (他プロセスが性能カウンタを専有中)";
+                break;
+            default:
+                reason_ = "PCM: program() failed (非対応 CPU か初期化失敗)";
+                break;
+        }
+    }
+
+    bool available() const override { return ok_; }
+    const char* source() const override { return "Intel PCM"; }
+    const char* unavailable_reason() const override { return reason_.c_str(); }
+
+    void begin_sample() override {
+        if (!ok_) return;
+        before_ = pcm::getSystemCounterState();
+    }
+
+    HwCounterSample end_sample() override {
+        HwCounterSample s;
+        s.source = "Intel PCM";
+        if (!ok_) {
+            s.available = false;
+            s.unavailable_reason = reason_;
+            return s;
+        }
+        const pcm::SystemCounterState after = pcm::getSystemCounterState();
+        s.available = true;
+        s.l2_hit_ratio = pcm::getL2CacheHitRatio(before_, after);
+        s.l3_hit_ratio = pcm::getL3CacheHitRatio(before_, after);
+        s.l2_misses    = pcm::getL2CacheMisses(before_, after);
+        s.l3_misses    = pcm::getL3CacheMisses(before_, after);
+        s.bytes_read_mc  = pcm::getBytesReadFromMC(before_, after);
+        s.bytes_write_mc = pcm::getBytesWrittenToMC(before_, after);
+        s.instructions_retired = static_cast<double>(pcm::getInstructionsRetired(before_, after));
+        s.ipc = pcm::getIPC(before_, after);
+        return s;
+    }
+
+private:
+    pcm::PCM*                 pcm_ = nullptr;
+    pcm::SystemCounterState   before_{};
+    bool                      ok_  = false;
+    std::string               reason_;
+};
+
+} // namespace
+
+std::unique_ptr<IHardwareCounterProvider> create_hardware_counter_provider() {
+    auto provider = std::make_unique<PcmHardwareCounterProvider>();
+    if (provider->available()) {
+        return provider;
+    }
+    // PCM 初期化に失敗 — null へ落とすが理由は PCM の文言を引き継ぐ。
+    return std::make_unique<NullHardwareCounterProvider>(provider->unavailable_reason());
+}
+
+#else  // PICTOR_ENABLE_HW_COUNTERS
+
+std::unique_ptr<IHardwareCounterProvider> create_hardware_counter_provider() {
+    return std::make_unique<NullHardwareCounterProvider>(
+        "PICTOR_ENABLE_HW_COUNTERS=OFF (HW カウンタ連携は未ビルド)");
+}
+
+#endif // PICTOR_ENABLE_HW_COUNTERS
+
+} // namespace pictor

--- a/src/profiler/perf_query_api.cpp
+++ b/src/profiler/perf_query_api.cpp
@@ -1,0 +1,510 @@
+#include "pictor/profiler/perf_query_api.h"
+
+#include "pictor/scene/scene_registry.h"
+#include "pictor/memory/memory_subsystem.h"
+#include "pictor/batch/batch_builder.h"
+#include "pictor/profiler/profiler.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <sstream>
+
+// Win32 GDI (wingdi.h) は `TRANSPARENT` を #define 1 する。透過的に取り込まれると
+// `ObjectFlags::TRANSPARENT` が `ObjectFlags::1` に化けてビルドが壊れるので外す。
+#ifdef TRANSPARENT
+#undef TRANSPARENT
+#endif
+
+namespace pictor {
+
+// ============================================================
+// 共通ヘルパ
+// ============================================================
+
+const char* to_string(BatchSplitReason reason) {
+    switch (reason) {
+        case BatchSplitReason::None:              return "None";
+        case BatchSplitReason::DifferentMesh:     return "DifferentMesh";
+        case BatchSplitReason::DifferentMaterial: return "DifferentMaterial";
+        case BatchSplitReason::DifferentShader:   return "DifferentShader";
+        case BatchSplitReason::Transparent:       return "Transparent";
+        case BatchSplitReason::CustomShader:      return "CustomShader";
+        case BatchSplitReason::DifferentPool:     return "DifferentPool";
+    }
+    return "Unknown";
+}
+
+namespace {
+
+constexpr size_t kCacheLine = PICTOR_CACHE_LINE_SIZE > 0 ? PICTOR_CACHE_LINE_SIZE : 64;
+
+const char* pool_name(PoolType t) {
+    switch (t) {
+        case PoolType::STATIC:     return "STATIC";
+        case PoolType::DYNAMIC:    return "DYNAMIC";
+        case PoolType::GPU_DRIVEN: return "GPU_DRIVEN";
+    }
+    return "?";
+}
+
+/// アドレスを割り切る最大の 2^k (4096 で頭打ち)。0 アドレスは 0。
+size_t address_alignment(uintptr_t addr) {
+    if (addr == 0) return 0;
+    size_t align = 1;
+    while (align < 4096 && (addr % (align * 2)) == 0) align *= 2;
+    return align;
+}
+
+struct LineMetric {
+    size_t used  = 0;
+    size_t lines = 0;
+    double util  = 0.0; // %
+};
+
+LineMetric line_metric(size_t element_size, size_t count) {
+    LineMetric m;
+    m.used  = element_size * count;
+    m.lines = (m.used + kCacheLine - 1) / kCacheLine;
+    m.util  = m.lines ? (static_cast<double>(m.used) / (m.lines * static_cast<double>(kCacheLine))) * 100.0 : 0.0;
+    return m;
+}
+
+// 簡易 JSON helper -------------------------------------------------
+
+void json_escape(std::ostringstream& os, const std::string& s) {
+    os << '"';
+    for (char c : s) {
+        switch (c) {
+            case '"':  os << "\\\""; break;
+            case '\\': os << "\\\\"; break;
+            case '\n': os << "\\n";  break;
+            case '\t': os << "\\t";  break;
+            default:   os << c;      break;
+        }
+    }
+    os << '"';
+}
+
+void json_num(std::ostringstream& os, double v) {
+    if (std::isnan(v) || std::isinf(v)) { os << "null"; return; }
+    os << v;
+}
+
+} // namespace
+
+// ============================================================
+// 構築 / 破棄
+// ============================================================
+
+PerfQueryAPI::PerfQueryAPI(const SceneRegistry& scene,
+                           const MemorySubsystem& memory,
+                           const BatchBuilder& batches,
+                           const Profiler& profiler)
+    : scene_(scene), memory_(memory), batches_(batches), profiler_(profiler) {}
+
+PerfQueryAPI::~PerfQueryAPI() = default;
+
+// ============================================================
+// A. メモリレイアウト / キャッシュ効率
+// ============================================================
+
+MemoryLayoutReport PerfQueryAPI::memory_layout_report() const {
+    MemoryLayoutReport report;
+    report.cache_line_size = kCacheLine;
+
+    const std::array<PoolType, 3> pools = {
+        PoolType::STATIC, PoolType::DYNAMIC, PoolType::GPU_DRIVEN
+    };
+
+    size_t soa_reserved = 0;
+    size_t soa_used = 0;
+
+    for (PoolType pt : pools) {
+        const ObjectPool& pool = scene_.pool(pt);
+        PoolLayoutInfo pinfo;
+        pinfo.pool = pt;
+        pinfo.object_count = pool.count();
+
+        for (const auto& sv : pool.stream_views()) {
+            StreamLayoutInfo s;
+            s.name              = sv.name;
+            s.group             = sv.group;
+            s.pool              = pt;
+            s.element_size      = sv.element_size;
+            s.element_count     = sv.count;
+            s.capacity_elements = sv.capacity;
+            s.used_bytes        = sv.element_size * sv.count;
+            s.capacity_bytes    = sv.element_size * sv.capacity;
+
+            s.base_address       = reinterpret_cast<uintptr_t>(sv.base);
+            s.base_alignment     = address_alignment(s.base_address);
+            s.base_cache_aligned = (s.base_address != 0) && (s.base_address % kCacheLine == 0);
+
+            // 要素がキャッシュラインを跨ぐ = 要素サイズが 64 の約数でない
+            // (例: AABB=24B)。約数なら 1 要素は必ず 1 ライン内に収まる。
+            s.element_straddles_line =
+                (sv.element_size != 0) && (kCacheLine % sv.element_size != 0)
+                && (sv.element_size < kCacheLine);
+            // 64 の倍数要素 (例 float4x4=64) も「跨がない」(整列している)。
+            if (sv.element_size != 0 && sv.element_size % kCacheLine == 0) {
+                s.element_straddles_line = false;
+            }
+
+            const LineMetric lm = line_metric(sv.element_size, sv.count);
+            s.cache_lines_touched  = lm.lines;
+            s.line_utilization_pct = lm.util;
+            s.elements_per_line    = sv.element_size ? static_cast<double>(kCacheLine) / sv.element_size : 0.0;
+
+            pinfo.live_bytes     += s.used_bytes;
+            pinfo.reserved_bytes += s.capacity_bytes;
+            soa_used     += s.used_bytes;
+            soa_reserved += s.capacity_bytes;
+
+            pinfo.streams.push_back(std::move(s));
+        }
+        report.pools.push_back(std::move(pinfo));
+    }
+
+    // アロケータ断片化 — reallocate_array が旧配列を解放しないため、
+    // total_allocated は現生存 SoA reserved を上回る (死にバイト + 非 SoA 利用)。
+    const MemorySubsystem::Stats mstats = memory_.get_stats();
+    report.pool_allocator_total_bytes = mstats.pool_allocated;
+    report.soa_reserved_bytes = soa_reserved;
+    report.soa_used_bytes     = soa_used;
+    report.unaccounted_bytes  = (mstats.pool_allocated > soa_reserved)
+        ? (mstats.pool_allocated - soa_reserved) : 0;
+    report.fragmentation_pct  = mstats.pool_allocated
+        ? (static_cast<double>(report.unaccounted_bytes) / mstats.pool_allocated) * 100.0
+        : 0.0;
+
+    // DoD 不変条件 (コンパイル時の事実を UI へそのまま供給)。
+    auto inv = [](const char* name, size_t actual, size_t expected, const char* note) {
+        DoDInvariant d;
+        d.name = name; d.actual = actual; d.expected = expected;
+        d.ok = (actual == expected); d.note = note;
+        return d;
+    };
+    report.invariants.push_back(inv("float4x4", sizeof(float4x4), 64,
+        "1 transform = 1 cache line (alignas(64))"));
+    report.invariants.push_back(inv("AABB", sizeof(AABB), 24,
+        "tight-pack。24B は 64 の非約数 → bounds stream は要素ライン跨ぎあり"));
+    report.invariants.push_back(inv("float3", sizeof(float3), 12,
+        "12B tight-pack (SIMD 整列ではない)"));
+    report.invariants.push_back(inv("PICTOR_CACHE_LINE_SIZE", kCacheLine, 64,
+        "x86/x64・Apple Silicon は 64。-D で上書き可"));
+
+    return report;
+}
+
+// ============================================================
+// B. パス毎キャッシュトラフィック (モデル推定)
+// ============================================================
+
+std::vector<CacheTrafficInfo> PerfQueryAPI::cache_traffic() const {
+    const FrameStats& fs = profiler_.get_frame_stats();
+
+    const uint32_t total =
+        scene_.static_pool().count() +
+        scene_.dynamic_pool().count() +
+        scene_.gpu_driven_pool().count();
+    const uint32_t dyn = scene_.dynamic_pool().count();
+
+    // 各パスが触る stream の要素サイズ合計 × 対象オブジェクト数。
+    struct PassDef {
+        const char* name;
+        double      cpu_ms;
+        size_t      bytes_per_object;  // そのパスが読み書きする stream の要素サイズ和
+        uint32_t    object_count;
+    };
+
+    const std::array<PassDef, 4> passes = {{
+        // DataUpdate: transforms (read+write) + prev_transforms (write)
+        {"DataUpdate", fs.data_update_ms, sizeof(float4x4) * 2, dyn},
+        // Culling: bounds (read) + visibility_flags (write)
+        {"Culling", fs.culling_ms, sizeof(AABB) + sizeof(uint8_t), total},
+        // Sort: shader_keys + sort_keys (read/write) + index (uint32)
+        {"Sort", fs.sort_ms, sizeof(uint64_t) * 2 + sizeof(uint32_t), total},
+        // BatchBuild: shader_keys + material_keys + mesh_handles (read)
+        {"BatchBuild", fs.batch_build_ms,
+            sizeof(uint64_t) + sizeof(uint32_t) + sizeof(MeshHandle), total},
+    }};
+
+    std::vector<CacheTrafficInfo> out;
+    out.reserve(passes.size());
+    for (const auto& p : passes) {
+        CacheTrafficInfo c;
+        c.pass_name      = p.name;
+        c.cpu_ms         = p.cpu_ms;
+        c.streamed_bytes = p.bytes_per_object * p.object_count;
+        // 実効帯域 = bytes / 秒。cpu_ms が 0 (未計測) なら 0。
+        c.effective_gbps = (p.cpu_ms > 0.0)
+            ? (static_cast<double>(c.streamed_bytes) / (p.cpu_ms / 1000.0)) / 1.0e9
+            : 0.0;
+        // SoA は基本詰まっているのでライン利用率はパス全体の bytes から概算。
+        const LineMetric lm = line_metric(1, c.streamed_bytes); // 1B 要素換算 = 連続バイト
+        c.line_utilization_pct = lm.util;
+        out.push_back(std::move(c));
+    }
+    return out;
+}
+
+// ============================================================
+// バッチ適格性 (per-object → per-batch)
+// ============================================================
+
+BatchEligibilityReport PerfQueryAPI::batch_eligibility_report() const {
+    BatchEligibilityReport report;
+
+    // (pool, mesh, shaderKey, materialKey) でグルーピング。
+    struct Key {
+        PoolType pool; MeshHandle mesh; uint64_t shader; uint32_t material;
+        bool operator<(const Key& o) const {
+            if (pool != o.pool) return pool < o.pool;
+            if (mesh != o.mesh) return mesh < o.mesh;
+            if (shader != o.shader) return shader < o.shader;
+            return material < o.material;
+        }
+    };
+    struct Agg {
+        uint32_t count = 0;
+        bool any_transparent = false;
+        bool any_custom = false;
+    };
+    std::map<Key, Agg> groups;
+
+    const std::array<PoolType, 3> pools = {
+        PoolType::STATIC, PoolType::DYNAMIC, PoolType::GPU_DRIVEN
+    };
+    for (PoolType pt : pools) {
+        const ObjectPool& pool = scene_.pool(pt);
+        const uint32_t n = pool.count();
+        const auto& meshes    = pool.mesh_handles();
+        const auto& shaders   = pool.shader_keys();
+        const auto& materials = pool.material_keys();
+        const auto& flags     = pool.flags();
+        for (uint32_t i = 0; i < n; ++i) {
+            Key k{pt, meshes[i], shaders[i], materials[i]};
+            Agg& a = groups[k];
+            a.count++;
+            if (flags[i] & ObjectFlags::TRANSPARENT) a.any_transparent = true;
+            if (ShaderKey::is_custom(shaders[i]))     a.any_custom = true;
+        }
+    }
+
+    // 実バッチ数を (mesh, shaderKey, materialKey) で照合。
+    auto actual_batches_for = [&](MeshHandle mesh, uint64_t shader, uint32_t material) -> uint32_t {
+        uint32_t c = 0;
+        for (const RenderBatch& b : batches_.batches()) {
+            if (b.mesh == mesh && b.shaderKey == shader && b.materialKey == material) c++;
+        }
+        return c;
+    };
+
+    uint32_t total_objects = 0;
+    uint32_t ideal_total = 0;
+    for (const auto& [k, a] : groups) {
+        BatchEligibilityGroup g;
+        g.pool         = k.pool;
+        g.mesh         = k.mesh;
+        g.shader_key   = k.shader;
+        g.material_key = k.material;
+        g.object_count = a.count;
+        g.actual_batches = actual_batches_for(k.mesh, k.shader, k.material);
+
+        // ideal: 単体なら 1、透過は順序制約で畳めない (= object_count)、それ以外は 1。
+        if (a.count <= 1) {
+            g.ideal_batches = a.count;
+            g.gpu_batchable = false;
+            g.reasons.push_back(BatchSplitReason::None);
+        } else if (a.any_transparent) {
+            g.ideal_batches = a.count;
+            g.gpu_batchable = false;
+            g.reasons.push_back(BatchSplitReason::Transparent);
+        } else {
+            g.ideal_batches = 1;
+            g.gpu_batchable = true;
+            if (a.any_custom) g.reasons.push_back(BatchSplitReason::CustomShader);
+            else              g.reasons.push_back(BatchSplitReason::None);
+        }
+
+        total_objects += a.count;
+        ideal_total   += g.ideal_batches;
+        report.groups.push_back(std::move(g));
+    }
+
+    report.total_objects = total_objects;
+    report.total_batches = static_cast<uint32_t>(batches_.batches().size());
+    report.ideal_batches = ideal_total;
+    report.batch_efficiency_pct = report.total_batches
+        ? (static_cast<double>(ideal_total) / report.total_batches) * 100.0
+        : 0.0;
+
+    return report;
+}
+
+// ============================================================
+// per-batch GPU 時間 / HW カウンタ
+// ============================================================
+
+void PerfQueryAPI::set_batch_timings(std::vector<BatchTimingInfo> timings) {
+    batch_timings_ = std::move(timings);
+}
+
+HwCounterSample PerfQueryAPI::hw_counters() const {
+    if (!hw_provider_) {
+        HwCounterSample s;
+        s.available = false;
+        s.source = "disabled";
+        s.unavailable_reason = "HW counter provider 未注入 (set_hardware_counter_provider)";
+        return s;
+    }
+    hw_provider_->begin_sample();
+    return hw_provider_->end_sample();
+}
+
+// ============================================================
+// JSON export (spec §5 契約)
+// ============================================================
+
+std::string PerfQueryAPI::export_memory_json() const {
+    const MemoryLayoutReport r = memory_layout_report();
+    std::ostringstream os;
+    os << "{";
+    os << "\"cacheLineSize\":" << r.cache_line_size;
+    os << ",\"poolAllocatorTotalBytes\":" << r.pool_allocator_total_bytes;
+    os << ",\"soaReservedBytes\":" << r.soa_reserved_bytes;
+    os << ",\"soaUsedBytes\":" << r.soa_used_bytes;
+    os << ",\"unaccountedBytes\":" << r.unaccounted_bytes;
+    os << ",\"fragmentationPct\":"; json_num(os, r.fragmentation_pct);
+
+    os << ",\"invariants\":[";
+    for (size_t i = 0; i < r.invariants.size(); ++i) {
+        const auto& d = r.invariants[i];
+        if (i) os << ",";
+        os << "{\"name\":"; json_escape(os, d.name);
+        os << ",\"actual\":" << d.actual << ",\"expected\":" << d.expected
+           << ",\"ok\":" << (d.ok ? "true" : "false")
+           << ",\"note\":"; json_escape(os, d.note); os << "}";
+    }
+    os << "]";
+
+    os << ",\"pools\":[";
+    for (size_t pi = 0; pi < r.pools.size(); ++pi) {
+        const auto& p = r.pools[pi];
+        if (pi) os << ",";
+        os << "{\"pool\":\"" << pool_name(p.pool) << "\""
+           << ",\"objectCount\":" << p.object_count
+           << ",\"liveBytes\":" << p.live_bytes
+           << ",\"reservedBytes\":" << p.reserved_bytes
+           << ",\"streams\":[";
+        for (size_t si = 0; si < p.streams.size(); ++si) {
+            const auto& s = p.streams[si];
+            if (si) os << ",";
+            os << "{\"name\":"; json_escape(os, s.name);
+            os << ",\"group\":"; json_escape(os, s.group);
+            os << ",\"elementSize\":" << s.element_size
+               << ",\"elementCount\":" << s.element_count
+               << ",\"usedBytes\":" << s.used_bytes
+               << ",\"capacityBytes\":" << s.capacity_bytes
+               << ",\"baseAlignment\":" << s.base_alignment
+               << ",\"baseCacheAligned\":" << (s.base_cache_aligned ? "true" : "false")
+               << ",\"straddlesLine\":" << (s.element_straddles_line ? "true" : "false")
+               << ",\"cacheLinesTouched\":" << s.cache_lines_touched
+               << ",\"lineUtilizationPct\":"; json_num(os, s.line_utilization_pct);
+            os << ",\"elementsPerLine\":"; json_num(os, s.elements_per_line);
+            os << "}";
+        }
+        os << "]}";
+    }
+    os << "]";
+    os << "}";
+    return os.str();
+}
+
+std::string PerfQueryAPI::export_batches_json() const {
+    const BatchEligibilityReport r = batch_eligibility_report();
+    std::ostringstream os;
+    os << "{";
+    os << "\"totalObjects\":" << r.total_objects
+       << ",\"totalBatches\":" << r.total_batches
+       << ",\"idealBatches\":" << r.ideal_batches
+       << ",\"batchEfficiencyPct\":"; json_num(os, r.batch_efficiency_pct);
+    os << ",\"groups\":[";
+    for (size_t i = 0; i < r.groups.size(); ++i) {
+        const auto& g = r.groups[i];
+        if (i) os << ",";
+        os << "{\"pool\":\"" << pool_name(g.pool) << "\""
+           << ",\"mesh\":" << g.mesh
+           << ",\"shaderKey\":" << g.shader_key
+           << ",\"materialKey\":" << g.material_key
+           << ",\"objectCount\":" << g.object_count
+           << ",\"actualBatches\":" << g.actual_batches
+           << ",\"idealBatches\":" << g.ideal_batches
+           << ",\"gpuBatchable\":" << (g.gpu_batchable ? "true" : "false")
+           << ",\"reasons\":[";
+        for (size_t ri = 0; ri < g.reasons.size(); ++ri) {
+            if (ri) os << ",";
+            os << "\"" << to_string(g.reasons[ri]) << "\"";
+        }
+        os << "]}";
+    }
+    os << "]}";
+    return os.str();
+}
+
+std::string PerfQueryAPI::export_json() const {
+    std::ostringstream os;
+    os << "{";
+    os << "\"memory\":" << export_memory_json();
+
+    os << ",\"cacheTraffic\":[";
+    const auto traffic = cache_traffic();
+    for (size_t i = 0; i < traffic.size(); ++i) {
+        const auto& c = traffic[i];
+        if (i) os << ",";
+        os << "{\"pass\":"; json_escape(os, c.pass_name);
+        os << ",\"cpuMs\":"; json_num(os, c.cpu_ms);
+        os << ",\"streamedBytes\":" << c.streamed_bytes;
+        os << ",\"gbps\":"; json_num(os, c.effective_gbps);
+        os << ",\"lineUtilPct\":"; json_num(os, c.line_utilization_pct);
+        os << "}";
+    }
+    os << "]";
+
+    os << ",\"batches\":" << export_batches_json();
+
+    os << ",\"batchTimings\":[";
+    for (size_t i = 0; i < batch_timings_.size(); ++i) {
+        const auto& t = batch_timings_[i];
+        if (i) os << ",";
+        os << "{\"batchIndex\":" << t.batch_index
+           << ",\"pool\":\"" << pool_name(t.pool) << "\""
+           << ",\"mesh\":" << t.mesh
+           << ",\"objectCount\":" << t.object_count
+           << ",\"gpuMs\":"; json_num(os, t.gpu_ms);
+        os << ",\"perObjectUs\":"; json_num(os, t.per_object_us);
+        os << ",\"measured\":" << (t.measured ? "true" : "false") << "}";
+    }
+    os << "]";
+
+    const HwCounterSample hw = hw_counters();
+    os << ",\"hwCounters\":{"
+       << "\"available\":" << (hw.available ? "true" : "false")
+       << ",\"source\":"; json_escape(os, hw.source);
+    os << ",\"reason\":"; json_escape(os, hw.unavailable_reason);
+    os << ",\"l2HitRatio\":"; json_num(os, hw.l2_hit_ratio);
+    os << ",\"l3HitRatio\":"; json_num(os, hw.l3_hit_ratio);
+    os << ",\"l2Misses\":" << hw.l2_misses
+       << ",\"l3Misses\":" << hw.l3_misses
+       << ",\"bytesReadMC\":"; json_num(os, hw.bytes_read_mc);
+    os << ",\"bytesWriteMC\":"; json_num(os, hw.bytes_write_mc);
+    os << ",\"ipc\":"; json_num(os, hw.ipc);
+    os << "}";
+
+    os << "}";
+    return os.str();
+}
+
+} // namespace pictor

--- a/src/profiler/perf_query_api.cpp
+++ b/src/profiler/perf_query_api.cpp
@@ -25,7 +25,7 @@ namespace pictor {
 
 const char* to_string(BatchSplitReason reason) {
     switch (reason) {
-        case BatchSplitReason::None:              return "None";
+        case BatchSplitReason::Mergeable:         return "Mergeable";
         case BatchSplitReason::DifferentMesh:     return "DifferentMesh";
         case BatchSplitReason::DifferentMaterial: return "DifferentMaterial";
         case BatchSplitReason::DifferentShader:   return "DifferentShader";
@@ -317,7 +317,7 @@ BatchEligibilityReport PerfQueryAPI::batch_eligibility_report() const {
         if (a.count <= 1) {
             g.ideal_batches = a.count;
             g.gpu_batchable = false;
-            g.reasons.push_back(BatchSplitReason::None);
+            g.reasons.push_back(BatchSplitReason::Mergeable);
         } else if (a.any_transparent) {
             g.ideal_batches = a.count;
             g.gpu_batchable = false;
@@ -326,7 +326,7 @@ BatchEligibilityReport PerfQueryAPI::batch_eligibility_report() const {
             g.ideal_batches = 1;
             g.gpu_batchable = true;
             if (a.any_custom) g.reasons.push_back(BatchSplitReason::CustomShader);
-            else              g.reasons.push_back(BatchSplitReason::None);
+            else              g.reasons.push_back(BatchSplitReason::Mergeable);
         }
 
         total_objects += a.count;

--- a/src/scene/object_pool.cpp
+++ b/src/scene/object_pool.cpp
@@ -1,4 +1,5 @@
 ﻿#include "pictor/scene/object_pool.h"
+#include <type_traits>
 
 namespace pictor {
 
@@ -50,6 +51,43 @@ uint32_t ObjectPool::add(const ObjectDescriptor& desc, ObjectId id) {
     object_ids_.push_back(id);
 
     return index;
+}
+
+std::vector<ObjectPool::StreamView> ObjectPool::stream_views() const {
+    // 各 SoA stream を宣言順 (= アロケータ確保順) に列挙する。
+    // element_size は sizeof(T)、base/count/capacity は stream の現状をそのまま。
+    auto view = [](const char* name, const char* group, auto& s) -> StreamView {
+        using Elem = std::remove_reference_t<decltype(s[0])>;
+        return StreamView{
+            name, group,
+            sizeof(Elem),
+            static_cast<const void*>(s.data()),
+            s.size(),
+            s.capacity()
+        };
+    };
+
+    std::vector<StreamView> out;
+    out.reserve(13);
+    // Group A: Culling (Hot)
+    out.push_back(view("bounds",            "A:culling",   bounds_));
+    out.push_back(view("visibility_flags",  "A:culling",   visibility_flags_));
+    // Group B: Sort/Batch (Hot)
+    out.push_back(view("shader_keys",       "B:sort",      shader_keys_));
+    out.push_back(view("sort_keys",         "B:sort",      sort_keys_));
+    out.push_back(view("material_keys",     "B:sort",      material_keys_));
+    // Group C: Transform (Hot for Dynamic)
+    out.push_back(view("transforms",        "C:transform", transforms_));
+    out.push_back(view("prev_transforms",   "C:transform", prev_transforms_));
+    // Group D: Metadata (Cold)
+    out.push_back(view("mesh_handles",      "D:meta",      mesh_handles_));
+    out.push_back(view("material_handles",  "D:meta",      material_handles_));
+    out.push_back(view("lod_levels",        "D:meta",      lod_levels_));
+    out.push_back(view("flags",             "D:meta",      flags_));
+    out.push_back(view("last_frame_updated","D:meta",      last_frame_updated_));
+    // ID mapping
+    out.push_back(view("object_ids",        "id",          object_ids_));
+    return out;
 }
 
 ObjectId ObjectPool::remove(uint32_t index) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(PICTOR_TESTS
     unit_parser_dos_test
     unit_gpu_ring_flight_test
     unit_gpu_timer_test
+    unit_perf_introspection_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_perf_introspection_test.cpp
+++ b/tests/unit_perf_introspection_test.cpp
@@ -1,0 +1,164 @@
+/// Perf introspection unit test (headless, Vulkan 不要)。
+/// spec/subsystem/perf_introspection.md §6 を裏取りする。
+
+#include "pictor/profiler/perf_query_api.h"
+#include "pictor/profiler/hardware_counters.h"
+#include "pictor/scene/scene_registry.h"
+#include "pictor/memory/memory_subsystem.h"
+#include "pictor/batch/batch_builder.h"
+#include "pictor/profiler/profiler.h"
+#include "test_common.h"
+
+#include <string>
+
+// Win32 GDI (wingdi.h) の `TRANSPARENT` マクロ衝突を外す
+// (ObjectFlags::TRANSPARENT が `::1` に化けるのを防ぐ)。
+#ifdef TRANSPARENT
+#undef TRANSPARENT
+#endif
+
+using namespace pictor;
+using namespace pictor_test;
+
+namespace {
+
+ObjectDescriptor make_obj(MeshHandle mesh, uint32_t material, uint16_t flags) {
+    ObjectDescriptor d;
+    d.mesh        = mesh;
+    d.material    = material;
+    d.materialKey = material;
+    d.shaderKey   = 0;
+    d.flags       = flags;
+    d.bounds      = AABB{ float3{0,0,0}, float3{1,1,1} };
+    return d;
+}
+
+const StreamLayoutInfo* find_stream(const MemoryLayoutReport& r,
+                                    PoolType pool, const std::string& name) {
+    for (const auto& p : r.pools) {
+        if (p.pool != pool) continue;
+        for (const auto& s : p.streams) {
+            if (s.name == name) return &s;
+        }
+    }
+    return nullptr;
+}
+
+} // namespace
+
+int main() {
+    MemorySubsystem memory;
+    SceneRegistry   scene(memory);
+    BatchBuilder    batches(scene);
+    Profiler        profiler;
+
+    // 同一 mesh/material の 4 オブジェクト + 別 mesh 1 + 透過 2
+    // (透過は順序制約で畳めない理由を出すため複数登録する)。
+    for (int i = 0; i < 4; ++i) scene.register_object(make_obj(10, 5, ObjectFlags::DYNAMIC));
+    scene.register_object(make_obj(20, 5, ObjectFlags::DYNAMIC));
+    for (int i = 0; i < 2; ++i)
+        scene.register_object(make_obj(30, 7, ObjectFlags::DYNAMIC | ObjectFlags::TRANSPARENT));
+
+    batches.build(memory.frame_allocator());
+
+    PerfQueryAPI perf(scene, memory, batches, profiler);
+
+    // ---- A. メモリレイアウト ----
+    {
+        const MemoryLayoutReport r = perf.memory_layout_report();
+        PT_ASSERT_OP(r.cache_line_size, ==, 64u, "cache line 64");
+
+        const StreamLayoutInfo* bounds = find_stream(r, PoolType::DYNAMIC, "bounds");
+        PT_ASSERT(bounds != nullptr, "bounds stream present");
+        if (bounds) {
+            // PoolAllocator は 64B 整列を保証する (裏取り)。
+            PT_ASSERT(bounds->base_cache_aligned, "bounds base 64B aligned");
+            PT_ASSERT_OP(bounds->element_size, ==, 24u, "AABB == 24B");
+            // 24B は 64 の非約数 → 要素がキャッシュライン跨ぎ。
+            PT_ASSERT(bounds->element_straddles_line, "AABB straddles cache line");
+        }
+
+        const StreamLayoutInfo* xf = find_stream(r, PoolType::DYNAMIC, "transforms");
+        PT_ASSERT(xf != nullptr, "transforms stream present");
+        if (xf) {
+            PT_ASSERT_OP(xf->element_size, ==, 64u, "float4x4 == 64B");
+            PT_ASSERT(!xf->element_straddles_line, "float4x4 does not straddle");
+            PT_ASSERT(xf->base_cache_aligned, "transforms base 64B aligned");
+            // 64*N は 64 の倍数 → 100% 利用。
+            PT_ASSERT_OP((long long)(xf->line_utilization_pct + 0.5), ==, 100LL,
+                         "transforms line utilization 100%");
+        }
+
+        // 断片化は total >= reserved >= used。
+        PT_ASSERT_OP(r.soa_reserved_bytes, >=, r.soa_used_bytes, "reserved >= used");
+        PT_ASSERT_OP(r.pool_allocator_total_bytes, >=, r.soa_reserved_bytes,
+                     "allocator total >= reserved");
+
+        // DoD 不変条件が全て ok。
+        bool all_ok = !r.invariants.empty();
+        for (const auto& inv : r.invariants) {
+            if (!inv.ok) {
+                std::fprintf(stderr, "  invariant FAIL: %s actual=%zu expected=%zu\n",
+                             inv.name.c_str(), inv.actual, inv.expected);
+                all_ok = false;
+            }
+        }
+        PT_ASSERT(all_ok, "all DoD invariants ok");
+    }
+
+    // ---- バッチ適格性 ----
+    {
+        const BatchEligibilityReport r = perf.batch_eligibility_report();
+        PT_ASSERT_OP(r.total_objects, ==, 7u, "7 objects total");
+        // 期待グループ: (mesh10/mat5) x4, (mesh20/mat5) x1, (mesh30/mat7,透過) x2
+        PT_ASSERT_OP((unsigned)r.groups.size(), ==, 3u, "3 batch groups");
+
+        const BatchEligibilityGroup* g_main = nullptr;
+        const BatchEligibilityGroup* g_trans = nullptr;
+        for (const auto& g : r.groups) {
+            if (g.mesh == 10) g_main = &g;
+            if (g.mesh == 30) g_trans = &g;
+        }
+        PT_ASSERT(g_main != nullptr, "mesh10 group present");
+        if (g_main) {
+            PT_ASSERT_OP(g_main->object_count, ==, 4u, "mesh10 has 4 objects");
+            PT_ASSERT(g_main->gpu_batchable, "mesh10 group is GPU-batchable");
+            PT_ASSERT_OP(g_main->ideal_batches, ==, 1u, "mesh10 ideal = 1 batch");
+        }
+        PT_ASSERT(g_trans != nullptr, "transparent group present");
+        if (g_trans) {
+            PT_ASSERT(!g_trans->gpu_batchable, "transparent group not freely batchable");
+            bool has_reason = false;
+            for (auto rr : g_trans->reasons)
+                if (rr == BatchSplitReason::Transparent) has_reason = true;
+            PT_ASSERT(has_reason, "transparent group reason = Transparent");
+        }
+    }
+
+    // ---- C. HW カウンタ (null provider, 理由付き) ----
+    {
+        const HwCounterSample s = perf.hw_counters();
+        PT_ASSERT(!s.available, "no provider → unavailable");
+        PT_ASSERT(!s.unavailable_reason.empty(), "unavailable reason non-empty");
+
+        auto provider = create_hardware_counter_provider();
+        PT_ASSERT(provider != nullptr, "factory returns a provider");
+        // ビルドフラグ OFF の既定では利用不可だが理由は必ずある。
+        if (provider && !provider->available()) {
+            PT_ASSERT(provider->unavailable_reason()[0] != '\0',
+                      "null provider reports a reason");
+        }
+    }
+
+    // ---- JSON export が妥当な文字列を返す ----
+    {
+        const std::string json = perf.export_json();
+        PT_ASSERT(json.size() > 32, "json non-trivial");
+        PT_ASSERT(json.front() == '{' && json.back() == '}', "json object braces");
+        PT_ASSERT(json.find("\"memory\"") != std::string::npos, "json has memory");
+        PT_ASSERT(json.find("\"batches\"") != std::string::npos, "json has batches");
+        PT_ASSERT(json.find("\"hwCounters\"") != std::string::npos, "json has hwCounters");
+    }
+
+    return report("unit_perf_introspection_test");
+}


### PR DESCRIPTION
@
## 概要

Ergo の Pictor 専用パフォーマンスモニター (`pictor_perf` プラグイン) が消費する
**read-only 性能観測 API** を Pictor へ追加する。`DataQueryAPI` と同じ非破壊
facade パターンで、**レンダーループには一切触れず**既存サブシステムの状態を
読むだけで A/B/C 三層 + バッチ適格性を集約する。

正本設計: `spec/subsystem/perf_introspection.md`

## 何を可視化するか

| 層 | 内容 | API |
|---|---|---|
| **A 構造的** | stream 毎の要素サイズ / 先頭ptr アライメント / used・capacity / **キャッシュライン跨ぎ** / ライン利用率、アロケータ断片化、DoD 不変条件 | `MemoryLayoutReport` |
| **B モデル推定** | パス毎 streamed bytes × 実測 ms → 実効帯域 GB/s | `CacheTrafficInfo` |
| **C ハードウェア** | 真の L2/L3 ヒット率・DRAM 帯域・IPC (Intel PCM) | `IHardwareCounterProvider` |
| **バッチ適格性** | `(pool,mesh,shaderKey,materialKey)` でグルーピングし per-object→per-batch の畳み込み可否と理由 | `BatchEligibilityReport` |
| **per-batch 時間** | host が draw cmd を bracket して計測 | `BatchGpuTimer` |

## 設計判断

- **per-object → per-batch 読み替え**: Pictor は SoA + バッチ + GPU-driven で
  個別オブジェクトの draw call が存在しない。GPU 時間はバッチ単位で測り
  1オブジェクト按分を出す。
- **無言フォールバック禁止**: 計測できない値はでっち上げない。HW カウンタ未対応時は
  理由付き `available=false`。per-batch 時間も host が draw を出さない箇所は
  `measured=false` のまま。CMake も `PICTOR_ENABLE_HW_COUNTERS=ON` で PCM が
  見つからなければ `FATAL_ERROR`。
- **DoD アライメント検証**: `MemoryLayoutReport` が `AABB(24B)` のキャッシュライン
  跨ぎや `reallocate_array` 由来の断片化を実測で surface する
  (static_assert では見えないランタイム実害)。

## 追加 / 変更

- 新規: `profiler/{perf_introspection.h, perf_query_api.h/.cpp, hardware_counters.h/.cpp, batch_gpu_timer.h/.cpp}`
- `ObjectPool::stream_views()` — stream の物理 introspection 口
- `PictorRenderer::create_perf_query_api()` / `batch_builder()`
- CMake: `PICTOR_ENABLE_HW_COUNTERS` オプション (default OFF)

## テスト

`tests/unit_perf_introspection_test` (headless, Vulkan 不要) を追加。
**全 16 テスト green** (Debug)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@