### PR TITLE
feat(graph-demo): Iter 関連グラフ native renderer Step1 (instanced/DoD)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,7 +410,22 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
         target_include_directories(pictor_texture2d_demo PRIVATE demo/texture2d third_party/stb)
         target_link_libraries(pictor_texture2d_demo PRIVATE pictor)
 
-        message(STATUS "Pictor: All demos enabled (benchmark, window, graphics, ocean, text, postprocess, texture2d)")
+        # Iter relation-graph demo (instanced/DoD large graph view, Step 1)
+        add_executable(pictor_graph_demo
+            demo/graph/main.cpp
+            demo/graph/graph_store.cpp
+            demo/graph/camera2d.cpp
+            demo/graph/graph_generator.cpp
+            demo/graph/graph_renderer.cpp
+        )
+        target_include_directories(pictor_graph_demo PRIVATE demo/graph)
+        target_link_libraries(pictor_graph_demo PRIVATE pictor)
+        if(MSVC)
+            # /utf-8 does not propagate from the pictor lib to demo targets.
+            target_compile_options(pictor_graph_demo PRIVATE /utf-8)
+        endif()
+
+        message(STATUS "Pictor: All demos enabled (benchmark, window, graphics, ocean, text, postprocess, texture2d, graph)")
     else()
         message(STATUS "Pictor: Only benchmark demo enabled (Vulkan + GLFW3 required for other demos)")
     endif()
@@ -497,6 +512,9 @@ if(PICTOR_BUILD_DEMO AND Vulkan_FOUND AND Vulkan_GLSLC_EXECUTABLE)
         ${CMAKE_SOURCE_DIR}/demo/postprocess/shaders/pp_demo_scene.frag
         ${CMAKE_SOURCE_DIR}/demo/texture2d/shaders/texture2d.vert
         ${CMAKE_SOURCE_DIR}/demo/texture2d/shaders/texture2d.frag
+        ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_node.vert
+        ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_edge.vert
+        ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_flat.frag
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/model.vert
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/model.frag
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/bone.vert
@@ -538,6 +556,9 @@ if(PICTOR_BUILD_DEMO AND Vulkan_FOUND AND Vulkan_GLSLC_EXECUTABLE)
     endif()
     if(TARGET pictor_texture2d_demo)
         add_dependencies(pictor_texture2d_demo pictor_shaders)
+    endif()
+    if(TARGET pictor_graph_demo)
+        add_dependencies(pictor_graph_demo pictor_shaders)
     endif()
     if(TARGET pictor_fbx_viewer)
         add_dependencies(pictor_fbx_viewer pictor_shaders)

--- a/demo/graph/camera2d.cpp
+++ b/demo/graph/camera2d.cpp
@@ -1,0 +1,58 @@
+#include "camera2d.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace pictor::graph {
+
+void Camera2D::pan_pixels(float dx, float dy) {
+    // Dragging right should move the content right, i.e. the world point at the
+    // center moves left by the screen delta scaled back into world units.
+    cx_ -= dx / zoom_;
+    cy_ -= dy / zoom_;
+}
+
+void Camera2D::zoom_at(float screen_x, float screen_y, float factor,
+                       float vw, float vh) {
+    const float hw = vw * 0.5f;
+    const float hh = vh * 0.5f;
+
+    // World point currently under the cursor.
+    const float wx = cx_ + (screen_x - hw) / zoom_;
+    const float wy = cy_ + (screen_y - hh) / zoom_;
+
+    zoom_ = std::clamp(zoom_ * factor, kMinZoom, kMaxZoom);
+
+    // Re-anchor the center so that same world point stays under the cursor.
+    cx_ = wx - (screen_x - hw) / zoom_;
+    cy_ = wy - (screen_y - hh) / zoom_;
+}
+
+void Camera2D::reset(float center_x, float center_y, float zoom) {
+    cx_   = center_x;
+    cy_   = center_y;
+    zoom_ = std::clamp(zoom, kMinZoom, kMaxZoom);
+}
+
+void Camera2D::build_view(float* m, float vw, float vh) const {
+    std::memset(m, 0, 16 * sizeof(float));
+    m[0]  = zoom_;
+    m[5]  = zoom_;
+    m[10] = 1.0f;
+    m[15] = 1.0f;
+    m[12] = vw * 0.5f - cx_ * zoom_;
+    m[13] = vh * 0.5f - cy_ * zoom_;
+}
+
+void Camera2D::build_proj(float* m, float vw, float vh) {
+    // ortho(l=0, r=vw, b=vh, t=0, n=-1, f=1): screen px → clip, Y down.
+    std::memset(m, 0, 16 * sizeof(float));
+    m[0]  =  2.0f / vw;
+    m[5]  = -2.0f / vh;
+    m[10] = -1.0f;          // -2/(f-n) with n=-1,f=1
+    m[12] = -1.0f;
+    m[13] =  1.0f;
+    m[15] =  1.0f;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/camera2d.h
+++ b/demo/graph/camera2d.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace pictor::graph {
+
+/// Pannable / zoomable 2D camera for the relation-graph view.
+///
+/// Maps world units → screen pixels: screen = (world - center) * zoom + viewport/2.
+/// The view is rebuilt every frame as a plain affine matrix; the camera itself
+/// holds only the world point sitting at the viewport center plus the zoom.
+class Camera2D {
+public:
+    /// Drag the view by a screen-space pixel delta (content follows the cursor).
+    void pan_pixels(float dx, float dy);
+
+    /// Zoom by `factor` while keeping the world point under (screen_x, screen_y)
+    /// fixed on screen. vw/vh are the current viewport size in pixels.
+    void zoom_at(float screen_x, float screen_y, float factor, float vw, float vh);
+
+    void reset(float center_x, float center_y, float zoom);
+
+    float zoom()     const { return zoom_; }
+    float center_x() const { return cx_; }
+    float center_y() const { return cy_; }
+
+    /// world → screen(px) affine, column-major (matches demo mat helpers).
+    void build_view(float* out16, float vw, float vh) const;
+
+    /// screen(px) → clip ortho, column-major. Y points down (row 0 = top).
+    static void build_proj(float* out16, float vw, float vh);
+
+private:
+    float cx_   = 0.0f;   // world point at viewport center
+    float cy_   = 0.0f;
+    float zoom_ = 1.0f;
+
+    static constexpr float kMinZoom = 0.01f;
+    static constexpr float kMaxZoom = 64.0f;
+};
+
+} // namespace pictor::graph

--- a/demo/graph/graph_generator.cpp
+++ b/demo/graph/graph_generator.cpp
@@ -1,0 +1,103 @@
+#include "graph_generator.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace pictor::graph {
+
+namespace {
+
+/// Small deterministic LCG so the demo graph is reproducible across runs
+/// without pulling in <random> (and without any global state).
+struct Lcg {
+    uint32_t state;
+    explicit Lcg(uint32_t seed) : state(seed ? seed : 0x9E3779B9u) {}
+    uint32_t next() {
+        state = state * 1664525u + 1013904223u;
+        return state;
+    }
+    // Uniform in [0, n).
+    uint32_t below(uint32_t n) { return n ? (next() % n) : 0u; }
+    float unit() { return static_cast<float>(next() >> 8) / 16777216.0f; }
+};
+
+// Palette indexed by NodeKind — kept readable on the dark clear color.
+constexpr uint32_t kKindColor[static_cast<int>(NodeKind::Count)] = {
+    0x4FA3FFFFu, // Function  — blue
+    0x6BD389FFu, // Method    — green
+    0xE0B04AFFu, // Variable  — amber
+    0xC080F0FFu, // Type      — violet
+    0x9AA0A6FFu, // Other     — grey
+};
+
+} // namespace
+
+GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed) {
+    GraphStore store;
+    if (node_count == 0) return store;
+
+    Lcg rng(seed);
+
+    // Roughly square aspect: ~sqrt(N) nodes per layer.
+    const uint32_t per_layer =
+        std::max(1u, static_cast<uint32_t>(std::sqrt(static_cast<double>(node_count))));
+    const uint32_t layer_count = (node_count + per_layer - 1u) / per_layer;
+
+    constexpr float kNodeW    = 120.0f;
+    constexpr float kNodeH    = 44.0f;
+    constexpr float kGapX     = 70.0f;
+    constexpr float kGapY     = 90.0f;
+    const float     stride_x  = kNodeW + kGapX;
+    const float     stride_y  = kNodeH + kGapY;
+
+    store.reserve(node_count, static_cast<size_t>(node_count) * 2u);
+
+    // Remember where each layer's nodes start so edges can target the next one.
+    std::vector<uint32_t> layer_begin;
+    layer_begin.reserve(layer_count + 1u);
+
+    uint32_t made = 0;
+    for (uint32_t layer = 0; layer < layer_count && made < node_count; ++layer) {
+        layer_begin.push_back(made);
+        const uint32_t in_this = std::min(per_layer, node_count - made);
+
+        // Center each layer horizontally for a tidy spread.
+        const float row_w = static_cast<float>(in_this) * stride_x;
+        const float x0    = -row_w * 0.5f;
+        const float y     = static_cast<float>(layer) * stride_y;
+
+        for (uint32_t i = 0; i < in_this; ++i) {
+            const float x = x0 + static_cast<float>(i) * stride_x;
+            // Slight jitter so the grid does not look mechanical.
+            const float jx = (rng.unit() - 0.5f) * kGapX * 0.5f;
+            const auto  kind = static_cast<NodeKind>(rng.below(static_cast<uint32_t>(NodeKind::Count)));
+            store.add_node(x + jx, y, kNodeW, kNodeH,
+                           kKindColor[static_cast<int>(kind)], kind);
+            ++made;
+        }
+    }
+    layer_begin.push_back(made);
+
+    // Forward edges: each node points at 1–3 nodes in the next layer.
+    for (uint32_t layer = 0; layer + 1u < static_cast<uint32_t>(layer_begin.size()) - 1u; ++layer) {
+        const uint32_t begin = layer_begin[layer];
+        const uint32_t end   = layer_begin[layer + 1u];
+        const uint32_t next_begin = layer_begin[layer + 1u];
+        const uint32_t next_end   = layer_begin[layer + 2u];
+        const uint32_t next_size  = next_end - next_begin;
+        if (next_size == 0) continue;
+
+        for (uint32_t n = begin; n < end; ++n) {
+            const uint32_t fanout = 1u + rng.below(3u);
+            for (uint32_t f = 0; f < fanout; ++f) {
+                const uint32_t target = next_begin + rng.below(next_size);
+                store.add_edge(n, target, EdgeKind::Call);
+            }
+        }
+    }
+
+    return store;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/graph_generator.h
+++ b/demo/graph/graph_generator.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+#include "graph_store.h"
+
+namespace pictor::graph {
+
+/// Generate a deterministic, layered synthetic graph for the Step 1 stress
+/// test (no real clangd data yet). Positions are fixed at generation time
+/// (Sugiyama layout is a later step); the goal is only to prove that N boxes +
+/// edges pan/zoom without melting.
+///
+/// Nodes are laid out in horizontal layers; each node connects forward to a
+/// few nodes in the next layer, approximating a call hierarchy fan-out.
+GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed = 1u);
+
+} // namespace pictor::graph

--- a/demo/graph/graph_renderer.cpp
+++ b/demo/graph/graph_renderer.cpp
@@ -1,0 +1,430 @@
+#include "graph_renderer.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include "graph_store.h"
+#include "pictor/surface/vulkan_context.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace pictor::graph {
+
+namespace {
+
+inline void unpack_rgba(uint32_t rgba, float out[4]) {
+    out[0] = static_cast<float>((rgba >> 24) & 0xFFu) / 255.0f;
+    out[1] = static_cast<float>((rgba >> 16) & 0xFFu) / 255.0f;
+    out[2] = static_cast<float>((rgba >> 8)  & 0xFFu) / 255.0f;
+    out[3] = static_cast<float>( rgba        & 0xFFu) / 255.0f;
+}
+
+constexpr float kEdgeThicknessPx = 1.5f;
+
+} // namespace
+
+GraphRenderer::~GraphRenderer() {
+    if (initialized_) shutdown();
+}
+
+bool GraphRenderer::initialize(VulkanContext& vk_ctx, const char* shader_dir,
+                               const GraphStore& store) {
+    printf("[Graph] Initializing (%zu nodes, %zu edges)...\n",
+           store.node_count(), store.edge_count());
+    vk_ctx_ = &vk_ctx;
+    device_ = vk_ctx.device();
+
+    if (!build_instance_buffers(store)) {
+        fprintf(stderr, "[Graph] Failed to build instance buffers\n");
+        return false;
+    }
+    if (!create_descriptors()) {
+        fprintf(stderr, "[Graph] Failed to create descriptors\n");
+        return false;
+    }
+
+    const std::string node_vert = std::string(shader_dir) + "/graph_node.vert.spv";
+    const std::string edge_vert = std::string(shader_dir) + "/graph_edge.vert.spv";
+    const std::string flat_frag = std::string(shader_dir) + "/graph_flat.frag.spv";
+
+    if (!create_pipeline(node_vert.c_str(), flat_frag.c_str(), node_pipeline_) ||
+        !create_pipeline(edge_vert.c_str(), flat_frag.c_str(), edge_pipeline_)) {
+        fprintf(stderr, "[Graph] Failed to create pipelines\n");
+        return false;
+    }
+
+    initialized_ = true;
+    printf("[Graph] Initialization complete\n");
+    return true;
+}
+
+void GraphRenderer::shutdown() {
+    if (!initialized_ && !vk_ctx_) return;
+    vkDeviceWaitIdle(device_);
+
+    if (node_pipeline_)   vkDestroyPipeline(device_, node_pipeline_, nullptr);
+    if (edge_pipeline_)   vkDestroyPipeline(device_, edge_pipeline_, nullptr);
+    if (pipeline_layout_) vkDestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+    if (desc_pool_)       vkDestroyDescriptorPool(device_, desc_pool_, nullptr);
+    if (desc_set_layout_) vkDestroyDescriptorSetLayout(device_, desc_set_layout_, nullptr);
+
+    auto destroy_buf = [&](VkBuffer& b, VkDeviceMemory& m) {
+        if (b) vkDestroyBuffer(device_, b, nullptr);
+        if (m) vkFreeMemory(device_, m, nullptr);
+        b = VK_NULL_HANDLE; m = VK_NULL_HANDLE;
+    };
+    destroy_buf(node_buffer_, node_memory_);
+    destroy_buf(edge_buffer_, edge_memory_);
+
+    node_pipeline_   = VK_NULL_HANDLE;
+    edge_pipeline_   = VK_NULL_HANDLE;
+    pipeline_layout_ = VK_NULL_HANDLE;
+    desc_pool_       = VK_NULL_HANDLE;
+    desc_set_layout_ = VK_NULL_HANDLE;
+    initialized_     = false;
+}
+
+// ─── Instance buffers ────────────────────────────────────────
+
+bool GraphRenderer::build_instance_buffers(const GraphStore& store) {
+    const auto& nodes = store.nodes();
+    const auto& edges = store.edges();
+    node_count_ = static_cast<uint32_t>(store.node_count());
+    edge_count_ = static_cast<uint32_t>(store.edge_count());
+
+    // Nodes → flat AoS instance records.
+    std::vector<NodeInstance> node_inst(node_count_);
+    for (uint32_t i = 0; i < node_count_; ++i) {
+        NodeInstance& d = node_inst[i];
+        d.rect[0] = nodes.cx[i];
+        d.rect[1] = nodes.cy[i];
+        d.rect[2] = nodes.w[i];
+        d.rect[3] = nodes.h[i];
+        unpack_rgba(nodes.rgba[i], d.color);
+    }
+
+    // Edges → endpoints looked up from node centers (cold path, once).
+    std::vector<EdgeInstance> edge_inst(edge_count_);
+    for (uint32_t i = 0; i < edge_count_; ++i) {
+        const uint32_t a = edges.from[i];
+        const uint32_t b = edges.to[i];
+        EdgeInstance& d = edge_inst[i];
+        d.ends[0] = nodes.cx[a];
+        d.ends[1] = nodes.cy[a];
+        d.ends[2] = nodes.cx[b];
+        d.ends[3] = nodes.cy[b];
+        d.color[0] = 0.45f; d.color[1] = 0.50f; d.color[2] = 0.58f; // muted grey-blue
+        d.color[3] = kEdgeThicknessPx;
+    }
+
+    // Vulkan disallows zero-size buffers; keep a 1-record floor so binding is valid.
+    const VkDeviceSize node_bytes =
+        std::max<VkDeviceSize>(1, node_count_) * sizeof(NodeInstance);
+    const VkDeviceSize edge_bytes =
+        std::max<VkDeviceSize>(1, edge_count_) * sizeof(EdgeInstance);
+
+    if (!create_storage_buffer(node_bytes, node_inst.empty() ? nullptr : node_inst.data(),
+                               node_buffer_, node_memory_))
+        return false;
+    if (!create_storage_buffer(edge_bytes, edge_inst.empty() ? nullptr : edge_inst.data(),
+                               edge_buffer_, edge_memory_))
+        return false;
+    return true;
+}
+
+bool GraphRenderer::create_storage_buffer(VkDeviceSize size, const void* data,
+                                          VkBuffer& buf, VkDeviceMemory& mem) {
+    VkBufferCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    info.size  = size;
+    info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+
+    if (vkCreateBuffer(device_, &info, nullptr, &buf) != VK_SUCCESS)
+        return false;
+
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(device_, buf, &req);
+
+    VkMemoryAllocateInfo alloc{};
+    alloc.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    alloc.allocationSize  = req.size;
+    alloc.memoryTypeIndex = find_memory_type(
+        req.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+
+    if (vkAllocateMemory(device_, &alloc, nullptr, &mem) != VK_SUCCESS) {
+        vkDestroyBuffer(device_, buf, nullptr);
+        buf = VK_NULL_HANDLE;
+        return false;
+    }
+    vkBindBufferMemory(device_, buf, mem, 0);
+
+    if (data) {
+        void* mapped = nullptr;
+        vkMapMemory(device_, mem, 0, size, 0, &mapped);
+        std::memcpy(mapped, data, static_cast<size_t>(size));
+        vkUnmapMemory(device_, mem);
+    }
+    return true;
+}
+
+// ─── Descriptors ─────────────────────────────────────────────
+
+bool GraphRenderer::create_descriptors() {
+    VkDescriptorSetLayoutBinding binding{};
+    binding.binding         = 0;
+    binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    binding.descriptorCount = 1;
+    binding.stageFlags      = VK_SHADER_STAGE_VERTEX_BIT;
+
+    VkDescriptorSetLayoutCreateInfo layout_info{};
+    layout_info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layout_info.bindingCount = 1;
+    layout_info.pBindings    = &binding;
+    if (vkCreateDescriptorSetLayout(device_, &layout_info, nullptr, &desc_set_layout_) != VK_SUCCESS)
+        return false;
+
+    VkDescriptorPoolSize pool_size{};
+    pool_size.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    pool_size.descriptorCount = 2;
+
+    VkDescriptorPoolCreateInfo pool_info{};
+    pool_info.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pool_info.maxSets       = 2;
+    pool_info.poolSizeCount = 1;
+    pool_info.pPoolSizes    = &pool_size;
+    if (vkCreateDescriptorPool(device_, &pool_info, nullptr, &desc_pool_) != VK_SUCCESS)
+        return false;
+
+    auto alloc_set = [&](VkDescriptorSet& out) -> bool {
+        VkDescriptorSetAllocateInfo a{};
+        a.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        a.descriptorPool     = desc_pool_;
+        a.descriptorSetCount = 1;
+        a.pSetLayouts        = &desc_set_layout_;
+        return vkAllocateDescriptorSets(device_, &a, &out) == VK_SUCCESS;
+    };
+    if (!alloc_set(node_set_) || !alloc_set(edge_set_))
+        return false;
+
+    bind_storage_descriptor(node_set_, node_buffer_, VK_WHOLE_SIZE);
+    bind_storage_descriptor(edge_set_, edge_buffer_, VK_WHOLE_SIZE);
+    return true;
+}
+
+void GraphRenderer::bind_storage_descriptor(VkDescriptorSet set, VkBuffer buf,
+                                            VkDeviceSize range) {
+    VkDescriptorBufferInfo info{};
+    info.buffer = buf;
+    info.offset = 0;
+    info.range  = range;
+
+    VkWriteDescriptorSet write{};
+    write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet          = set;
+    write.dstBinding      = 0;
+    write.descriptorCount = 1;
+    write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    write.pBufferInfo     = &info;
+    vkUpdateDescriptorSets(device_, 1, &write, 0, nullptr);
+}
+
+// ─── Pipeline ────────────────────────────────────────────────
+
+bool GraphRenderer::create_pipeline(const char* vert_spv, const char* frag_spv,
+                                    VkPipeline& out) {
+    VkShaderModule vert = load_shader(vert_spv);
+    VkShaderModule frag = load_shader(frag_spv);
+    if (!vert || !frag) {
+        if (vert) vkDestroyShaderModule(device_, vert, nullptr);
+        if (frag) vkDestroyShaderModule(device_, frag, nullptr);
+        return false;
+    }
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = vert;
+    stages[0].pName  = "main";
+    stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = frag;
+    stages[1].pName  = "main";
+
+    // No vertex buffers: geometry comes from gl_VertexIndex in the shader.
+    VkPipelineVertexInputStateCreateInfo vertex_input{};
+    vertex_input.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vp{};
+    vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vp.viewportCount = 1;
+    vp.scissorCount  = 1;
+
+    VkPipelineRasterizationStateCreateInfo raster{};
+    raster.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    raster.polygonMode = VK_POLYGON_MODE_FILL;
+    raster.cullMode    = VK_CULL_MODE_NONE;
+    raster.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    raster.lineWidth   = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{};
+    ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    ds.depthTestEnable  = VK_FALSE;
+    ds.depthWriteEnable = VK_FALSE;
+
+    VkPipelineColorBlendAttachmentState blend_att{};
+    blend_att.blendEnable         = VK_TRUE;
+    blend_att.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    blend_att.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blend_att.colorBlendOp        = VK_BLEND_OP_ADD;
+    blend_att.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    blend_att.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    blend_att.alphaBlendOp        = VK_BLEND_OP_ADD;
+    blend_att.colorWriteMask      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                                    VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineColorBlendStateCreateInfo blend{};
+    blend.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    blend.attachmentCount = 1;
+    blend.pAttachments    = &blend_att;
+
+    VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo dyn{};
+    dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn.dynamicStateCount = 2;
+    dyn.pDynamicStates    = dyn_states;
+
+    // Pipeline layout is shared by both pipelines; create it once (lazily).
+    if (pipeline_layout_ == VK_NULL_HANDLE) {
+        VkPushConstantRange push_range{};
+        push_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+        push_range.offset     = 0;
+        push_range.size       = sizeof(GraphPushConstants);
+
+        VkPipelineLayoutCreateInfo layout_info{};
+        layout_info.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+        layout_info.setLayoutCount         = 1;
+        layout_info.pSetLayouts            = &desc_set_layout_;
+        layout_info.pushConstantRangeCount = 1;
+        layout_info.pPushConstantRanges    = &push_range;
+        if (vkCreatePipelineLayout(device_, &layout_info, nullptr, &pipeline_layout_) != VK_SUCCESS) {
+            vkDestroyShaderModule(device_, vert, nullptr);
+            vkDestroyShaderModule(device_, frag, nullptr);
+            return false;
+        }
+    }
+
+    VkGraphicsPipelineCreateInfo pi{};
+    pi.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pi.stageCount          = 2;
+    pi.pStages             = stages;
+    pi.pVertexInputState   = &vertex_input;
+    pi.pInputAssemblyState = &ia;
+    pi.pViewportState      = &vp;
+    pi.pRasterizationState = &raster;
+    pi.pMultisampleState   = &ms;
+    pi.pDepthStencilState  = &ds;
+    pi.pColorBlendState    = &blend;
+    pi.pDynamicState       = &dyn;
+    pi.layout              = pipeline_layout_;
+    pi.renderPass          = vk_ctx_->default_render_pass();
+    pi.subpass             = 0;
+
+    VkResult result = vkCreateGraphicsPipelines(device_, VK_NULL_HANDLE, 1, &pi, nullptr, &out);
+    vkDestroyShaderModule(device_, vert, nullptr);
+    vkDestroyShaderModule(device_, frag, nullptr);
+
+    if (result != VK_SUCCESS) {
+        fprintf(stderr, "[Graph] vkCreateGraphicsPipelines failed (%d)\n", result);
+        return false;
+    }
+    return true;
+}
+
+// ─── Render ──────────────────────────────────────────────────
+
+void GraphRenderer::render(VkCommandBuffer cmd, VkExtent2D extent,
+                           const GraphPushConstants& pc) {
+    if (!initialized_) return;
+
+    VkViewport viewport{};
+    viewport.width    = static_cast<float>(extent.width);
+    viewport.height   = static_cast<float>(extent.height);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    vkCmdSetViewport(cmd, 0, 1, &viewport);
+
+    VkRect2D scissor = {{0, 0}, extent};
+    vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+    vkCmdPushConstants(cmd, pipeline_layout_, VK_SHADER_STAGE_VERTEX_BIT,
+                       0, sizeof(GraphPushConstants), &pc);
+
+    // Edges first (under), then nodes on top.
+    if (edge_count_ > 0) {
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, edge_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                pipeline_layout_, 0, 1, &edge_set_, 0, nullptr);
+        vkCmdDraw(cmd, 6, edge_count_, 0, 0);
+    }
+    if (node_count_ > 0) {
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, node_pipeline_);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                pipeline_layout_, 0, 1, &node_set_, 0, nullptr);
+        vkCmdDraw(cmd, 6, node_count_, 0, 0);
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+VkShaderModule GraphRenderer::load_shader(const char* path) {
+    std::ifstream file(path, std::ios::ate | std::ios::binary);
+    if (!file.is_open()) {
+        fprintf(stderr, "[Graph] Cannot open shader: %s\n", path);
+        return VK_NULL_HANDLE;
+    }
+    const size_t size = static_cast<size_t>(file.tellg());
+    std::vector<char> code(size);
+    file.seekg(0);
+    file.read(code.data(), static_cast<std::streamsize>(size));
+
+    VkShaderModuleCreateInfo info{};
+    info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    info.codeSize = size;
+    info.pCode    = reinterpret_cast<const uint32_t*>(code.data());
+
+    VkShaderModule mod = VK_NULL_HANDLE;
+    if (vkCreateShaderModule(device_, &info, nullptr, &mod) != VK_SUCCESS) {
+        fprintf(stderr, "[Graph] Failed to create shader module: %s\n", path);
+    }
+    return mod;
+}
+
+uint32_t GraphRenderer::find_memory_type(uint32_t type_filter, VkMemoryPropertyFlags props) {
+    VkPhysicalDeviceMemoryProperties mem_props;
+    vkGetPhysicalDeviceMemoryProperties(vk_ctx_->physical_device(), &mem_props);
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
+        if ((type_filter & (1u << i)) &&
+            (mem_props.memoryTypes[i].propertyFlags & props) == props) {
+            return i;
+        }
+    }
+    fprintf(stderr, "[Graph] No suitable memory type\n");
+    return 0;
+}
+
+} // namespace pictor::graph
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/graph_renderer.h
+++ b/demo/graph/graph_renderer.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace pictor {
+
+class VulkanContext;
+
+namespace graph {
+
+class GraphStore;
+
+/// Push constants shared by the node and edge pipelines (matches shader layout).
+struct GraphPushConstants {
+    float proj[16];    // screen px → clip
+    float view[16];    // world → screen px (pan/zoom)
+    float params[4];   // x = zoom (edge thickness compensation), yzw reserved
+};
+
+/// Instanced, DoD graph renderer (Iter relation-graph, Step 1).
+///
+/// Two pipelines, each driven entirely by gl_VertexIndex + an SSBO of flat
+/// instance records — no per-vertex buffers, one draw call per primitive type:
+///   - edges: instanced quad stretched along each segment (drawn first, under)
+///   - nodes: instanced rounded-box quad (drawn on top)
+///
+/// Instance data is packed once at initialize() from the SoA GraphStore; the
+/// hot render path only binds + issues two vkCmdDraw calls.
+class GraphRenderer {
+public:
+    GraphRenderer() = default;
+    ~GraphRenderer();
+
+    GraphRenderer(const GraphRenderer&)            = delete;
+    GraphRenderer& operator=(const GraphRenderer&) = delete;
+
+    bool initialize(VulkanContext& vk_ctx, const char* shader_dir, const GraphStore& store);
+    void shutdown();
+
+    /// Record both draws into `cmd` (must be inside a render pass).
+    void render(VkCommandBuffer cmd, VkExtent2D extent, const GraphPushConstants& pc);
+
+    uint32_t node_count() const { return node_count_; }
+    uint32_t edge_count() const { return edge_count_; }
+    bool     is_initialized() const { return initialized_; }
+
+private:
+    // GPU-packed instance records (std430: vec4 + vec4 = 32 bytes).
+    struct NodeInstance { float rect[4];  float color[4]; }; // rect = cx,cy,w,h
+    struct EdgeInstance { float ends[4];  float color[4]; }; // ends = ax,ay,bx,by; color.a = thickness(px)
+
+    bool build_instance_buffers(const GraphStore& store);
+    bool create_descriptors();
+    bool create_pipeline(const char* vert_spv, const char* frag_spv, VkPipeline& out);
+
+    VkShaderModule load_shader(const char* path);
+    uint32_t       find_memory_type(uint32_t type_filter, VkMemoryPropertyFlags props);
+    bool           create_storage_buffer(VkDeviceSize size, const void* data,
+                                         VkBuffer& buf, VkDeviceMemory& mem);
+    void           bind_storage_descriptor(VkDescriptorSet set, VkBuffer buf, VkDeviceSize range);
+
+    VulkanContext* vk_ctx_ = nullptr;
+    VkDevice       device_ = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout desc_set_layout_ = VK_NULL_HANDLE;
+    VkDescriptorPool      desc_pool_       = VK_NULL_HANDLE;
+    VkDescriptorSet       node_set_        = VK_NULL_HANDLE;
+    VkDescriptorSet       edge_set_        = VK_NULL_HANDLE;
+
+    VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline       node_pipeline_   = VK_NULL_HANDLE;
+    VkPipeline       edge_pipeline_   = VK_NULL_HANDLE;
+
+    VkBuffer       node_buffer_ = VK_NULL_HANDLE;
+    VkDeviceMemory node_memory_ = VK_NULL_HANDLE;
+    VkBuffer       edge_buffer_ = VK_NULL_HANDLE;
+    VkDeviceMemory edge_memory_ = VK_NULL_HANDLE;
+
+    uint32_t node_count_ = 0;
+    uint32_t edge_count_ = 0;
+
+    bool initialized_ = false;
+};
+
+} // namespace graph
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/graph_store.cpp
+++ b/demo/graph/graph_store.cpp
@@ -1,0 +1,38 @@
+#include "graph_store.h"
+
+namespace pictor::graph {
+
+void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
+    nodes_.cx.reserve(node_capacity);
+    nodes_.cy.reserve(node_capacity);
+    nodes_.w.reserve(node_capacity);
+    nodes_.h.reserve(node_capacity);
+    nodes_.rgba.reserve(node_capacity);
+    nodes_.kind.reserve(node_capacity);
+    nodes_.flags.reserve(node_capacity);
+
+    edges_.from.reserve(edge_capacity);
+    edges_.to.reserve(edge_capacity);
+    edges_.kind.reserve(edge_capacity);
+}
+
+NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
+                                uint32_t rgba, NodeKind kind) {
+    const NodeHandle handle = static_cast<NodeHandle>(nodes_.cx.size());
+    nodes_.cx.push_back(cx);
+    nodes_.cy.push_back(cy);
+    nodes_.w.push_back(w);
+    nodes_.h.push_back(h);
+    nodes_.rgba.push_back(rgba);
+    nodes_.kind.push_back(static_cast<uint8_t>(kind));
+    nodes_.flags.push_back(0);
+    return handle;
+}
+
+void GraphStore::add_edge(NodeHandle from, NodeHandle to, EdgeKind kind) {
+    edges_.from.push_back(from);
+    edges_.to.push_back(to);
+    edges_.kind.push_back(static_cast<uint8_t>(kind));
+}
+
+} // namespace pictor::graph

--- a/demo/graph/graph_store.h
+++ b/demo/graph/graph_store.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace pictor::graph {
+
+using NodeHandle = uint32_t;
+constexpr NodeHandle INVALID_NODE = 0xFFFFFFFFu;
+
+/// Semantic kind of a graph node (drives default color). Mirrors the
+/// caller/callee/reference vocabulary Iter surfaces from clangd.
+enum class NodeKind : uint8_t {
+    Function = 0,
+    Method,
+    Variable,
+    Type,
+    Other,
+    Count
+};
+
+/// Edge relation kind. Phase 1 only renders them as flat lines, but the kind
+/// is carried so later phases can color/route by relation.
+enum class EdgeKind : uint8_t {
+    Call = 0,
+    Reference,
+    Override,
+    Count
+};
+
+/// Struct-of-Arrays graph store (Iter relation-graph, Step 1).
+///
+/// DoD discipline (Pictor CLAUDE.md): the per-node parallel arrays are the only
+/// data the render / cull hot path touches, indexed by NodeHandle. Symbol
+/// strings and the id→handle map live on the cold side and are read once at
+/// build / expand time, never per frame. Node arrays are append-only so live
+/// handles stay stable (required for animation + incremental expand later).
+class GraphStore {
+public:
+    struct Nodes {
+        std::vector<float>    cx, cy;   // center, world units
+        std::vector<float>    w, h;     // box size, world units
+        std::vector<uint32_t> rgba;     // packed 0xRRGGBBAA
+        std::vector<uint8_t>  kind;     // NodeKind
+        std::vector<uint8_t>  flags;    // selected/hovered/... (Step 1: unused)
+    };
+
+    struct Edges {
+        std::vector<uint32_t> from;     // NodeHandle
+        std::vector<uint32_t> to;       // NodeHandle
+        std::vector<uint8_t>  kind;     // EdgeKind
+    };
+
+    void reserve(size_t node_capacity, size_t edge_capacity);
+
+    NodeHandle add_node(float cx, float cy, float w, float h,
+                        uint32_t rgba, NodeKind kind);
+    void       add_edge(NodeHandle from, NodeHandle to, EdgeKind kind = EdgeKind::Call);
+
+    size_t       node_count() const { return nodes_.cx.size(); }
+    size_t       edge_count() const { return edges_.from.size(); }
+    const Nodes& nodes()      const { return nodes_; }
+    const Edges& edges()      const { return edges_; }
+
+private:
+    Nodes nodes_;
+    Edges edges_;
+};
+
+} // namespace pictor::graph

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -1,0 +1,275 @@
+/// Pictor — Iter Relation Graph Demo (Step 1)
+///
+/// Renders a large synthetic node/edge graph with an instanced/DoD pipeline to
+/// prove that ~10k boxes + edges pan/zoom smoothly on the desktop — the case
+/// web graph renderers (React Flow et al., used by Iter) choke on. Real clangd
+/// data, layout solving, labels and snippets come in later steps.
+///
+/// Controls:
+///   Drag        : pan
+///   Scroll      : zoom (towards cursor)
+///   R           : reset view
+///   Esc         : quit
+///
+/// Args:
+///   --nodes  N  : node count        (default 10000)
+///   --frames N  : auto-exit after N frames, 0 = run until closed (default 0)
+
+#include "pictor/surface/vulkan_context.h"
+#include "pictor/surface/glfw_surface_provider.h"
+#include "graph_store.h"
+#include "graph_generator.h"
+#include "graph_renderer.h"
+#include "camera2d.h"
+
+#include <GLFW/glfw3.h>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+using namespace pictor;
+using namespace pictor::graph;
+
+// ─── Input state ─────────────────────────────────────────────
+
+struct AppState {
+    Camera2D camera;
+    bool     dragging     = false;
+    double   last_mouse_x = 0.0;
+    double   last_mouse_y = 0.0;
+    float    viewport_w   = 1280.0f;
+    float    viewport_h   = 720.0f;
+    bool     reset_view   = false;
+
+    // Initial "fit whole graph" framing, captured at startup so R re-fits.
+    float    fit_cx       = 0.0f;
+    float    fit_cy       = 0.0f;
+    float    fit_zoom     = 1.0f;
+};
+
+static AppState g_state;
+
+static void mouse_button_callback(GLFWwindow* win, int button, int action, int) {
+    if (button == GLFW_MOUSE_BUTTON_LEFT) {
+        g_state.dragging = (action == GLFW_PRESS);
+        if (g_state.dragging)
+            glfwGetCursorPos(win, &g_state.last_mouse_x, &g_state.last_mouse_y);
+    }
+}
+
+static void cursor_pos_callback(GLFWwindow*, double x, double y) {
+    if (!g_state.dragging) return;
+    const float dx = static_cast<float>(x - g_state.last_mouse_x);
+    const float dy = static_cast<float>(y - g_state.last_mouse_y);
+    g_state.camera.pan_pixels(dx, dy);
+    g_state.last_mouse_x = x;
+    g_state.last_mouse_y = y;
+}
+
+static void scroll_callback(GLFWwindow* win, double, double yoffset) {
+    double mx = 0.0, my = 0.0;
+    glfwGetCursorPos(win, &mx, &my);
+    const float factor = (yoffset > 0) ? 1.15f : (1.0f / 1.15f);
+    g_state.camera.zoom_at(static_cast<float>(mx), static_cast<float>(my),
+                           factor, g_state.viewport_w, g_state.viewport_h);
+}
+
+static void key_callback(GLFWwindow* win, int key, int, int action, int) {
+    if (action != GLFW_PRESS) return;
+    if (key == GLFW_KEY_R)      g_state.reset_view = true;
+    if (key == GLFW_KEY_ESCAPE) glfwSetWindowShouldClose(win, GLFW_TRUE);
+}
+
+// ─── Args ────────────────────────────────────────────────────
+
+struct Args {
+    uint32_t nodes  = 10000;
+    uint64_t frames = 0; // 0 = run until window closed
+};
+
+static Args parse_args(int argc, char** argv) {
+    Args a;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--nodes") == 0 && i + 1 < argc)
+            a.nodes = static_cast<uint32_t>(std::strtoul(argv[++i], nullptr, 10));
+        else if (std::strcmp(argv[i], "--frames") == 0 && i + 1 < argc)
+            a.frames = std::strtoull(argv[++i], nullptr, 10);
+    }
+    if (a.nodes == 0) a.nodes = 1;
+    return a;
+}
+
+// ─── Main ────────────────────────────────────────────────────
+
+int main(int argc, char** argv) {
+    const Args args = parse_args(argc, argv);
+    printf("=== Pictor Iter Relation Graph Demo (Step 1) ===\n");
+    printf("[init] Nodes requested: %u  (frames: %llu)\n",
+           args.nodes, static_cast<unsigned long long>(args.frames));
+
+    // ── Window ───────────────────────────────────────────────
+    GlfwSurfaceProvider surface_provider;
+    GlfwWindowConfig win_cfg;
+    win_cfg.width  = 1280;
+    win_cfg.height = 720;
+    win_cfg.title  = "Pictor — Iter Relation Graph (Step 1)";
+    win_cfg.vsync  = true;
+    if (!surface_provider.create(win_cfg)) {
+        fprintf(stderr, "[init] FATAL: Failed to create GLFW window\n");
+        return 1;
+    }
+
+    // ── Vulkan ───────────────────────────────────────────────
+    VulkanContext vk_ctx;
+    VulkanContextConfig vk_cfg;
+    vk_cfg.app_name   = "Pictor Iter Graph Demo";
+    vk_cfg.validation = true;
+    if (!vk_ctx.initialize(&surface_provider, vk_cfg)) {
+        fprintf(stderr, "[init] FATAL: Failed to initialize Vulkan context\n");
+        surface_provider.destroy();
+        return 1;
+    }
+    printf("[init] Vulkan ready. Swapchain: %ux%u\n",
+           vk_ctx.swapchain_extent().width, vk_ctx.swapchain_extent().height);
+
+    // ── Graph data ───────────────────────────────────────────
+    GraphStore store = generate_layered_graph(args.nodes);
+    printf("[init] Generated graph: %zu nodes, %zu edges\n",
+           store.node_count(), store.edge_count());
+
+    // ── Renderer ─────────────────────────────────────────────
+    GraphRenderer graph_renderer;
+    if (!graph_renderer.initialize(vk_ctx, "shaders", store)) {
+        fprintf(stderr, "[init] FATAL: Failed to initialize graph renderer\n");
+        vk_ctx.shutdown();
+        surface_provider.destroy();
+        return 1;
+    }
+
+    // Frame the whole graph: center the camera, pick a zoom that fits.
+    {
+        const auto& n = store.nodes();
+        float min_x = 0, max_x = 0, min_y = 0, max_y = 0;
+        if (store.node_count() > 0) {
+            min_x = max_x = n.cx[0];
+            min_y = max_y = n.cy[0];
+            for (size_t i = 1; i < store.node_count(); ++i) {
+                min_x = (n.cx[i] < min_x) ? n.cx[i] : min_x;
+                max_x = (n.cx[i] > max_x) ? n.cx[i] : max_x;
+                min_y = (n.cy[i] < min_y) ? n.cy[i] : min_y;
+                max_y = (n.cy[i] > max_y) ? n.cy[i] : max_y;
+            }
+        }
+        const float span_x = (max_x - min_x) + 200.0f;
+        const float span_y = (max_y - min_y) + 200.0f;
+        const float zx = static_cast<float>(win_cfg.width)  / span_x;
+        const float zy = static_cast<float>(win_cfg.height) / span_y;
+        g_state.fit_cx   = (min_x + max_x) * 0.5f;
+        g_state.fit_cy   = (min_y + max_y) * 0.5f;
+        g_state.fit_zoom = (zx < zy) ? zx : zy;
+        g_state.camera.reset(g_state.fit_cx, g_state.fit_cy, g_state.fit_zoom);
+    }
+
+    // ── Callbacks ────────────────────────────────────────────
+    GLFWwindow* win = surface_provider.glfw_window();
+    glfwSetMouseButtonCallback(win, mouse_button_callback);
+    glfwSetCursorPosCallback(win, cursor_pos_callback);
+    glfwSetScrollCallback(win, scroll_callback);
+    glfwSetKeyCallback(win, key_callback);
+
+    // ── Loop ─────────────────────────────────────────────────
+    printf("[loop] Controls: Drag=pan, Scroll=zoom, R=reset, Esc=quit\n");
+    uint64_t frame_count = 0;
+    auto fps_t0 = std::chrono::steady_clock::now();
+    uint64_t fps_frames = 0;
+
+    while (!surface_provider.should_close()) {
+        surface_provider.poll_events();
+
+        if (g_state.reset_view) {
+            // R re-fits the whole graph using the framing captured at startup.
+            g_state.reset_view = false;
+            g_state.camera.reset(g_state.fit_cx, g_state.fit_cy, g_state.fit_zoom);
+        }
+
+        const VkExtent2D ext = vk_ctx.swapchain_extent();
+        g_state.viewport_w = static_cast<float>(ext.width);
+        g_state.viewport_h = static_cast<float>(ext.height);
+
+        GraphPushConstants pc{};
+        Camera2D::build_proj(pc.proj, g_state.viewport_w, g_state.viewport_h);
+        g_state.camera.build_view(pc.view, g_state.viewport_w, g_state.viewport_h);
+        pc.params[0] = g_state.camera.zoom();
+
+        const uint32_t image_idx = vk_ctx.acquire_next_image();
+        if (image_idx == UINT32_MAX) continue; // swapchain recreated
+
+        VkCommandBuffer cmd = vk_ctx.command_buffers()[image_idx];
+        vkResetCommandBuffer(cmd, 0);
+
+        VkCommandBufferBeginInfo begin_info{};
+        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        vkBeginCommandBuffer(cmd, &begin_info);
+
+        VkClearValue clear_color = {{{0.09f, 0.10f, 0.13f, 1.0f}}};
+        VkRenderPassBeginInfo rp_info{};
+        rp_info.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp_info.renderPass      = vk_ctx.default_render_pass();
+        rp_info.framebuffer     = vk_ctx.framebuffers()[image_idx];
+        rp_info.renderArea      = {{0, 0}, ext};
+        rp_info.clearValueCount = 1;
+        rp_info.pClearValues    = &clear_color;
+        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+
+        graph_renderer.render(cmd, ext, pc);
+
+        vkCmdEndRenderPass(cmd);
+        vkEndCommandBuffer(cmd);
+
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSemaphore wait_sem = vk_ctx.image_available_semaphore();
+        VkSemaphore sig_sem  = vk_ctx.render_finished_semaphore();
+
+        VkSubmitInfo submit_info{};
+        submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.waitSemaphoreCount   = 1;
+        submit_info.pWaitSemaphores      = &wait_sem;
+        submit_info.pWaitDstStageMask    = &wait_stage;
+        submit_info.commandBufferCount   = 1;
+        submit_info.pCommandBuffers      = &cmd;
+        submit_info.signalSemaphoreCount = 1;
+        submit_info.pSignalSemaphores    = &sig_sem;
+        vkQueueSubmit(vk_ctx.graphics_queue(), 1, &submit_info, vk_ctx.in_flight_fence());
+
+        vk_ctx.present(image_idx);
+
+        ++frame_count;
+        ++fps_frames;
+        auto now = std::chrono::steady_clock::now();
+        double elapsed = std::chrono::duration<double>(now - fps_t0).count();
+        if (elapsed >= 1.0) {
+            printf("[loop] FPS: %.1f | nodes: %u edges: %u | zoom: %.3f\n",
+                   fps_frames / elapsed, graph_renderer.node_count(),
+                   graph_renderer.edge_count(), g_state.camera.zoom());
+            fps_t0 = now;
+            fps_frames = 0;
+        }
+
+        if (args.frames != 0 && frame_count >= args.frames) {
+            printf("[loop] Reached --frames %llu, exiting\n",
+                   static_cast<unsigned long long>(args.frames));
+            break;
+        }
+    }
+
+    // ── Cleanup (reverse order) ──────────────────────────────
+    vk_ctx.device_wait_idle();
+    graph_renderer.shutdown();
+    vk_ctx.shutdown();
+    surface_provider.destroy();
+    printf("[cleanup] Done. %llu frames.\n",
+           static_cast<unsigned long long>(frame_count));
+    return 0;
+}

--- a/demo/graph/shaders/graph_edge.vert
+++ b/demo/graph/shaders/graph_edge.vert
@@ -1,0 +1,50 @@
+#version 450
+
+// Instanced edge: a unit quad stretched along the segment a->b, with a
+// screen-constant thickness (thickness px / zoom -> world units).
+
+layout(push_constant) uniform PushConstants {
+    mat4 proj;      // screen px -> clip
+    mat4 view;      // world -> screen px (pan/zoom)
+    vec4 params;    // x = zoom
+} pc;
+
+struct EdgeInstance {
+    vec4 ends;      // ax, ay, bx, by  (world units)
+    vec4 color;     // rgb + thickness(px) in .a
+};
+
+layout(std430, set = 0, binding = 0) readonly buffer Edges {
+    EdgeInstance edges[];
+};
+
+layout(location = 0) out vec4 vColor;
+
+vec2 corner(int i) {
+    // x in [0,1] = t along the segment, y in [-0.5,0.5] = side.
+    if (i == 0) return vec2(0.0, -0.5);
+    if (i == 1) return vec2(1.0, -0.5);
+    if (i == 2) return vec2(1.0,  0.5);
+    if (i == 3) return vec2(0.0, -0.5);
+    if (i == 4) return vec2(1.0,  0.5);
+    return vec2(0.0, 0.5);
+}
+
+void main() {
+    EdgeInstance e = edges[gl_InstanceIndex];
+    vec2 a = e.ends.xy;
+    vec2 b = e.ends.zw;
+    vec2 q = corner(gl_VertexIndex);
+
+    vec2 delta = b - a;
+    float len = length(delta);
+    vec2 dir = (len > 1e-6) ? delta / len : vec2(1.0, 0.0);
+    vec2 nrm = vec2(-dir.y, dir.x);
+
+    float zoom = max(pc.params.x, 1e-6);
+    float thick_world = e.color.a / zoom;   // constant pixels on screen
+
+    vec2 world = a + dir * (q.x * len) + nrm * (q.y * thick_world);
+    gl_Position = pc.proj * pc.view * vec4(world, 0.0, 1.0);
+    vColor = vec4(e.color.rgb, 1.0);
+}

--- a/demo/graph/shaders/graph_flat.frag
+++ b/demo/graph/shaders/graph_flat.frag
@@ -1,0 +1,10 @@
+#version 450
+
+// Flat passthrough fragment shader shared by the node and edge pipelines.
+
+layout(location = 0) in  vec4 vColor;
+layout(location = 0) out vec4 outColor;
+
+void main() {
+    outColor = vColor;
+}

--- a/demo/graph/shaders/graph_node.vert
+++ b/demo/graph/shaders/graph_node.vert
@@ -1,0 +1,39 @@
+#version 450
+
+// Instanced node quad. Geometry comes purely from gl_VertexIndex (6 verts,
+// two triangles) + a flat SSBO record per instance — no vertex buffer.
+
+layout(push_constant) uniform PushConstants {
+    mat4 proj;      // screen px -> clip
+    mat4 view;      // world -> screen px (pan/zoom)
+    vec4 params;    // x = zoom (unused for nodes)
+} pc;
+
+struct NodeInstance {
+    vec4 rect;      // cx, cy, w, h  (world units)
+    vec4 color;     // rgba 0..1
+};
+
+layout(std430, set = 0, binding = 0) readonly buffer Nodes {
+    NodeInstance nodes[];
+};
+
+layout(location = 0) out vec4 vColor;
+
+vec2 corner(int i) {
+    // CCW unit quad in [-0.5, 0.5], two triangles.
+    if (i == 0) return vec2(-0.5, -0.5);
+    if (i == 1) return vec2( 0.5, -0.5);
+    if (i == 2) return vec2( 0.5,  0.5);
+    if (i == 3) return vec2(-0.5, -0.5);
+    if (i == 4) return vec2( 0.5,  0.5);
+    return vec2(-0.5, 0.5);
+}
+
+void main() {
+    NodeInstance n = nodes[gl_InstanceIndex];
+    vec2 local = corner(gl_VertexIndex);
+    vec2 world = n.rect.xy + local * n.rect.zw;
+    gl_Position = pc.proj * pc.view * vec4(world, 0.0, 1.0);
+    vColor = n.color;
+}


### PR DESCRIPTION
## 目的
Iter (C/C++ の caller/callee/reference をグラフ可視化するデスクトップエディタ) の
グラフビューを、Web (React Flow / @xyflow) が大規模で詰まる問題に対して **native
(Pictor) 描画**へ持ち上げるための **Step 1**。「描画量を視界に比例させる
(SoA × LOD × instancing)」設計の足場を作る。

## このPRでやること (Step 1)
~1万ノードの合成グラフを **instanced/DoD** でノード+エッジ描画し、pan/zoom が
溶けないことを示す土台。ラベル/snippet/レイアウトソルバ/clangd 実データは後段。

## 実装 (`demo/graph/`, SRP 分割)
- `graph_store.{h,cpp}` — SoA グラフストア (node/edge, append-only。hot path は
  handle index のみ、symbol/id-map は cold 側 = Pictor DoD 規約)
- `camera2d.{h,cpp}` — pan/zoom 2D カメラ (world↔screen、cursor 固定ズーム)
- `graph_generator.{h,cpp}` — 決定的な層状合成グラフ (Step1 は固定座標)
- `graph_renderer.{h,cpp}` — 2 pipeline・`gl_VertexIndex` 駆動の instanced quad。
  ノード/エッジ各 **1 draw**、エッジは screen 一定太さ。SSBO へ一括 pack
- `shaders/graph_node.vert` / `graph_edge.vert` / `graph_flat.frag`
- `main.cpp` — window + frame loop + 入力 (Drag=pan, Scroll=zoom, R=fit, Esc) +
  起動時に全体フィット。`--nodes N` `--frames N`

## ビルド
```
cmake -S . -B build && cmake --build build --target pictor_graph_demo --config Debug
```
→ error/warning 0、SPIR-V 生成、`pictor_graph_demo.exe` 生成を確認済。
実行確認は Pictor 規約によりユーザ側。

## 次段 (このPRには含めない)
SpatialGrid cull/hit-test → Sugiyama layout(worker, double-buffer) →
glyph atlas + monospace LABEL LOD → snippet 遅延取得 (LRU) → incremental expand。
clangd 実データ結線は `IDataChannel` で後段 (Iter Rust ↔ Pictor 境界)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)