### PR TITLE
feat: マルチアーキ対応 — キャッシュ整列ポータビリティ + UMA メモリ + DX12設計

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 add_library(pictor STATIC
     # Core
     src/core/types.cpp
+    src/core/cache_info.cpp
 
     # Memory Subsystem
     src/memory/frame_allocator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(pictor STATIC
     # Core
     src/core/types.cpp
     src/core/cache_info.cpp
+    src/core/device_memory_profile.cpp
 
     # Memory Subsystem
     src/memory/frame_allocator.cpp

--- a/include/pictor/core/cache_info.h
+++ b/include/pictor/core/cache_info.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "pictor/core/types.h"
+#include <cstddef>
+#include <string>
+
+// ============================================================
+// 実機の CPU キャッシュライン幅を検出する (multi-arch)。
+//
+// alignas はコンパイル時に固定されるため、ビルド時に選んだ
+// PICTOR_CACHE_LINE_SIZE と実機のライン幅がズレても整列自体は変えられない。
+// ここでは実機値を取得し「ビルド想定 vs 実機」を perf モニタで可視化して
+// 誤ビルド (例: 64B 想定バイナリを Apple 128B 機で実行) を検出可能にする。
+//
+// 検出経路:
+//   Windows : GetLogicalProcessorInformation の L1 データ/統合キャッシュ LineSize
+//   Apple   : sysctlbyname("hw.cachelinesize")
+//   Linux/Android : sysconf(_SC_LEVEL1_DCACHE_LINESIZE)
+//                   → 取れなければ /sys の coherency_line_size を読む
+// ============================================================
+
+namespace pictor {
+
+struct CacheLineInfo {
+    size_t      compiled_line_size = PICTOR_CACHE_LINE_SIZE; // ビルド時の想定ライン幅
+    size_t      runtime_line_size  = 0;     // 実機 L1D ライン幅 (0 = 検出不能)
+    bool        matches            = true;  // runtime==0 (不明) または runtime==compiled
+    std::string arch;                        // "x86-64" / "arm64" / "arm64-apple" / ...
+    std::string source;                      // 検出経路名 ("win32-logical-processor" 等)
+};
+
+/// 実機のキャッシュライン情報を取得する。検出不能でも throw せず
+/// runtime_line_size=0 / matches=true (不明扱い) を返す。
+CacheLineInfo query_cache_line_info();
+
+} // namespace pictor

--- a/include/pictor/core/device_memory_profile.h
+++ b/include/pictor/core/device_memory_profile.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// ============================================================
+// 統合GPU (UMA) / ReBAR 判定とアップロード戦略の決定。
+//
+// discrete GPU は VRAM が host から見えないため staging buffer 経由で
+// device-local へコピーする。一方:
+//   - 統合GPU (Integrated, UMA): メモリは CPU/GPU 共有 → staging は無駄な
+//     余計コピー。host-visible device-local へ直接書く (Direct) のが速い。
+//   - discrete + ReBAR: VRAM 全体が host-visible device-local として見える →
+//     大きい host-visible device-local heap があれば Direct を選べる。
+//
+// 判定ロジックは Vulkan 非依存の plain 記述 (DeviceMemoryDesc) を入力に取り、
+// headless で単体テストできる。Vk 型→DeviceMemoryDesc の変換は VulkanContext
+// 側のアダプタが担う (境界 API は OOP / consumer に Vk を漏らさない)。
+// ============================================================
+
+namespace pictor {
+
+enum class GpuKind : uint8_t {
+    Unknown = 0,
+    Discrete,     // 専用 VRAM
+    Integrated,   // UMA (CPU と共有)
+    Virtual,
+    Cpu,          // ソフトウェアラスタライザ等
+};
+
+const char* to_string(GpuKind kind);
+
+/// CPU→GPU アップロード戦略。
+enum class UploadPolicy : uint8_t {
+    Staging = 0,  // host-visible staging → device-local へ copy
+    Direct,       // host-visible device-local へ直接書き、staging を省略
+};
+
+const char* to_string(UploadPolicy policy);
+
+// ---- Vulkan 非依存の入力記述 ----
+
+struct MemoryHeapDesc {
+    uint64_t size_bytes   = 0;
+    bool     device_local = false;
+};
+
+struct MemoryTypeDesc {
+    uint32_t heap_index   = 0;
+    bool     device_local = false;
+    bool     host_visible = false;
+    bool     host_coherent = false;
+};
+
+struct DeviceMemoryDesc {
+    GpuKind                     kind = GpuKind::Unknown;
+    std::vector<MemoryHeapDesc> heaps;
+    std::vector<MemoryTypeDesc> types;
+};
+
+// ---- 判定結果 ----
+
+struct DeviceMemoryProfile {
+    GpuKind      kind          = GpuKind::Unknown;
+    bool         is_uma        = false;  // device-local かつ host-visible な type が存在
+    bool         has_rebar     = false;  // 上記 type の heap が大きい (= VRAM 全体 mappable)
+    UploadPolicy upload_policy = UploadPolicy::Staging;
+    uint64_t     largest_device_local_heap = 0;
+    uint64_t     direct_mappable_bytes = 0; // host-visible device-local heap の最大サイズ
+    std::string  rationale;               // なぜその policy か (理由を必ず残す)
+};
+
+/// ReBAR とみなす host-visible device-local heap の下限。これ未満だと
+/// 旧来の 256MB BAR ウィンドウ相当とみなし discrete は Staging を選ぶ。
+constexpr uint64_t kReBarThresholdBytes = 256ull * 1024 * 1024;
+
+/// メモリ記述からアップロード戦略を決定する (純粋関数・副作用なし)。
+DeviceMemoryProfile analyze_device_memory(const DeviceMemoryDesc& desc);
+
+} // namespace pictor

--- a/include/pictor/core/types.h
+++ b/include/pictor/core/types.h
@@ -6,29 +6,53 @@
 #include <vector>
 
 // ============================================================
-// Cache-Line Alignment Configuration
+// Cache-Line / Alignment Configuration (multi-arch)
 //
-// PICTOR_CACHE_LINE_SIZE controls the alignment of hot data structures
-// for Data-Oriented Design (DoD) cache optimization.
+// 2 つの別 concern を分離する (混同すると 128B ライン機で float4x4 が
+// 膨らんで static_assert が落ちる — 旧実装のバグ):
 //
-// Typical values:
-//   64  — x86/x64, Apple Silicon (default)
-//   32  — some ARM/embedded
-//   128 — some server CPUs (Intel Ice Lake L2)
+//   1. PICTOR_CACHE_LINE_SIZE  — その CPU の「真の」L1 ライン幅。偽共有
+//      (destructive interference) 回避と perf モニタの「要素ライン跨ぎ」
+//      計算に使う。アーキ別に既定値を選ぶ:
+//        - Apple Silicon (M 系) / 近年の A 系 (iOS)         = 128B
+//        - POWER (ppc64)                                    = 128B
+//        - x86-64 (PC: Intel/AMD) / ARM Cortex-A (Android)  = 64B
+//      ※ iOS こそ 128B 側。Android 主流 SoC (Cortex-A/Kryo) は 64B。
+//      `-DPICTOR_CACHE_LINE_SIZE=N` で上書き可 (ARM サーバ Neoverse 等)。
+//      0 で整列を無効化。
 //
-// Override via compiler define: -DPICTOR_CACHE_LINE_SIZE=32
-// Set to 0 to disable cache-line alignment entirely.
+//   2. PICTOR_SIMD_ALIGN       — SIMD / 充填構造体 (float4x4 等) の整列。
+//      ライン幅とは独立の固定 16B。ライン幅を 128 にしても float4x4 を
+//      128B へ膨らませず transform ストリーム密度 (64B/要素) を保つ。
+//
+//   PICTOR_FALSE_SHARING_ALIGN — スレッド別データを 1 ライン専有させて
+//      偽共有を断つための alignas(ライン幅)。
+//
+// ※ ライン幅はコンパイル時定数 (alignas は実行時に変えられない)。実機の
+//   ライン幅は core/cache_info.h の query_cache_line_info() で取得し、
+//   「ビルド想定 vs 実機」の不一致を perf モニタで可視化する。
 // ============================================================
 
 #ifndef PICTOR_CACHE_LINE_SIZE
-#define PICTOR_CACHE_LINE_SIZE 64
+  #if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    #define PICTOR_CACHE_LINE_SIZE 128
+  #elif defined(__powerpc64__) || defined(__ppc64__)
+    #define PICTOR_CACHE_LINE_SIZE 128
+  #else
+    #define PICTOR_CACHE_LINE_SIZE 64
+  #endif
 #endif
 
 #if PICTOR_CACHE_LINE_SIZE > 0
-#define PICTOR_CACHE_ALIGN alignas(PICTOR_CACHE_LINE_SIZE)
+  #define PICTOR_CACHE_ALIGN         alignas(PICTOR_CACHE_LINE_SIZE)
+  #define PICTOR_FALSE_SHARING_ALIGN alignas(PICTOR_CACHE_LINE_SIZE)
 #else
-#define PICTOR_CACHE_ALIGN
+  #define PICTOR_CACHE_ALIGN
+  #define PICTOR_FALSE_SHARING_ALIGN
 #endif
+
+// SIMD / 充填構造体の整列 (ライン幅から独立。16B 固定)。
+#define PICTOR_SIMD_ALIGN alignas(16)
 
 // Suppress MSVC C4324 "structure was padded due to alignment specifier"
 // This is expected and intentional for DoD cache optimization.
@@ -58,7 +82,10 @@ struct float4 {
     float x = 0.0f, y = 0.0f, z = 0.0f, w = 0.0f;
 };
 
-struct PICTOR_CACHE_ALIGN float4x4 {
+// float4x4 は「充填構造体」: ライン幅 (128B 機含む) に依らず常に 64B を保つ。
+// よって PICTOR_CACHE_ALIGN ではなく SIMD 整列 (16B) を使う。配列要素は
+// PoolAllocator の 64B 起点 + 64B ストライドで自然にライン整列する。
+struct PICTOR_SIMD_ALIGN float4x4 {
     float m[4][4] = {};
 
     static float4x4 identity() {

--- a/include/pictor/gpu/gpu_buffer_manager.h
+++ b/include/pictor/gpu/gpu_buffer_manager.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "pictor/core/types.h"
+#include "pictor/core/device_memory_profile.h"
 #include "pictor/memory/gpu_memory_allocator.h"
 #include "pictor/scene/scene_registry.h"
 #include <vector>
@@ -55,6 +56,18 @@ public:
 
     GpuAllocation allocate_instance_data(size_t size);
 
+    // ---- Upload policy (UMA / ReBAR — spec/subsystem/uma_memory.md) ----
+
+    /// host が検出した device メモリ特性を渡す (VulkanContext::device_memory_profile())。
+    /// 既定は Staging (安全側)。
+    void set_memory_profile(const DeviceMemoryProfile& profile) { memory_profile_ = profile; }
+    const DeviceMemoryProfile& memory_profile() const { return memory_profile_; }
+
+    /// CPU→GPU 転送で staging を経由すべきか。UMA/ReBAR (Direct) なら false =
+    /// host-visible device-local へ直接書ける。production の upload 経路は
+    /// この判定を見て staging コピーを省く (現状 uploader はスタブ)。
+    bool should_stage() const { return memory_profile_.upload_policy == UploadPolicy::Staging; }
+
     // ---- Staging (§5.6) ----
 
     /// Allocate staging buffer for CPU→GPU transfer
@@ -85,6 +98,7 @@ private:
     SSBOLayout          current_layout_;
     std::vector<DirtyRegion> dirty_regions_;
     uint32_t            dirty_chunk_count_ = 0;
+    DeviceMemoryProfile memory_profile_;   // 既定 Staging (安全側)
 };
 
 } // namespace pictor

--- a/include/pictor/profiler/perf_introspection.h
+++ b/include/pictor/profiler/perf_introspection.h
@@ -64,7 +64,15 @@ struct DoDInvariant {
 };
 
 struct MemoryLayoutReport {
-    size_t cache_line_size = 0;
+    size_t cache_line_size = 0;             // ビルド時 PICTOR_CACHE_LINE_SIZE
+
+    // 実機キャッシュライン (core/cache_info.h)。alignas はビルド時固定なので、
+    // ここで「ビルド想定 vs 実機」を出して誤ビルド (例 64B 想定を Apple 128B 機で
+    // 実行) を可視化する。
+    size_t      runtime_cache_line_size = 0;  // 実機検出 (0 = 不明)
+    bool        cache_line_matches      = true; // 実機==ビルド想定 (不明は true)
+    std::string cpu_arch;                       // "x86-64" / "arm64-apple" / ...
+
     std::vector<PoolLayoutInfo> pools;
 
     // アロケータ断片化 (reallocate_array は旧配列を解放しないため死にバイトが溜まる)。

--- a/include/pictor/surface/vulkan_context.h
+++ b/include/pictor/surface/vulkan_context.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "pictor/surface/surface_provider.h"
+#include "pictor/core/device_memory_profile.h"
 #include <cstdint>
 #include <vector>
 #include <string>
@@ -120,6 +121,12 @@ public:
     //   cheaper than interlock on some drivers.
     bool has_fragment_shader_interlock()               const { return has_fragment_shader_interlock_; }
     bool has_rasterization_order_attachment_access()   const { return has_rasterization_order_attachment_access_; }
+
+    /// 物理デバイスのメモリ構成を Vk 非依存記述に変換する (UMA/ReBAR 判定の入力)。
+    DeviceMemoryDesc    describe_device_memory() const;
+    /// 物理デバイスから直接アップロード戦略を判定する
+    /// (= analyze_device_memory(describe_device_memory()))。
+    DeviceMemoryProfile device_memory_profile() const;
 #endif
 
 private:

--- a/spec/dx12-backend-design.md
+++ b/spec/dx12-backend-design.md
@@ -1,0 +1,132 @@
+# DirectX 12 Backend — 設計検討 (RHI 抽象化)
+
+> ステータス: **設計のみ (未実装)**。Pictor は現状 Vulkan 専用。本書は DX12 を
+> 併設するための RHI (Render Hardware Interface) 抽象と段階的移行計画を示す。
+> キャッシュ整列 / UMA とは独立した別軸 (GPU API の話)。
+
+## 1. 目的とスコープ
+
+PC で **Vulkan に加えて DirectX 12** を選べるようにする。狙い:
+
+- Windows ネイティブ最適化 (WDDM/PIX/GPU ベンダドライバの DX12 経路)。
+- Vulkan が弱い/不安定な環境 (一部 Intel/古い AMD ドライバ) の代替。
+- 将来 Xbox 系への展開余地。
+
+**非目標**: DoD コア (scene/batch/culling/memory の SoA ロジック) の書き換え。
+これらは GPU API 非依存であり、RHI 抽象の下でそのまま再利用する。
+
+## 2. 現状の API 結合度 (どこを抽象化すべきか)
+
+Pictor は幸い**公開 API が既にほぼ抽象**:
+
+- `PictorRenderer` / `c_api.h` / `ObjectDescriptor` 入力 — Vulkan 型を漏らさない。
+- `MemorySubsystem` / `SceneRegistry` / `BatchBuilder` / `CullingSystem` /
+  `GpuMemoryAllocator` (論理サブアロケータ) — **API 非依存**。これらは無改修で済む。
+
+一方、**Vulkan が露出している箇所** = RHI 化の対象:
+
+| 箇所 | Vulkan 依存 | RHI 後 |
+|---|---|---|
+| `surface/vulkan_context.{h,cpp}` | VkInstance/Device/Queue/Swapchain | `IDevice` / `ISwapchain` |
+| `profiler/gpu_timer.{h,cpp}` | VkQueryPool / vkCmdWriteTimestamp | `IQueryHeap` (timestamp) |
+| `pipeline/render_pass_scheduler.cpp` | VkCommandBuffer 記録 | `ICommandEncoder` |
+| `profiler/batch_gpu_timer` | VkCommandBuffer | `ICommandEncoder` 経由 |
+| `gpu/gpu_buffer_manager` | (現状ほぼ論理。実 VkBuffer は将来) | `IBuffer` |
+| `data/{vertex_data_uploader,texture_registry}` | (upload はスタブ) | `IBuffer`/`ITexture` + upload |
+| `surface/*_surface_provider` | VkSurfaceKHR (GLFW/Android/iOS) | swapchain 生成は `IDevice` 委譲 |
+| shaders/*.{vert,frag,comp} | GLSL→SPIR-V | HLSL→(SPIR-V+DXIL) |
+
+`#ifdef PICTOR_HAS_VULKAN` ガードが既に分離線になっており、ここを
+`PICTOR_RHI_VULKAN` / `PICTOR_RHI_D3D12` に再編するのが自然。
+
+## 3. 提案 RHI インターフェース (Interface Segregation)
+
+太い 1 個ではなく責務別に薄く切る (Pictor の `ICuller`/`IShader`/`IPass` と同方針):
+
+```text
+IRhiDevice        — 生成/破棄、capability 照会、queue 取得、UMA 判定
+  ├ create_buffer(BufferDesc)        -> IRhiBuffer
+  ├ create_texture(TextureDesc)      -> IRhiTexture
+  ├ create_pipeline(PipelineDesc)    -> IRhiPipeline
+  ├ create_query_heap(kind, count)   -> IRhiQueryHeap
+  ├ create_swapchain(SurfaceDesc)    -> IRhiSwapchain
+  └ memory_profile()                 -> DeviceMemoryProfile   (Task 2 と合流)
+
+IRhiCommandEncoder — フレームのコマンド記録 (VkCommandBuffer / ID3D12GraphicsCommandList)
+  ├ begin/end_render_pass(RenderTargetDesc)
+  ├ bind_pipeline / bind_buffers / set_push_constants
+  ├ draw_indexed(indexCount, instanceCount, ...)   ← per-batch instancing もここ
+  ├ dispatch(x,y,z)                                ← GPU-driven compute
+  ├ write_timestamp(IRhiQueryHeap, index)          ← GpuTimerManager の下回り
+  └ resource_barrier(...)
+
+IRhiQueryHeap     — timestamp / occlusion。GpuTimerManager をこの上に載せ替える。
+IRhiSwapchain     — acquire / present (VulkanContext の swapchain 部分を移管)。
+IRhiBuffer/Texture — GpuAllocation を実バッキングに結ぶ。
+```
+
+`Camera` / `RenderBatch` / `ObjectDescriptor` 等の値型は API 非依存のまま
+RHI 境界を渡る (内部 layout を漏らさない = Pictor CLAUDE.md の境界 OOP 方針)。
+
+## 4. 概念マッピング (Vulkan ↔ D3D12)
+
+| Pictor RHI | Vulkan | D3D12 |
+|---|---|---|
+| IRhiDevice | VkDevice + VkPhysicalDevice | ID3D12Device |
+| queue | VkQueue | ID3D12CommandQueue |
+| ICommandEncoder | VkCommandBuffer | ID3D12GraphicsCommandList |
+| IRhiBuffer | VkBuffer + VkDeviceMemory | ID3D12Resource (buffer) |
+| IRhiTexture | VkImage + View | ID3D12Resource (tex) + descriptor |
+| IRhiPipeline | VkPipeline + Layout | ID3D12PipelineState + RootSignature |
+| IRhiQueryHeap (ts) | VkQueryPool TIMESTAMP | ID3D12QueryHeap TIMESTAMP |
+| swapchain | VkSwapchainKHR | IDXGISwapChain |
+| descriptor set | VkDescriptorSet | descriptor heap + root params |
+| SSBO (instance buf) | storage buffer | SRV/UAV (StructuredBuffer) |
+
+**instancing**: 両 API とも `draw_indexed(instanceCount, firstInstance)` 同等で、
+`gl_InstanceIndex` ↔ `SV_InstanceID`。本書 §6 (3D モデル instancing) と整合。
+
+**UMA (Task 2 と合流)**: D3D12 は `D3D12_FEATURE_DATA_ARCHITECTURE` の
+`UMA` / `CacheCoherentUMA` で判定でき、`analyze_device_memory()` の入力
+(`DeviceMemoryDesc`) に同じ語彙でマップできる。判定ロジックは共有可能。
+
+## 5. シェーダ戦略
+
+現状 GLSL→SPIR-V。DX12 は DXIL が要る。選択肢:
+
+1. **HLSL 単一ソース → DXC で SPIR-V + DXIL の両方を出す** (推奨)。DXC は両対応。
+   既存 GLSL を HLSL へ移植する一括作業が要る。
+2. GLSL 維持 + SPIRV-Cross で HLSL 生成 → DXC で DXIL。中間変換が増え脆い。
+
+→ **HLSL 正本 + DXC デュアル出力**を推奨。CMake に `compile_hlsl()` を追加し
+`*.hlsl` から `.spv` / `.dxil` を生成、profile/loader が backend に応じて選ぶ。
+
+## 6. 段階的移行計画 (フェーズ)
+
+DoD コアを壊さないため、**先に Vulkan を RHI の上へ載せ替えてから** DX12 を足す:
+
+1. **Phase 0 — RHI 抽出**: 上記 interface を定義し、`vulkan_context` /
+   `gpu_timer` / `render_pass_scheduler` の Vulkan 呼び出しを `IRhi*` の Vulkan
+   実装 (`rhi/vulkan/`) へ移す。**外形の挙動は不変** (回帰のみ確認)。
+2. **Phase 1 — RHI 上の Vulkan で全テスト green** を確認 (現行と等価)。
+3. **Phase 2 — D3D12 実装** (`rhi/d3d12/`): IDevice/Encoder/Buffer/QueryHeap/
+   Swapchain を実装。最小パス (clear + 1 instanced draw + timestamp) から。
+4. **Phase 3 — HLSL 移行** + profile loader の backend 分岐。
+5. **Phase 4 — UMA/ReBAR を D3D12 ARCHITECTURE で配線** (Task 2 と合流)。
+
+各 Phase は単独で green を保ち、`PICTOR_RHI_BACKEND={vulkan,d3d12}` で選択。
+
+## 7. リスクと評価 (decision-metrics)
+
+- **作業コスト: 大**。RHI 抽出はレンダ経路全面に及ぶ。Phase 0/1 が最重量
+  (挙動不変のリファクタ + 全回帰)。
+- **AI 学習量: 高**。RHI 設計・2 API の差異・HLSL/DXC の実体験。
+- **解決度**: DX12 が要る環境で根本解決。Vulkan も RHI 化で疎結合化の副益。
+- **主目的一致度**: 「他アーキ対応」のうち **GPU API 軸**。CPU キャッシュ整列
+  (Task 1) / UMA (Task 2) とは独立。UMA 判定語彙は §4 で合流できる。
+
+## 8. 推奨
+
+いきなり DX12 を書かず **Phase 0 (RHI 抽出) を独立 PR** で先行する。抽出だけで
+Vulkan 経路の疎結合化という独立価値があり、DX12 はその上に安全に積める。
+Phase 0 着手前にこの設計をレビューし、interface の粒度を確定する。

--- a/spec/subsystem/cache_portability.md
+++ b/spec/subsystem/cache_portability.md
@@ -1,0 +1,59 @@
+# Cache-Line Portability — マルチアーキ DoD 整列
+
+> 対象: `include/pictor/core/types.h` (整列マクロ) /
+> `core/cache_info.h/.cpp` (実機検出) / `profiler/perf_introspection.h`
+> (ビルド vs 実機の可視化)。
+
+## 1. 目的
+
+DoD のキャッシュ整列を **x86-64 / ARM (Android) / Apple Silicon (iOS) /
+POWER** で正しく機能させる。旧実装は 1 マクロ `PICTOR_CACHE_LINE_SIZE` が
+「偽共有回避」と「データ充填」の 2 concern を兼ね、128B ライン機で
+`float4x4` が膨れて `static_assert(sizeof==64)` が落ちるバグがあった。
+
+## 2. アーキ別キャッシュライン (事実)
+
+| アーキ | L1/L2 ライン | 既定 |
+|---|---|---|
+| x86-64 (PC: Intel/AMD) | 64B | 64 |
+| ARM Cortex-A / Kryo (Android 主流 SoC) | 64B | 64 |
+| **Apple Silicon (M 系) / 近年 A 系 (iOS)** | **128B** | **128** |
+| POWER (ppc64) / 一部 ARM サーバ | 128B | 128 (Neoverse 等は `-D` 上書き) |
+
+→ **iOS が 128B 側の外れ値**。Android は 64B で x86 と揃う
+(SoC 差はライン幅にはほぼ出ない)。
+
+## 3. concern 分離 (設計判断)
+
+| マクロ | 用途 | 値 |
+|---|---|---|
+| `PICTOR_CACHE_LINE_SIZE` | 偽共有回避 + perf モニタの跨ぎ計算に使う「真のライン幅」 | アーキ別 (64/128)、`-D` 上書き可 |
+| `PICTOR_FALSE_SHARING_ALIGN` | スレッド別データを 1 ライン専有 | `alignas(ライン幅)` |
+| `PICTOR_SIMD_ALIGN` | 充填構造体 (`float4x4` 等) の SIMD 整列 | **固定 `alignas(16)`** |
+
+`float4x4` は `PICTOR_SIMD_ALIGN` を使い、ライン幅を 128 にしても **64B を維持**
+(transform ストリーム密度を保つ)。配列要素は PoolAllocator の 64B 起点 +
+64B ストライドで自然にライン整列する。
+
+## 4. ランタイム検出 → 可視化
+
+`alignas` はコンパイル時固定で実行時に変えられない。そこで実機ライン幅を
+`query_cache_line_info()` で取得し、`MemoryLayoutReport` に
+`runtimeCacheLineSize` / `cacheLineMatches` / `cpuArch` を載せて perf モニタへ。
+**「64B 想定バイナリを Apple 128B 機で実行 → 跨ぎ倍増」** のような誤ビルドを
+視認できる (整列自体は直せないが検出はできる)。
+
+検出経路:
+- Windows: `GetLogicalProcessorInformation` の L1 データ/統合キャッシュ LineSize
+- Apple: `sysctlbyname("hw.cachelinesize")`
+- Linux/Android: `sysconf(_SC_LEVEL1_DCACHE_LINESIZE)` → 不可なら sysfs
+  `coherency_line_size`
+
+検出不能でも throw せず `runtime=0 / matches=true` (不明扱い、誤警告なし)。
+
+## 5. テスト (`tests/unit_cache_info_test.cpp`)
+
+- `sizeof(float4x4)==64` / `alignof(float4x4)==16` を全アーキで維持。
+- ビルド時ライン幅が 2 のべき [32,256]。
+- ランタイム検出値が妥当 (2 のべき) か 0 (不明)。`matches` が正しく反映。
+- x86-64 ビルドは 64B に解決。

--- a/spec/subsystem/uma_memory.md
+++ b/spec/subsystem/uma_memory.md
@@ -1,0 +1,52 @@
+# UMA / ReBAR メモリ最適化 — 統合GPU 向けアップロード戦略
+
+> 対象: `core/device_memory_profile.h/.cpp` (判定) /
+> `surface/vulkan_context.{h,cpp}` (Vk アダプタ) /
+> `gpu/gpu_buffer_manager.h` (判定 seam)。
+
+## 1. 目的
+
+discrete GPU は VRAM が CPU から不可視なので staging buffer 経由で device-local
+へコピーする。一方:
+
+- **統合GPU (Integrated, UMA)**: メモリは CPU/GPU 共有。staging は**無駄な余計
+  コピー** → host-visible device-local へ直接書く (Direct) のが速い。
+- **discrete + ReBAR**: VRAM 全体が host-visible device-local に見える → 大きい
+  host-visible device-local heap があれば Direct を選べる。
+
+これを検出し、アップロード戦略 (`Staging` / `Direct`) を決める。
+
+## 2. 設計 (concern 分離・テスト可能性)
+
+判定ロジックは **Vulkan 非依存の純粋関数** `analyze_device_memory(DeviceMemoryDesc)`
+として切り出す。Vk 型 (`VkPhysicalDeviceMemoryProperties`) → `DeviceMemoryDesc`
+変換は `VulkanContext::describe_device_memory()` (Vk アダプタ) が担う。これにより
+判定を **headless で単体テスト**できる (合成入力で discrete/integrated/ReBAR を再現)。
+
+判定:
+- `is_uma` = device-local かつ host-visible な memory type が存在。
+- `has_rebar` = `is_uma` かつ その heap が `kReBarThresholdBytes`(256MB) 以上。
+- `upload_policy`:
+  - Integrated + UMA → **Direct**
+  - Discrete + ReBAR → **Direct**
+  - それ以外 (discrete no-rebar / Cpu / Unknown) → **Staging** (安全側)
+- `rationale` に必ず理由を残す (無言フォールバック禁止)。
+
+## 3. 配線 (現状の正直な範囲)
+
+`GPUBufferManager::set_memory_profile()` / `should_stage()` を判定 seam として追加。
+host は起動時に `buffer_manager.set_memory_profile(vk.device_memory_profile())` を
+呼ぶ。production の upload 経路はこの `should_stage()` を見て staging コピーを省く。
+
+> **重要 (正直な現状)**: `vertex_data_uploader` / `texture_registry` の実 upload は
+> 現在**スタブ**(「In production: memcpy to staging, record copy command」コメントの
+> まま、実 `vkCmdCopyBuffer` 未実装)。よって本 PR は **判定とその供給口までを実装**し、
+> 実コピー実装時に `should_stage()==false` で Direct 経路を取れるよう配線する。
+> 「staging を実際に省いた」と装わない — 実コピー経路の実装は別タスク。
+
+## 4. テスト (`tests/unit_device_memory_profile_test.cpp`)
+
+- discrete (host-visible device-local 無し) → Staging
+- discrete + 大 host-visible device-local heap → Direct (ReBAR)
+- integrated (UMA) → Direct
+- 空/Unknown → Staging (安全側)

--- a/src/core/cache_info.cpp
+++ b/src/core/cache_info.cpp
@@ -1,0 +1,113 @@
+#include "pictor/core/cache_info.h"
+
+#if defined(_WIN32)
+  #define WIN32_LEAN_AND_MEAN
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
+  #include <windows.h>
+  #include <vector>
+#elif defined(__APPLE__)
+  #include <sys/sysctl.h>
+#else // Linux / Android
+  #include <unistd.h>
+  #include <cstdio>
+#endif
+
+namespace pictor {
+
+namespace {
+
+const char* detect_arch() {
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    return "arm64-apple";
+#elif defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+    return "arm64";
+#elif defined(__arm__) || defined(_M_ARM)
+    return "arm32";
+#elif defined(__x86_64__) || defined(_M_X64)
+    return "x86-64";
+#elif defined(__i386__) || defined(_M_IX86)
+    return "x86";
+#elif defined(__powerpc64__) || defined(__ppc64__)
+    return "ppc64";
+#else
+    return "unknown";
+#endif
+}
+
+#if defined(_WIN32)
+
+size_t detect_runtime_line_size(const char** source) {
+    *source = "win32-logical-processor";
+    DWORD len = 0;
+    GetLogicalProcessorInformation(nullptr, &len);
+    if (len == 0) return 0;
+
+    std::vector<SYSTEM_LOGICAL_PROCESSOR_INFORMATION> buf(
+        len / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION));
+    if (!GetLogicalProcessorInformation(buf.data(), &len)) return 0;
+
+    // L1 のデータ / 統合キャッシュのライン幅を採る。
+    for (const auto& info : buf) {
+        if (info.Relationship == RelationCache &&
+            info.Cache.Level == 1 &&
+            (info.Cache.Type == CacheData || info.Cache.Type == CacheUnified)) {
+            return static_cast<size_t>(info.Cache.LineSize);
+        }
+    }
+    return 0;
+}
+
+#elif defined(__APPLE__)
+
+size_t detect_runtime_line_size(const char** source) {
+    *source = "sysctl-hw.cachelinesize";
+    size_t line = 0;
+    size_t sz = sizeof(line);
+    if (sysctlbyname("hw.cachelinesize", &line, &sz, nullptr, 0) == 0) {
+        return line;
+    }
+    return 0;
+}
+
+#else // Linux / Android
+
+size_t detect_runtime_line_size(const char** source) {
+    *source = "sysconf";
+#if defined(_SC_LEVEL1_DCACHE_LINESIZE)
+    long v = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+    if (v > 0) return static_cast<size_t>(v);
+#endif
+    // フォールバック: sysfs の coherency_line_size を読む。
+    *source = "sysfs-coherency_line_size";
+    if (FILE* f = std::fopen(
+            "/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", "r")) {
+        long v = 0;
+        const int n = std::fscanf(f, "%ld", &v);
+        std::fclose(f);
+        if (n == 1 && v > 0) return static_cast<size_t>(v);
+    }
+    return 0;
+}
+
+#endif
+
+} // namespace
+
+CacheLineInfo query_cache_line_info() {
+    CacheLineInfo info;
+    info.compiled_line_size = PICTOR_CACHE_LINE_SIZE;
+    info.arch = detect_arch();
+
+    const char* source = "none";
+    info.runtime_line_size = detect_runtime_line_size(&source);
+    info.source = source;
+
+    // 検出不能 (0) は「不明」扱いで一致とみなす (誤警告を出さない)。
+    info.matches = (info.runtime_line_size == 0) ||
+                   (info.runtime_line_size == info.compiled_line_size);
+    return info;
+}
+
+} // namespace pictor

--- a/src/core/device_memory_profile.cpp
+++ b/src/core/device_memory_profile.cpp
@@ -1,0 +1,75 @@
+#include "pictor/core/device_memory_profile.h"
+
+namespace pictor {
+
+const char* to_string(GpuKind kind) {
+    switch (kind) {
+        case GpuKind::Unknown:    return "Unknown";
+        case GpuKind::Discrete:   return "Discrete";
+        case GpuKind::Integrated: return "Integrated";
+        case GpuKind::Virtual:    return "Virtual";
+        case GpuKind::Cpu:        return "Cpu";
+    }
+    return "Unknown";
+}
+
+const char* to_string(UploadPolicy policy) {
+    switch (policy) {
+        case UploadPolicy::Staging: return "Staging";
+        case UploadPolicy::Direct:  return "Direct";
+    }
+    return "Staging";
+}
+
+DeviceMemoryProfile analyze_device_memory(const DeviceMemoryDesc& desc) {
+    DeviceMemoryProfile p;
+    p.kind = desc.kind;
+
+    // device-local heap の最大サイズ。
+    for (const auto& h : desc.heaps) {
+        if (h.device_local && h.size_bytes > p.largest_device_local_heap) {
+            p.largest_device_local_heap = h.size_bytes;
+        }
+    }
+
+    // host-visible かつ device-local な memory type が UMA / ReBAR の鍵。
+    for (const auto& t : desc.types) {
+        if (t.device_local && t.host_visible) {
+            p.is_uma = true;
+            const uint64_t heap_size =
+                (t.heap_index < desc.heaps.size()) ? desc.heaps[t.heap_index].size_bytes : 0;
+            if (heap_size > p.direct_mappable_bytes) p.direct_mappable_bytes = heap_size;
+        }
+    }
+    p.has_rebar = p.is_uma && (p.direct_mappable_bytes >= kReBarThresholdBytes);
+
+    // 戦略決定 (理由を必ず残す — 無言フォールバック禁止)。
+    if (desc.kind == GpuKind::Integrated) {
+        if (p.is_uma) {
+            p.upload_policy = UploadPolicy::Direct;
+            p.rationale = "統合GPU(UMA): host-visible device-local 有 → staging 省略し直接書き";
+        } else {
+            // 統合GPU なのに host-visible device-local が無いのは異例。安全側で staging。
+            p.upload_policy = UploadPolicy::Staging;
+            p.rationale = "統合GPU だが host-visible device-local が無い → 安全側で staging";
+        }
+    } else if (desc.kind == GpuKind::Discrete) {
+        if (p.has_rebar) {
+            p.upload_policy = UploadPolicy::Direct;
+            p.rationale = "discrete + ReBAR (host-visible device-local heap が大) → 直接書き可";
+        } else {
+            p.upload_policy = UploadPolicy::Staging;
+            p.rationale = p.is_uma
+                ? "discrete: host-visible device-local heap が小 (256MB BAR 窓相当) → staging"
+                : "discrete: VRAM は host から不可視 → staging 経由でコピー";
+        }
+    } else {
+        // Cpu / Virtual / Unknown: 安全側で staging。
+        p.upload_policy = UploadPolicy::Staging;
+        p.rationale = std::string("device kind=") + to_string(desc.kind) + " → 安全側で staging";
+    }
+
+    return p;
+}
+
+} // namespace pictor

--- a/src/profiler/perf_query_api.cpp
+++ b/src/profiler/perf_query_api.cpp
@@ -4,6 +4,7 @@
 #include "pictor/memory/memory_subsystem.h"
 #include "pictor/batch/batch_builder.h"
 #include "pictor/profiler/profiler.h"
+#include "pictor/core/cache_info.h"
 
 #include <array>
 #include <cmath>
@@ -113,6 +114,12 @@ PerfQueryAPI::~PerfQueryAPI() = default;
 MemoryLayoutReport PerfQueryAPI::memory_layout_report() const {
     MemoryLayoutReport report;
     report.cache_line_size = kCacheLine;
+
+    // 実機キャッシュライン (ビルド想定との不一致を可視化)。
+    const CacheLineInfo cli = query_cache_line_info();
+    report.runtime_cache_line_size = cli.runtime_line_size;
+    report.cache_line_matches      = cli.matches;
+    report.cpu_arch                = cli.arch;
 
     const std::array<PoolType, 3> pools = {
         PoolType::STATIC, PoolType::DYNAMIC, PoolType::GPU_DRIVEN
@@ -373,6 +380,9 @@ std::string PerfQueryAPI::export_memory_json() const {
     std::ostringstream os;
     os << "{";
     os << "\"cacheLineSize\":" << r.cache_line_size;
+    os << ",\"runtimeCacheLineSize\":" << r.runtime_cache_line_size;
+    os << ",\"cacheLineMatches\":" << (r.cache_line_matches ? "true" : "false");
+    os << ",\"cpuArch\":"; json_escape(os, r.cpu_arch);
     os << ",\"poolAllocatorTotalBytes\":" << r.pool_allocator_total_bytes;
     os << ",\"soaReservedBytes\":" << r.soa_reserved_bytes;
     os << ",\"soaUsedBytes\":" << r.soa_used_bytes;

--- a/src/surface/vulkan_context.cpp
+++ b/src/surface/vulkan_context.cpp
@@ -179,6 +179,49 @@ void VulkanContext::device_wait_idle() {
     if (device_) vkDeviceWaitIdle(device_);
 }
 
+// ---------- device memory profile (UMA / ReBAR) ----------
+
+DeviceMemoryDesc VulkanContext::describe_device_memory() const {
+    DeviceMemoryDesc d;
+    if (physical_device_ == VK_NULL_HANDLE) return d;
+
+    VkPhysicalDeviceProperties props{};
+    vkGetPhysicalDeviceProperties(physical_device_, &props);
+    switch (props.deviceType) {
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:   d.kind = GpuKind::Discrete;   break;
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: d.kind = GpuKind::Integrated; break;
+        case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:    d.kind = GpuKind::Virtual;    break;
+        case VK_PHYSICAL_DEVICE_TYPE_CPU:            d.kind = GpuKind::Cpu;        break;
+        default:                                     d.kind = GpuKind::Unknown;    break;
+    }
+
+    VkPhysicalDeviceMemoryProperties mem{};
+    vkGetPhysicalDeviceMemoryProperties(physical_device_, &mem);
+
+    d.heaps.reserve(mem.memoryHeapCount);
+    for (uint32_t i = 0; i < mem.memoryHeapCount; ++i) {
+        MemoryHeapDesc h;
+        h.size_bytes   = mem.memoryHeaps[i].size;
+        h.device_local = (mem.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0;
+        d.heaps.push_back(h);
+    }
+    d.types.reserve(mem.memoryTypeCount);
+    for (uint32_t i = 0; i < mem.memoryTypeCount; ++i) {
+        const VkMemoryType& mt = mem.memoryTypes[i];
+        MemoryTypeDesc t;
+        t.heap_index    = mt.heapIndex;
+        t.device_local  = (mt.propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)  != 0;
+        t.host_visible  = (mt.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)  != 0;
+        t.host_coherent = (mt.propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0;
+        d.types.push_back(t);
+    }
+    return d;
+}
+
+DeviceMemoryProfile VulkanContext::device_memory_profile() const {
+    return analyze_device_memory(describe_device_memory());
+}
+
 // ---------- private: instance ----------
 
 bool VulkanContext::create_instance(const VulkanContextConfig& cfg) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PICTOR_TESTS
     unit_gpu_timer_test
     unit_perf_introspection_test
     unit_cache_info_test
+    unit_device_memory_profile_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PICTOR_TESTS
     unit_gpu_ring_flight_test
     unit_gpu_timer_test
     unit_perf_introspection_test
+    unit_cache_info_test
     pixel_text_test
     fps_baseline_test
 )

--- a/tests/unit_cache_info_test.cpp
+++ b/tests/unit_cache_info_test.cpp
@@ -1,0 +1,49 @@
+/// Cache-line portability unit test (headless)。
+/// spec/subsystem/cache_portability.md を裏取りする。
+
+#include "pictor/core/cache_info.h"
+#include "pictor/core/types.h"
+#include "test_common.h"
+
+using namespace pictor;
+using namespace pictor_test;
+
+static bool is_pow2(size_t v) { return v != 0 && (v & (v - 1)) == 0; }
+
+int main() {
+    // 1. concern 分離: ライン幅を 128 にしても float4x4 は 64B のまま。
+    PT_ASSERT_OP(sizeof(float4x4), ==, 64u, "float4x4 stays 64B regardless of line size");
+    PT_ASSERT_OP(alignof(float4x4), ==, 16u, "float4x4 uses SIMD (16B) packing align");
+    PT_ASSERT_OP(sizeof(AABB), ==, 24u, "AABB tight-packed 24B");
+
+    // 2. ビルド時ライン幅は妥当な 2 のべき (32/64/128)。
+    PT_ASSERT(is_pow2(PICTOR_CACHE_LINE_SIZE), "compiled line size is power of two");
+    PT_ASSERT(PICTOR_CACHE_LINE_SIZE >= 32 && PICTOR_CACHE_LINE_SIZE <= 256,
+              "compiled line size in [32,256]");
+
+    // 3. ランタイム検出。
+    const CacheLineInfo info = query_cache_line_info();
+    PT_ASSERT_OP(info.compiled_line_size, ==, (size_t)PICTOR_CACHE_LINE_SIZE,
+                 "info.compiled matches macro");
+    PT_ASSERT(!info.arch.empty(), "arch string non-empty");
+    PT_ASSERT(!info.source.empty(), "source string non-empty");
+
+    // 検出できたなら妥当な 2 のべき。0 (不明) なら matches=true 扱い。
+    if (info.runtime_line_size != 0) {
+        PT_ASSERT(is_pow2(info.runtime_line_size), "runtime line size power of two");
+        PT_ASSERT(info.runtime_line_size >= 32 && info.runtime_line_size <= 256,
+                  "runtime line size in [32,256]");
+        PT_ASSERT_OP(info.matches, ==, (info.runtime_line_size == info.compiled_line_size),
+                     "matches reflects runtime vs compiled");
+    } else {
+        PT_ASSERT(info.matches, "unknown runtime → matches=true (no false warning)");
+    }
+
+    // 4. 現在のビルドホスト (x86-64 CI / dev) では 64B のはず — 一致を期待。
+    //    (Apple 128B 機では別 expectation だが、本 CI は x86-64。)
+#if defined(__x86_64__) || defined(_M_X64)
+    PT_ASSERT_OP(PICTOR_CACHE_LINE_SIZE, ==, 64u, "x86-64 compiles to 64B line");
+#endif
+
+    return report("unit_cache_info_test");
+}

--- a/tests/unit_device_memory_profile_test.cpp
+++ b/tests/unit_device_memory_profile_test.cpp
@@ -1,0 +1,90 @@
+/// UMA / ReBAR アップロード戦略判定の単体テスト (headless, Vk 非依存)。
+/// spec/subsystem/uma_memory.md を裏取りする。
+
+#include "pictor/core/device_memory_profile.h"
+#include "test_common.h"
+
+using namespace pictor;
+using namespace pictor_test;
+
+namespace {
+
+// discrete GPU: device-local VRAM heap + 別の host-visible system heap。
+// host-visible device-local 無し → staging。
+DeviceMemoryDesc make_discrete_no_rebar() {
+    DeviceMemoryDesc d;
+    d.kind = GpuKind::Discrete;
+    d.heaps = {
+        { 8ull * 1024 * 1024 * 1024, true  }, // 8GB VRAM (device-local)
+        { 16ull * 1024 * 1024 * 1024, false }, // 16GB system (host)
+    };
+    d.types = {
+        { 0, /*dl*/true,  /*hv*/false, false }, // device-local only
+        { 1, /*dl*/false, /*hv*/true,  true  }, // host-visible only
+    };
+    return d;
+}
+
+// discrete + ReBAR: 大きい host-visible device-local heap。
+DeviceMemoryDesc make_discrete_rebar() {
+    DeviceMemoryDesc d;
+    d.kind = GpuKind::Discrete;
+    d.heaps = {
+        { 8ull * 1024 * 1024 * 1024, true }, // 8GB device-local, host から見える
+        { 16ull * 1024 * 1024 * 1024, false },
+    };
+    d.types = {
+        { 0, true,  true,  true  }, // device-local + host-visible (ReBAR)
+        { 1, false, true,  true  },
+    };
+    return d;
+}
+
+// integrated (UMA): 共有メモリ、device-local かつ host-visible。
+DeviceMemoryDesc make_integrated() {
+    DeviceMemoryDesc d;
+    d.kind = GpuKind::Integrated;
+    d.heaps = { { 16ull * 1024 * 1024 * 1024, true } }; // 共有 16GB
+    d.types = {
+        { 0, true, false, false }, // device-local
+        { 0, true, true,  true  }, // device-local + host-visible (UMA)
+    };
+    return d;
+}
+
+} // namespace
+
+int main() {
+    // discrete (ReBAR 無し) → Staging。
+    {
+        const DeviceMemoryProfile p = analyze_device_memory(make_discrete_no_rebar());
+        PT_ASSERT(p.kind == GpuKind::Discrete, "discrete kind");
+        PT_ASSERT(!p.is_uma, "discrete no host-visible device-local → not uma");
+        PT_ASSERT(!p.has_rebar, "no rebar");
+        PT_ASSERT(p.upload_policy == UploadPolicy::Staging, "discrete no-rebar → Staging");
+        PT_ASSERT(!p.rationale.empty(), "rationale recorded");
+    }
+    // discrete + ReBAR → Direct。
+    {
+        const DeviceMemoryProfile p = analyze_device_memory(make_discrete_rebar());
+        PT_ASSERT(p.is_uma, "host-visible device-local present");
+        PT_ASSERT(p.has_rebar, "large host-visible device-local heap → rebar");
+        PT_ASSERT(p.upload_policy == UploadPolicy::Direct, "discrete+rebar → Direct");
+        PT_ASSERT_OP(p.direct_mappable_bytes, >=, kReBarThresholdBytes, "mappable >= threshold");
+    }
+    // integrated (UMA) → Direct。
+    {
+        const DeviceMemoryProfile p = analyze_device_memory(make_integrated());
+        PT_ASSERT(p.kind == GpuKind::Integrated, "integrated kind");
+        PT_ASSERT(p.is_uma, "integrated is uma");
+        PT_ASSERT(p.upload_policy == UploadPolicy::Direct, "integrated → Direct (staging 省略)");
+        PT_ASSERT(!p.rationale.empty(), "rationale recorded");
+    }
+    // 空 desc (Unknown) → 安全側 Staging。
+    {
+        const DeviceMemoryProfile p = analyze_device_memory(DeviceMemoryDesc{});
+        PT_ASSERT(p.upload_policy == UploadPolicy::Staging, "unknown → Staging (安全側)");
+    }
+
+    return report("unit_device_memory_profile_test");
+}


### PR DESCRIPTION
@
## 概要

「キャッシュ整列を他アーキ (モバイル/PC) に対応させたい」という要望に対し、
**他アーキ対応**を 3 コミットで実装/設計する。

1. **CPU キャッシュ整列ポータビリティ** (実装 + テスト)
2. **統合GPU (UMA) / ReBAR アップロード戦略** (検出 + 判定 seam + テスト)
3. **DirectX12 backend の RHI 抽象化** (設計ドキュメントのみ)

## 1. キャッシュ整列ポータビリティ (`core/types.h`, `core/cache_info`)

旧 `PICTOR_CACHE_LINE_SIZE` は「偽共有回避」と「データ充填」の 2 concern を兼ね、
**128B ライン機 (Apple Silicon/iOS) で `float4x4` が膨れて `static_assert` が落ちる
バグ**があった。concern を分離:

- `PICTOR_CACHE_LINE_SIZE`: アーキ別の真のライン幅 (**Apple/iOS=128**, POWER=128,
  x86-64 / ARM Cortex-A(**Android**)=64)。※iOS が 128B 側、Android 主流は 64B。
- `PICTOR_SIMD_ALIGN` (固定16B): `float4x4` 等の充填構造体。ライン幅を 128 にしても
  64B 維持。
- `PICTOR_FALSE_SHARING_ALIGN`: スレッド別データの 1 ライン専有。

実機ライン幅を `query_cache_line_info()` で検出 (Win32/Apple sysctl/Linux sysconf)
し、`MemoryLayoutReport` に `runtimeCacheLineSize/cacheLineMatches/cpuArch` を載せて
**「ビルド想定 vs 実機」不一致を perf モニタで可視化**。

## 2. UMA / ReBAR (`core/device_memory_profile`, `VulkanContext`, `GPUBufferManager`)

統合GPU/ReBAR は host-visible device-local へ直接書けて staging コピーを省ける。
Vulkan 非依存の純粋関数 `analyze_device_memory()` で判定 (headless テスト可能)、
`VulkanContext::device_memory_profile()` で実デバイスから取得、
`GPUBufferManager::should_stage()` を production upload の判定 seam に。
D3D12 の `ARCHITECTURE.UMA` とも同語彙で合流可。

> **正直な現状**: 実 upload 経路 (`vertex_data_uploader` 等) は現状スタブ
> (`vkCmdCopyBuffer` 未実装) のため、本 PR は判定とその供給口までを実装。
> 「staging を実際に省いた」とは装わない (実コピーは別タスク)。

## 3. DX12 backend 設計 (`spec/dx12-backend-design.md`)

RHI 抽象 (IDevice/CommandEncoder/Buffer/QueryHeap/Swapchain) と Vulkan↔D3D12
マッピング、HLSL+DXC、Phase 0 (RHI 抽出) 先行の段階計画。**設計のみ・コード変更なし**。

## テスト

`unit_cache_info_test` / `unit_device_memory_profile_test` 追加。**全 18 テスト green** (Debug)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@