### PR TITLE
feat(graph-demo): SpatialGrid cull/hit-test + native dock (Step2 + d)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,13 +410,18 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
         target_include_directories(pictor_texture2d_demo PRIVATE demo/texture2d third_party/stb)
         target_link_libraries(pictor_texture2d_demo PRIVATE pictor)
 
-        # Iter relation-graph demo (instanced/DoD large graph view, Step 1)
+        # Iter relation-graph demo (instanced/DoD graph view + cull/hit-test + dock)
         add_executable(pictor_graph_demo
             demo/graph/main.cpp
             demo/graph/graph_store.cpp
             demo/graph/camera2d.cpp
             demo/graph/graph_generator.cpp
+            demo/graph/vk_util.cpp
+            demo/graph/spatial_grid.cpp
             demo/graph/graph_renderer.cpp
+            demo/graph/graph_view.cpp
+            demo/graph/ui_rect_renderer.cpp
+            demo/graph/dock_layout.cpp
         )
         target_include_directories(pictor_graph_demo PRIVATE demo/graph)
         target_link_libraries(pictor_graph_demo PRIVATE pictor)
@@ -515,6 +520,7 @@ if(PICTOR_BUILD_DEMO AND Vulkan_FOUND AND Vulkan_GLSLC_EXECUTABLE)
         ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_node.vert
         ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_edge.vert
         ${CMAKE_SOURCE_DIR}/demo/graph/shaders/graph_flat.frag
+        ${CMAKE_SOURCE_DIR}/demo/graph/shaders/ui_rect.vert
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/model.vert
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/model.frag
         ${CMAKE_SOURCE_DIR}/demo/fbx_viewer/shaders/bone.vert

--- a/demo/graph/dock_layout.cpp
+++ b/demo/graph/dock_layout.cpp
@@ -1,0 +1,226 @@
+#include "dock_layout.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace pictor::graph {
+
+int DockLayout::add_node(const Node& n) {
+    nodes_.push_back(n);
+    return static_cast<int>(nodes_.size()) - 1;
+}
+
+void DockLayout::set_default(int graph_panel, const std::vector<int>& tab_panels,
+                             float split_ratio) {
+    nodes_.clear();
+
+    Node leaf;
+    leaf.kind = Kind::Leaf;
+    leaf.panel_id = graph_panel;
+    const int left = add_node(leaf);
+
+    int right;
+    if (tab_panels.empty()) {
+        Node empty;
+        empty.kind = Kind::Leaf;
+        empty.panel_id = graph_panel;
+        right = add_node(empty);
+    } else {
+        Node tabs;
+        tabs.kind = Kind::Tabs;
+        tabs.tab_panels = tab_panels;
+        tabs.active = 0;
+        right = add_node(tabs);
+    }
+
+    Node split;
+    split.kind = Kind::Split;
+    split.orient = DockOrient::Horizontal;
+    split.ratio = split_ratio;
+    split.first = left;
+    split.second = right;
+    root_ = add_node(split);
+}
+
+// ─── Solve ───────────────────────────────────────────────────
+
+void DockLayout::solve(DockRect root) {
+    panels_.clear();
+    splitters_.clear();
+    tabs_.clear();
+    if (root_ >= 0) solve_node(root_, root);
+}
+
+void DockLayout::solve_node(int idx, DockRect rect) {
+    if (idx < 0 || idx >= static_cast<int>(nodes_.size())) return;
+    const Node& n = nodes_[idx];
+
+    switch (n.kind) {
+    case Kind::Leaf:
+        panels_.push_back({n.panel_id, rect});
+        break;
+
+    case Kind::Split: {
+        SolvedSplitter s;
+        s.node = idx;
+        s.orient = n.orient;
+        s.area = rect;
+        if (n.orient == DockOrient::Horizontal) {
+            const float avail = std::max(0.0f, rect.w - kSplitter);
+            const float fw = avail * n.ratio;
+            DockRect first{rect.x, rect.y, fw, rect.h};
+            s.handle = {rect.x + fw, rect.y, kSplitter, rect.h};
+            DockRect second{rect.x + fw + kSplitter, rect.y, avail - fw, rect.h};
+            splitters_.push_back(s);
+            solve_node(n.first, first);
+            solve_node(n.second, second);
+        } else {
+            const float avail = std::max(0.0f, rect.h - kSplitter);
+            const float fh = avail * n.ratio;
+            DockRect first{rect.x, rect.y, rect.w, fh};
+            s.handle = {rect.x, rect.y + fh, rect.w, kSplitter};
+            DockRect second{rect.x, rect.y + fh + kSplitter, rect.w, avail - fh};
+            splitters_.push_back(s);
+            solve_node(n.first, first);
+            solve_node(n.second, second);
+        }
+        break;
+    }
+
+    case Kind::Tabs: {
+        const int count = static_cast<int>(n.tab_panels.size());
+        const float bar_h = (count > 0) ? kTabBar : 0.0f;
+        const float tab_w = (count > 0) ? rect.w / static_cast<float>(count) : rect.w;
+        for (int i = 0; i < count; ++i) {
+            SolvedTab t;
+            t.node = idx;
+            t.panel_id = n.tab_panels[i];
+            t.rect = {rect.x + static_cast<float>(i) * tab_w, rect.y, tab_w, bar_h};
+            t.active = (i == n.active);
+            tabs_.push_back(t);
+        }
+        DockRect content{rect.x, rect.y + bar_h, rect.w, std::max(0.0f, rect.h - bar_h)};
+        if (count > 0) {
+            const int active = std::clamp(n.active, 0, count - 1);
+            panels_.push_back({n.tab_panels[active], content});
+        }
+        break;
+    }
+    }
+}
+
+// ─── Interaction ─────────────────────────────────────────────
+
+bool DockLayout::begin_drag(float x, float y) {
+    for (const auto& s : splitters_) {
+        if (s.handle.contains(x, y)) {
+            dragging_ = s.node;
+            return true;
+        }
+    }
+    return false;
+}
+
+void DockLayout::drag_to(float x, float y) {
+    if (dragging_ < 0) return;
+    // Use the last solved area of the dragged split node.
+    for (const auto& s : splitters_) {
+        if (s.node != dragging_) continue;
+        float ratio;
+        if (s.orient == DockOrient::Horizontal) {
+            const float avail = std::max(1.0f, s.area.w - kSplitter);
+            ratio = (x - s.area.x) / avail;
+        } else {
+            const float avail = std::max(1.0f, s.area.h - kSplitter);
+            ratio = (y - s.area.y) / avail;
+        }
+        nodes_[dragging_].ratio = std::clamp(ratio, 0.05f, 0.95f);
+        return;
+    }
+}
+
+bool DockLayout::on_click(float x, float y) {
+    for (const auto& t : tabs_) {
+        if (!t.rect.contains(x, y)) continue;
+        Node& node = nodes_[t.node];
+        for (int i = 0; i < static_cast<int>(node.tab_panels.size()); ++i) {
+            if (node.tab_panels[i] == t.panel_id) {
+                node.active = i;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// ─── Persistence (simple line format) ────────────────────────
+
+void DockLayout::save(const char* path) const {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out.is_open()) return;
+    out << "dock 1\n";
+    out << "root " << root_ << "\n";
+    out << "nodes " << nodes_.size() << "\n";
+    for (const auto& n : nodes_) {
+        if (n.kind == Kind::Leaf) {
+            out << "leaf " << n.panel_id << "\n";
+        } else if (n.kind == Kind::Split) {
+            out << "split " << (n.orient == DockOrient::Horizontal ? 'H' : 'V')
+                << ' ' << n.ratio << ' ' << n.first << ' ' << n.second << "\n";
+        } else {
+            out << "tabs " << n.active << ' ' << n.tab_panels.size();
+            for (int p : n.tab_panels) out << ' ' << p;
+            out << "\n";
+        }
+    }
+}
+
+bool DockLayout::load(const char* path) {
+    std::ifstream in(path);
+    if (!in.is_open()) return false;
+
+    std::vector<Node> parsed;
+    int root = -1;
+    size_t expected = 0;
+    std::string line;
+    while (std::getline(in, line)) {
+        std::istringstream ss(line);
+        std::string tag;
+        ss >> tag;
+        if (tag == "dock") {
+            // version — ignore for now
+        } else if (tag == "root") {
+            ss >> root;
+        } else if (tag == "nodes") {
+            ss >> expected;
+        } else if (tag == "leaf") {
+            Node n; n.kind = Kind::Leaf; ss >> n.panel_id; parsed.push_back(n);
+        } else if (tag == "split") {
+            Node n; n.kind = Kind::Split;
+            char o = 'H';
+            ss >> o >> n.ratio >> n.first >> n.second;
+            n.orient = (o == 'V') ? DockOrient::Vertical : DockOrient::Horizontal;
+            parsed.push_back(n);
+        } else if (tag == "tabs") {
+            Node n; n.kind = Kind::Tabs;
+            size_t cnt = 0;
+            ss >> n.active >> cnt;
+            for (size_t i = 0; i < cnt; ++i) { int p = 0; ss >> p; n.tab_panels.push_back(p); }
+            parsed.push_back(n);
+        }
+    }
+
+    if (parsed.empty() || root < 0 || root >= static_cast<int>(parsed.size()))
+        return false;
+    if (expected != parsed.size())
+        return false;  // corrupt / partial file — fall back to default
+
+    nodes_ = std::move(parsed);
+    root_  = root;
+    return true;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/dock_layout.h
+++ b/demo/graph/dock_layout.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace pictor::graph {
+
+/// Float rect in window pixels (Vulkan-free so the layout is self-contained).
+struct DockRect {
+    float x = 0, y = 0, w = 0, h = 0;
+    bool contains(float px, float py) const {
+        return px >= x && px < x + w && py >= y && py < y + h;
+    }
+};
+
+enum class DockOrient : uint8_t { Horizontal, Vertical }; // H = side-by-side, V = stacked
+
+/// Native dock layouter: a split / tabs / leaf tree that arranges panels, with
+/// draggable splitters, clickable tab headers and text persistence. Mirrors the
+/// semantics of Corpus's DockComponent (DockLayoutNode: leaf / split / tabs).
+/// Panels are referenced by integer id; the host decides what each id renders.
+class DockLayout {
+public:
+    struct SolvedPanel   { int   panel_id; DockRect rect; };               // visible content
+    struct SolvedSplitter{ int   node;     DockOrient orient; DockRect handle; DockRect area; };
+    struct SolvedTab     { int   node;     int panel_id; DockRect rect; bool active; };
+
+    /// Build the default layout: `graph` leaf on the left, a tabs container with
+    /// `tab_panels` on the right.
+    void set_default(int graph_panel, const std::vector<int>& tab_panels, float split_ratio = 0.72f);
+
+    bool load(const char* path);
+    void save(const char* path) const;
+
+    /// Recompute geometry for the given root rect; results are cached for both
+    /// the host (panels()/splitters()/tabs()) and interaction.
+    void solve(DockRect root);
+
+    const std::vector<SolvedPanel>&    panels()    const { return panels_; }
+    const std::vector<SolvedSplitter>& splitters() const { return splitters_; }
+    const std::vector<SolvedTab>&      tabs()      const { return tabs_; }
+
+    bool begin_drag(float x, float y);   // grab a splitter; true if one was hit
+    void drag_to(float x, float y);      // adjust the dragged split's ratio
+    void end_drag() { dragging_ = -1; }
+    bool is_dragging() const { return dragging_ >= 0; }
+
+    bool on_click(float x, float y);     // tab switch; true if consumed
+
+    static constexpr float kSplitter = 6.0f;
+    static constexpr float kTabBar   = 26.0f;
+
+private:
+    enum class Kind : uint8_t { Leaf, Split, Tabs };
+
+    struct Node {
+        Kind kind = Kind::Leaf;
+        int  panel_id = 0;          // Leaf
+        DockOrient orient = DockOrient::Horizontal; // Split
+        float ratio = 0.5f;         // Split
+        int  first = -1, second = -1;               // Split children
+        std::vector<int> tab_panels;                // Tabs
+        int  active = 0;            // Tabs (index into tab_panels)
+    };
+
+    int  add_node(const Node& n);
+    void solve_node(int idx, DockRect rect);
+
+    std::vector<Node> nodes_;
+    int               root_ = -1;
+
+    std::vector<SolvedPanel>    panels_;
+    std::vector<SolvedSplitter> splitters_;
+    std::vector<SolvedTab>      tabs_;
+
+    int dragging_ = -1; // node index of the split being dragged, or -1
+};
+
+} // namespace pictor::graph

--- a/demo/graph/graph_instances.h
+++ b/demo/graph/graph_instances.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace pictor::graph {
+
+/// GPU-packed instance records (std430: vec4 + vec4 = 32 bytes), shared between
+/// the culler (GraphView, which builds the visible subset each frame) and the
+/// renderer (which uploads + draws it).
+struct NodeInstance {
+    float rect[4];   // cx, cy, w, h  (world units)
+    float color[4];  // rgba 0..1
+};
+
+struct EdgeInstance {
+    float ends[4];   // ax, ay, bx, by  (world units)
+    float color[4];  // rgb + thickness(px) in .a
+};
+
+/// Screen-space solid rect for the dock chrome (panels / splitters / tab headers).
+struct UiRect {
+    float rect[4];   // x, y, w, h  (pixels)
+    float color[4];  // rgba 0..1
+};
+
+} // namespace pictor::graph

--- a/demo/graph/graph_renderer.cpp
+++ b/demo/graph/graph_renderer.cpp
@@ -2,83 +2,107 @@
 
 #ifdef PICTOR_HAS_VULKAN
 
-#include "graph_store.h"
 #include "pictor/surface/vulkan_context.h"
 
-#include <algorithm>
 #include <cstdio>
-#include <cstring>
-#include <fstream>
 #include <string>
-#include <vector>
 
 namespace pictor::graph {
-
-namespace {
-
-inline void unpack_rgba(uint32_t rgba, float out[4]) {
-    out[0] = static_cast<float>((rgba >> 24) & 0xFFu) / 255.0f;
-    out[1] = static_cast<float>((rgba >> 16) & 0xFFu) / 255.0f;
-    out[2] = static_cast<float>((rgba >> 8)  & 0xFFu) / 255.0f;
-    out[3] = static_cast<float>( rgba        & 0xFFu) / 255.0f;
-}
-
-constexpr float kEdgeThicknessPx = 1.5f;
-
-} // namespace
 
 GraphRenderer::~GraphRenderer() {
     if (initialized_) shutdown();
 }
 
 bool GraphRenderer::initialize(VulkanContext& vk_ctx, const char* shader_dir,
-                               const GraphStore& store) {
-    printf("[Graph] Initializing (%zu nodes, %zu edges)...\n",
-           store.node_count(), store.edge_count());
-    vk_ctx_ = &vk_ctx;
-    device_ = vk_ctx.device();
+                               uint32_t node_capacity, uint32_t edge_capacity) {
+    vk_ctx_  = &vk_ctx;
+    device_  = vk_ctx.device();
+    flights_ = vk_ctx.frames_in_flight();
+    if (node_capacity == 0) node_capacity = 1;
+    if (edge_capacity == 0) edge_capacity = 1;
 
-    if (!build_instance_buffers(store)) {
-        fprintf(stderr, "[Graph] Failed to build instance buffers\n");
+    // Descriptor layout: one storage buffer in the vertex stage.
+    VkDescriptorSetLayoutBinding binding{};
+    binding.binding         = 0;
+    binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    binding.descriptorCount = 1;
+    binding.stageFlags      = VK_SHADER_STAGE_VERTEX_BIT;
+
+    VkDescriptorSetLayoutCreateInfo li{};
+    li.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    li.bindingCount = 1;
+    li.pBindings    = &binding;
+    if (vkCreateDescriptorSetLayout(device_, &li, nullptr, &desc_set_layout_) != VK_SUCCESS)
         return false;
-    }
-    if (!create_descriptors()) {
-        fprintf(stderr, "[Graph] Failed to create descriptors\n");
+
+    // Pool: node + edge, one set per flight each.
+    const uint32_t set_count = flights_ * 2;
+    VkDescriptorPoolSize ps{};
+    ps.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    ps.descriptorCount = set_count;
+    VkDescriptorPoolCreateInfo pi{};
+    pi.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pi.maxSets       = set_count;
+    pi.poolSizeCount = 1;
+    pi.pPoolSizes    = &ps;
+    if (vkCreateDescriptorPool(device_, &pi, nullptr, &desc_pool_) != VK_SUCCESS)
         return false;
-    }
 
-    const std::string node_vert = std::string(shader_dir) + "/graph_node.vert.spv";
-    const std::string edge_vert = std::string(shader_dir) + "/graph_edge.vert.spv";
-    const std::string flat_frag = std::string(shader_dir) + "/graph_flat.frag.spv";
+    if (!node_buf_.initialize(vk_ctx, flights_,
+                              VkDeviceSize(node_capacity) * sizeof(NodeInstance),
+                              desc_set_layout_, desc_pool_))
+        return false;
+    if (!edge_buf_.initialize(vk_ctx, flights_,
+                              VkDeviceSize(edge_capacity) * sizeof(EdgeInstance),
+                              desc_set_layout_, desc_pool_))
+        return false;
 
-    if (!create_pipeline(node_vert.c_str(), flat_frag.c_str(), node_pipeline_) ||
-        !create_pipeline(edge_vert.c_str(), flat_frag.c_str(), edge_pipeline_)) {
+    // Shared pipeline layout (GraphPushConstants, vertex stage).
+    VkPushConstantRange pcr{};
+    pcr.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    pcr.offset     = 0;
+    pcr.size       = sizeof(GraphPushConstants);
+    VkPipelineLayoutCreateInfo pli{};
+    pli.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pli.setLayoutCount         = 1;
+    pli.pSetLayouts            = &desc_set_layout_;
+    pli.pushConstantRangeCount = 1;
+    pli.pPushConstantRanges    = &pcr;
+    if (vkCreatePipelineLayout(device_, &pli, nullptr, &pipeline_layout_) != VK_SUCCESS)
+        return false;
+
+    const std::string dir       = shader_dir;
+    const std::string node_vert = dir + "/graph_node.vert.spv";
+    const std::string edge_vert = dir + "/graph_edge.vert.spv";
+    const std::string flat_frag = dir + "/graph_flat.frag.spv";
+
+    node_pipeline_ = create_instanced_pipeline(device_, vk_ctx.default_render_pass(),
+                                               pipeline_layout_, node_vert.c_str(), flat_frag.c_str());
+    edge_pipeline_ = create_instanced_pipeline(device_, vk_ctx.default_render_pass(),
+                                               pipeline_layout_, edge_vert.c_str(), flat_frag.c_str());
+    if (!node_pipeline_ || !edge_pipeline_) {
         fprintf(stderr, "[Graph] Failed to create pipelines\n");
         return false;
     }
 
     initialized_ = true;
-    printf("[Graph] Initialization complete\n");
+    printf("[Graph] Renderer ready (flights=%u, node_cap=%u, edge_cap=%u)\n",
+           flights_, node_capacity, edge_capacity);
     return true;
 }
 
 void GraphRenderer::shutdown() {
-    if (!initialized_ && !vk_ctx_) return;
+    if (!vk_ctx_) return;
     vkDeviceWaitIdle(device_);
+
+    node_buf_.destroy(device_);
+    edge_buf_.destroy(device_);
 
     if (node_pipeline_)   vkDestroyPipeline(device_, node_pipeline_, nullptr);
     if (edge_pipeline_)   vkDestroyPipeline(device_, edge_pipeline_, nullptr);
     if (pipeline_layout_) vkDestroyPipelineLayout(device_, pipeline_layout_, nullptr);
     if (desc_pool_)       vkDestroyDescriptorPool(device_, desc_pool_, nullptr);
     if (desc_set_layout_) vkDestroyDescriptorSetLayout(device_, desc_set_layout_, nullptr);
-
-    auto destroy_buf = [&](VkBuffer& b, VkDeviceMemory& m) {
-        if (b) vkDestroyBuffer(device_, b, nullptr);
-        if (m) vkFreeMemory(device_, m, nullptr);
-        b = VK_NULL_HANDLE; m = VK_NULL_HANDLE;
-    };
-    destroy_buf(node_buffer_, node_memory_);
-    destroy_buf(edge_buffer_, edge_memory_);
 
     node_pipeline_   = VK_NULL_HANDLE;
     edge_pipeline_   = VK_NULL_HANDLE;
@@ -88,341 +112,42 @@ void GraphRenderer::shutdown() {
     initialized_     = false;
 }
 
-// ─── Instance buffers ────────────────────────────────────────
-
-bool GraphRenderer::build_instance_buffers(const GraphStore& store) {
-    const auto& nodes = store.nodes();
-    const auto& edges = store.edges();
-    node_count_ = static_cast<uint32_t>(store.node_count());
-    edge_count_ = static_cast<uint32_t>(store.edge_count());
-
-    // Nodes → flat AoS instance records.
-    std::vector<NodeInstance> node_inst(node_count_);
-    for (uint32_t i = 0; i < node_count_; ++i) {
-        NodeInstance& d = node_inst[i];
-        d.rect[0] = nodes.cx[i];
-        d.rect[1] = nodes.cy[i];
-        d.rect[2] = nodes.w[i];
-        d.rect[3] = nodes.h[i];
-        unpack_rgba(nodes.rgba[i], d.color);
-    }
-
-    // Edges → endpoints looked up from node centers (cold path, once).
-    std::vector<EdgeInstance> edge_inst(edge_count_);
-    for (uint32_t i = 0; i < edge_count_; ++i) {
-        const uint32_t a = edges.from[i];
-        const uint32_t b = edges.to[i];
-        EdgeInstance& d = edge_inst[i];
-        d.ends[0] = nodes.cx[a];
-        d.ends[1] = nodes.cy[a];
-        d.ends[2] = nodes.cx[b];
-        d.ends[3] = nodes.cy[b];
-        d.color[0] = 0.45f; d.color[1] = 0.50f; d.color[2] = 0.58f; // muted grey-blue
-        d.color[3] = kEdgeThicknessPx;
-    }
-
-    // Vulkan disallows zero-size buffers; keep a 1-record floor so binding is valid.
-    const VkDeviceSize node_bytes =
-        std::max<VkDeviceSize>(1, node_count_) * sizeof(NodeInstance);
-    const VkDeviceSize edge_bytes =
-        std::max<VkDeviceSize>(1, edge_count_) * sizeof(EdgeInstance);
-
-    if (!create_storage_buffer(node_bytes, node_inst.empty() ? nullptr : node_inst.data(),
-                               node_buffer_, node_memory_))
-        return false;
-    if (!create_storage_buffer(edge_bytes, edge_inst.empty() ? nullptr : edge_inst.data(),
-                               edge_buffer_, edge_memory_))
-        return false;
-    return true;
-}
-
-bool GraphRenderer::create_storage_buffer(VkDeviceSize size, const void* data,
-                                          VkBuffer& buf, VkDeviceMemory& mem) {
-    VkBufferCreateInfo info{};
-    info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    info.size  = size;
-    info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-
-    if (vkCreateBuffer(device_, &info, nullptr, &buf) != VK_SUCCESS)
-        return false;
-
-    VkMemoryRequirements req;
-    vkGetBufferMemoryRequirements(device_, buf, &req);
-
-    VkMemoryAllocateInfo alloc{};
-    alloc.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    alloc.allocationSize  = req.size;
-    alloc.memoryTypeIndex = find_memory_type(
-        req.memoryTypeBits,
-        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-
-    if (vkAllocateMemory(device_, &alloc, nullptr, &mem) != VK_SUCCESS) {
-        vkDestroyBuffer(device_, buf, nullptr);
-        buf = VK_NULL_HANDLE;
-        return false;
-    }
-    vkBindBufferMemory(device_, buf, mem, 0);
-
-    if (data) {
-        void* mapped = nullptr;
-        vkMapMemory(device_, mem, 0, size, 0, &mapped);
-        std::memcpy(mapped, data, static_cast<size_t>(size));
-        vkUnmapMemory(device_, mem);
-    }
-    return true;
-}
-
-// ─── Descriptors ─────────────────────────────────────────────
-
-bool GraphRenderer::create_descriptors() {
-    VkDescriptorSetLayoutBinding binding{};
-    binding.binding         = 0;
-    binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    binding.descriptorCount = 1;
-    binding.stageFlags      = VK_SHADER_STAGE_VERTEX_BIT;
-
-    VkDescriptorSetLayoutCreateInfo layout_info{};
-    layout_info.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    layout_info.bindingCount = 1;
-    layout_info.pBindings    = &binding;
-    if (vkCreateDescriptorSetLayout(device_, &layout_info, nullptr, &desc_set_layout_) != VK_SUCCESS)
-        return false;
-
-    VkDescriptorPoolSize pool_size{};
-    pool_size.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    pool_size.descriptorCount = 2;
-
-    VkDescriptorPoolCreateInfo pool_info{};
-    pool_info.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    pool_info.maxSets       = 2;
-    pool_info.poolSizeCount = 1;
-    pool_info.pPoolSizes    = &pool_size;
-    if (vkCreateDescriptorPool(device_, &pool_info, nullptr, &desc_pool_) != VK_SUCCESS)
-        return false;
-
-    auto alloc_set = [&](VkDescriptorSet& out) -> bool {
-        VkDescriptorSetAllocateInfo a{};
-        a.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-        a.descriptorPool     = desc_pool_;
-        a.descriptorSetCount = 1;
-        a.pSetLayouts        = &desc_set_layout_;
-        return vkAllocateDescriptorSets(device_, &a, &out) == VK_SUCCESS;
-    };
-    if (!alloc_set(node_set_) || !alloc_set(edge_set_))
-        return false;
-
-    bind_storage_descriptor(node_set_, node_buffer_, VK_WHOLE_SIZE);
-    bind_storage_descriptor(edge_set_, edge_buffer_, VK_WHOLE_SIZE);
-    return true;
-}
-
-void GraphRenderer::bind_storage_descriptor(VkDescriptorSet set, VkBuffer buf,
-                                            VkDeviceSize range) {
-    VkDescriptorBufferInfo info{};
-    info.buffer = buf;
-    info.offset = 0;
-    info.range  = range;
-
-    VkWriteDescriptorSet write{};
-    write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    write.dstSet          = set;
-    write.dstBinding      = 0;
-    write.descriptorCount = 1;
-    write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    write.pBufferInfo     = &info;
-    vkUpdateDescriptorSets(device_, 1, &write, 0, nullptr);
-}
-
-// ─── Pipeline ────────────────────────────────────────────────
-
-bool GraphRenderer::create_pipeline(const char* vert_spv, const char* frag_spv,
-                                    VkPipeline& out) {
-    VkShaderModule vert = load_shader(vert_spv);
-    VkShaderModule frag = load_shader(frag_spv);
-    if (!vert || !frag) {
-        if (vert) vkDestroyShaderModule(device_, vert, nullptr);
-        if (frag) vkDestroyShaderModule(device_, frag, nullptr);
-        return false;
-    }
-
-    VkPipelineShaderStageCreateInfo stages[2]{};
-    stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = vert;
-    stages[0].pName  = "main";
-    stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[1].module = frag;
-    stages[1].pName  = "main";
-
-    // No vertex buffers: geometry comes from gl_VertexIndex in the shader.
-    VkPipelineVertexInputStateCreateInfo vertex_input{};
-    vertex_input.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-
-    VkPipelineInputAssemblyStateCreateInfo ia{};
-    ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
-
-    VkPipelineViewportStateCreateInfo vp{};
-    vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    vp.viewportCount = 1;
-    vp.scissorCount  = 1;
-
-    VkPipelineRasterizationStateCreateInfo raster{};
-    raster.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    raster.polygonMode = VK_POLYGON_MODE_FILL;
-    raster.cullMode    = VK_CULL_MODE_NONE;
-    raster.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
-    raster.lineWidth   = 1.0f;
-
-    VkPipelineMultisampleStateCreateInfo ms{};
-    ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-
-    VkPipelineDepthStencilStateCreateInfo ds{};
-    ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
-    ds.depthTestEnable  = VK_FALSE;
-    ds.depthWriteEnable = VK_FALSE;
-
-    VkPipelineColorBlendAttachmentState blend_att{};
-    blend_att.blendEnable         = VK_TRUE;
-    blend_att.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
-    blend_att.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
-    blend_att.colorBlendOp        = VK_BLEND_OP_ADD;
-    blend_att.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-    blend_att.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    blend_att.alphaBlendOp        = VK_BLEND_OP_ADD;
-    blend_att.colorWriteMask      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                    VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-
-    VkPipelineColorBlendStateCreateInfo blend{};
-    blend.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    blend.attachmentCount = 1;
-    blend.pAttachments    = &blend_att;
-
-    VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
-    VkPipelineDynamicStateCreateInfo dyn{};
-    dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    dyn.dynamicStateCount = 2;
-    dyn.pDynamicStates    = dyn_states;
-
-    // Pipeline layout is shared by both pipelines; create it once (lazily).
-    if (pipeline_layout_ == VK_NULL_HANDLE) {
-        VkPushConstantRange push_range{};
-        push_range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-        push_range.offset     = 0;
-        push_range.size       = sizeof(GraphPushConstants);
-
-        VkPipelineLayoutCreateInfo layout_info{};
-        layout_info.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-        layout_info.setLayoutCount         = 1;
-        layout_info.pSetLayouts            = &desc_set_layout_;
-        layout_info.pushConstantRangeCount = 1;
-        layout_info.pPushConstantRanges    = &push_range;
-        if (vkCreatePipelineLayout(device_, &layout_info, nullptr, &pipeline_layout_) != VK_SUCCESS) {
-            vkDestroyShaderModule(device_, vert, nullptr);
-            vkDestroyShaderModule(device_, frag, nullptr);
-            return false;
-        }
-    }
-
-    VkGraphicsPipelineCreateInfo pi{};
-    pi.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pi.stageCount          = 2;
-    pi.pStages             = stages;
-    pi.pVertexInputState   = &vertex_input;
-    pi.pInputAssemblyState = &ia;
-    pi.pViewportState      = &vp;
-    pi.pRasterizationState = &raster;
-    pi.pMultisampleState   = &ms;
-    pi.pDepthStencilState  = &ds;
-    pi.pColorBlendState    = &blend;
-    pi.pDynamicState       = &dyn;
-    pi.layout              = pipeline_layout_;
-    pi.renderPass          = vk_ctx_->default_render_pass();
-    pi.subpass             = 0;
-
-    VkResult result = vkCreateGraphicsPipelines(device_, VK_NULL_HANDLE, 1, &pi, nullptr, &out);
-    vkDestroyShaderModule(device_, vert, nullptr);
-    vkDestroyShaderModule(device_, frag, nullptr);
-
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "[Graph] vkCreateGraphicsPipelines failed (%d)\n", result);
-        return false;
-    }
-    return true;
-}
-
-// ─── Render ──────────────────────────────────────────────────
-
-void GraphRenderer::render(VkCommandBuffer cmd, VkExtent2D extent,
-                           const GraphPushConstants& pc) {
+void GraphRenderer::draw(VkCommandBuffer cmd, VkRect2D region, const GraphPushConstants& pc,
+                         uint32_t flight,
+                         const NodeInstance* nodes, uint32_t node_count,
+                         const EdgeInstance* edges, uint32_t edge_count) {
     if (!initialized_) return;
 
+    node_buf_.upload(flight, nodes, VkDeviceSize(node_count) * sizeof(NodeInstance));
+    edge_buf_.upload(flight, edges, VkDeviceSize(edge_count) * sizeof(EdgeInstance));
+
     VkViewport viewport{};
-    viewport.width    = static_cast<float>(extent.width);
-    viewport.height   = static_cast<float>(extent.height);
+    viewport.x        = static_cast<float>(region.offset.x);
+    viewport.y        = static_cast<float>(region.offset.y);
+    viewport.width    = static_cast<float>(region.extent.width);
+    viewport.height   = static_cast<float>(region.extent.height);
     viewport.minDepth = 0.0f;
     viewport.maxDepth = 1.0f;
     vkCmdSetViewport(cmd, 0, 1, &viewport);
-
-    VkRect2D scissor = {{0, 0}, extent};
-    vkCmdSetScissor(cmd, 0, 1, &scissor);
+    vkCmdSetScissor(cmd, 0, 1, &region);
 
     vkCmdPushConstants(cmd, pipeline_layout_, VK_SHADER_STAGE_VERTEX_BIT,
                        0, sizeof(GraphPushConstants), &pc);
 
-    // Edges first (under), then nodes on top.
-    if (edge_count_ > 0) {
+    if (edge_count > 0) {
+        VkDescriptorSet set = edge_buf_.set(flight);
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, edge_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                pipeline_layout_, 0, 1, &edge_set_, 0, nullptr);
-        vkCmdDraw(cmd, 6, edge_count_, 0, 0);
+                                pipeline_layout_, 0, 1, &set, 0, nullptr);
+        vkCmdDraw(cmd, 6, edge_count, 0, 0);
     }
-    if (node_count_ > 0) {
+    if (node_count > 0) {
+        VkDescriptorSet set = node_buf_.set(flight);
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, node_pipeline_);
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                pipeline_layout_, 0, 1, &node_set_, 0, nullptr);
-        vkCmdDraw(cmd, 6, node_count_, 0, 0);
+                                pipeline_layout_, 0, 1, &set, 0, nullptr);
+        vkCmdDraw(cmd, 6, node_count, 0, 0);
     }
-}
-
-// ─── Helpers ─────────────────────────────────────────────────
-
-VkShaderModule GraphRenderer::load_shader(const char* path) {
-    std::ifstream file(path, std::ios::ate | std::ios::binary);
-    if (!file.is_open()) {
-        fprintf(stderr, "[Graph] Cannot open shader: %s\n", path);
-        return VK_NULL_HANDLE;
-    }
-    const size_t size = static_cast<size_t>(file.tellg());
-    std::vector<char> code(size);
-    file.seekg(0);
-    file.read(code.data(), static_cast<std::streamsize>(size));
-
-    VkShaderModuleCreateInfo info{};
-    info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
-    info.codeSize = size;
-    info.pCode    = reinterpret_cast<const uint32_t*>(code.data());
-
-    VkShaderModule mod = VK_NULL_HANDLE;
-    if (vkCreateShaderModule(device_, &info, nullptr, &mod) != VK_SUCCESS) {
-        fprintf(stderr, "[Graph] Failed to create shader module: %s\n", path);
-    }
-    return mod;
-}
-
-uint32_t GraphRenderer::find_memory_type(uint32_t type_filter, VkMemoryPropertyFlags props) {
-    VkPhysicalDeviceMemoryProperties mem_props;
-    vkGetPhysicalDeviceMemoryProperties(vk_ctx_->physical_device(), &mem_props);
-    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
-        if ((type_filter & (1u << i)) &&
-            (mem_props.memoryTypes[i].propertyFlags & props) == props) {
-            return i;
-        }
-    }
-    fprintf(stderr, "[Graph] No suitable memory type\n");
-    return 0;
 }
 
 } // namespace pictor::graph

--- a/demo/graph/graph_renderer.h
+++ b/demo/graph/graph_renderer.h
@@ -5,30 +5,29 @@
 #include <vulkan/vulkan.h>
 #include <cstdint>
 
+#include "graph_instances.h"
+#include "vk_util.h"
+
 namespace pictor {
 
 class VulkanContext;
 
 namespace graph {
 
-class GraphStore;
-
 /// Push constants shared by the node and edge pipelines (matches shader layout).
 struct GraphPushConstants {
-    float proj[16];    // screen px → clip
-    float view[16];    // world → screen px (pan/zoom)
+    float proj[16];    // region-local px -> clip
+    float view[16];    // world -> region-local px (pan/zoom)
     float params[4];   // x = zoom (edge thickness compensation), yzw reserved
 };
 
-/// Instanced, DoD graph renderer (Iter relation-graph, Step 1).
+/// Instanced graph renderer. Step 2: draws only the visible subset handed in by
+/// the culler each frame, into an arbitrary screen region (so it can live inside
+/// a dock leaf), via per-flight dynamic instance buffers.
 ///
-/// Two pipelines, each driven entirely by gl_VertexIndex + an SSBO of flat
-/// instance records — no per-vertex buffers, one draw call per primitive type:
-///   - edges: instanced quad stretched along each segment (drawn first, under)
-///   - nodes: instanced rounded-box quad (drawn on top)
-///
-/// Instance data is packed once at initialize() from the SoA GraphStore; the
-/// hot render path only binds + issues two vkCmdDraw calls.
+/// Two pipelines, gl_VertexIndex-driven instanced quads, one draw call each:
+///   - edges: quad stretched along each segment (drawn first, under)
+///   - nodes: box quad (drawn on top)
 class GraphRenderer {
 public:
     GraphRenderer() = default;
@@ -37,50 +36,33 @@ public:
     GraphRenderer(const GraphRenderer&)            = delete;
     GraphRenderer& operator=(const GraphRenderer&) = delete;
 
-    bool initialize(VulkanContext& vk_ctx, const char* shader_dir, const GraphStore& store);
+    /// `node_capacity` / `edge_capacity` bound the per-frame visible set.
+    bool initialize(VulkanContext& vk_ctx, const char* shader_dir,
+                    uint32_t node_capacity, uint32_t edge_capacity);
     void shutdown();
 
-    /// Record both draws into `cmd` (must be inside a render pass).
-    void render(VkCommandBuffer cmd, VkExtent2D extent, const GraphPushConstants& pc);
+    /// Upload the visible instances for `flight` and record both draws into
+    /// `cmd` (inside a render pass), clipped to `region`.
+    void draw(VkCommandBuffer cmd, VkRect2D region, const GraphPushConstants& pc,
+              uint32_t flight,
+              const NodeInstance* nodes, uint32_t node_count,
+              const EdgeInstance* edges, uint32_t edge_count);
 
-    uint32_t node_count() const { return node_count_; }
-    uint32_t edge_count() const { return edge_count_; }
-    bool     is_initialized() const { return initialized_; }
+    bool is_initialized() const { return initialized_; }
 
 private:
-    // GPU-packed instance records (std430: vec4 + vec4 = 32 bytes).
-    struct NodeInstance { float rect[4];  float color[4]; }; // rect = cx,cy,w,h
-    struct EdgeInstance { float ends[4];  float color[4]; }; // ends = ax,ay,bx,by; color.a = thickness(px)
-
-    bool build_instance_buffers(const GraphStore& store);
-    bool create_descriptors();
-    bool create_pipeline(const char* vert_spv, const char* frag_spv, VkPipeline& out);
-
-    VkShaderModule load_shader(const char* path);
-    uint32_t       find_memory_type(uint32_t type_filter, VkMemoryPropertyFlags props);
-    bool           create_storage_buffer(VkDeviceSize size, const void* data,
-                                         VkBuffer& buf, VkDeviceMemory& mem);
-    void           bind_storage_descriptor(VkDescriptorSet set, VkBuffer buf, VkDeviceSize range);
-
     VulkanContext* vk_ctx_ = nullptr;
     VkDevice       device_ = VK_NULL_HANDLE;
+    uint32_t       flights_ = 1;
 
     VkDescriptorSetLayout desc_set_layout_ = VK_NULL_HANDLE;
     VkDescriptorPool      desc_pool_       = VK_NULL_HANDLE;
-    VkDescriptorSet       node_set_        = VK_NULL_HANDLE;
-    VkDescriptorSet       edge_set_        = VK_NULL_HANDLE;
+    VkPipelineLayout      pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline            node_pipeline_   = VK_NULL_HANDLE;
+    VkPipeline            edge_pipeline_   = VK_NULL_HANDLE;
 
-    VkPipelineLayout pipeline_layout_ = VK_NULL_HANDLE;
-    VkPipeline       node_pipeline_   = VK_NULL_HANDLE;
-    VkPipeline       edge_pipeline_   = VK_NULL_HANDLE;
-
-    VkBuffer       node_buffer_ = VK_NULL_HANDLE;
-    VkDeviceMemory node_memory_ = VK_NULL_HANDLE;
-    VkBuffer       edge_buffer_ = VK_NULL_HANDLE;
-    VkDeviceMemory edge_memory_ = VK_NULL_HANDLE;
-
-    uint32_t node_count_ = 0;
-    uint32_t edge_count_ = 0;
+    DynamicInstanceBuffers node_buf_;
+    DynamicInstanceBuffers edge_buf_;
 
     bool initialized_ = false;
 };

--- a/demo/graph/graph_view.cpp
+++ b/demo/graph/graph_view.cpp
@@ -1,0 +1,171 @@
+#include "graph_view.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include "pictor/surface/vulkan_context.h"
+
+#include <utility>
+
+namespace pictor::graph {
+
+namespace {
+inline void unpack_rgba(uint32_t rgba, float out[4]) {
+    out[0] = static_cast<float>((rgba >> 24) & 0xFFu) / 255.0f;
+    out[1] = static_cast<float>((rgba >> 16) & 0xFFu) / 255.0f;
+    out[2] = static_cast<float>((rgba >> 8)  & 0xFFu) / 255.0f;
+    out[3] = static_cast<float>( rgba        & 0xFFu) / 255.0f;
+}
+constexpr float kEdgeThicknessPx = 1.5f;
+} // namespace
+
+bool GraphView::initialize(VulkanContext& vk_ctx, const char* shader_dir, GraphStore store) {
+    store_ = std::move(store);
+    grid_.build(store_);
+
+    const uint32_t nodes = static_cast<uint32_t>(store_.node_count());
+    const uint32_t edges = static_cast<uint32_t>(store_.edge_count());
+    if (!renderer_.initialize(vk_ctx, shader_dir, nodes, edges))
+        return false;
+
+    node_inst_.reserve(nodes);
+    edge_inst_.reserve(edges);
+    vis_stamp_.assign(nodes, 0);
+
+    fit_to_bounds();
+    return true;
+}
+
+void GraphView::shutdown() {
+    renderer_.shutdown();
+}
+
+bool GraphView::contains(float win_x, float win_y) const {
+    return win_x >= bounds_.offset.x &&
+           win_x <  bounds_.offset.x + static_cast<int32_t>(bounds_.extent.width) &&
+           win_y >= bounds_.offset.y &&
+           win_y <  bounds_.offset.y + static_cast<int32_t>(bounds_.extent.height);
+}
+
+void GraphView::to_world(float win_x, float win_y, float& wx, float& wy) const {
+    const float local_x = win_x - static_cast<float>(bounds_.offset.x);
+    const float local_y = win_y - static_cast<float>(bounds_.offset.y);
+    const float hw = bounds_.extent.width  * 0.5f;
+    const float hh = bounds_.extent.height * 0.5f;
+    const float z  = camera_.zoom();
+    wx = camera_.center_x() + (local_x - hw) / z;
+    wy = camera_.center_y() + (local_y - hh) / z;
+}
+
+void GraphView::pan(float dx, float dy) {
+    camera_.pan_pixels(dx, dy);
+}
+
+void GraphView::zoom_at(float win_x, float win_y, float factor) {
+    const float local_x = win_x - static_cast<float>(bounds_.offset.x);
+    const float local_y = win_y - static_cast<float>(bounds_.offset.y);
+    camera_.zoom_at(local_x, local_y, factor,
+                    static_cast<float>(bounds_.extent.width),
+                    static_cast<float>(bounds_.extent.height));
+}
+
+void GraphView::update_hover(float win_x, float win_y) {
+    float wx, wy;
+    to_world(win_x, win_y, wx, wy);
+    hovered_ = grid_.pick(wx, wy);
+}
+
+void GraphView::reset_view() {
+    fit_to_bounds();
+}
+
+void GraphView::fit_to_bounds() {
+    const auto& n = store_.nodes();
+    float min_x = 0, max_x = 0, min_y = 0, max_y = 0;
+    if (store_.node_count() > 0) {
+        min_x = max_x = n.cx[0];
+        min_y = max_y = n.cy[0];
+        for (size_t i = 1; i < store_.node_count(); ++i) {
+            if (n.cx[i] < min_x) min_x = n.cx[i];
+            if (n.cx[i] > max_x) max_x = n.cx[i];
+            if (n.cy[i] < min_y) min_y = n.cy[i];
+            if (n.cy[i] > max_y) max_y = n.cy[i];
+        }
+    }
+    const float span_x = (max_x - min_x) + 200.0f;
+    const float span_y = (max_y - min_y) + 200.0f;
+    const float vw = bounds_.extent.width  > 0 ? static_cast<float>(bounds_.extent.width)  : 1280.0f;
+    const float vh = bounds_.extent.height > 0 ? static_cast<float>(bounds_.extent.height) : 720.0f;
+    const float zx = vw / span_x;
+    const float zy = vh / span_y;
+    fit_cx_   = (min_x + max_x) * 0.5f;
+    fit_cy_   = (min_y + max_y) * 0.5f;
+    fit_zoom_ = (zx < zy) ? zx : zy;
+    camera_.reset(fit_cx_, fit_cy_, fit_zoom_);
+}
+
+void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
+    if (bounds_.extent.width == 0 || bounds_.extent.height == 0) return;
+
+    const float vw = static_cast<float>(bounds_.extent.width);
+    const float vh = static_cast<float>(bounds_.extent.height);
+    const float z  = camera_.zoom();
+
+    // View AABB in world units.
+    const float min_x = camera_.center_x() - (vw * 0.5f) / z;
+    const float max_x = camera_.center_x() + (vw * 0.5f) / z;
+    const float min_y = camera_.center_y() - (vh * 0.5f) / z;
+    const float max_y = camera_.center_y() + (vh * 0.5f) / z;
+
+    grid_.query_visible(min_x, min_y, max_x, max_y, vis_nodes_);
+
+    ++frame_;
+    const auto& n = store_.nodes();
+    node_inst_.clear();
+    node_inst_.reserve(vis_nodes_.size());
+    for (uint32_t i : vis_nodes_) {
+        vis_stamp_[i] = frame_;
+        NodeInstance d;
+        d.rect[0] = n.cx[i];
+        d.rect[1] = n.cy[i];
+        d.rect[2] = n.w[i];
+        d.rect[3] = n.h[i];
+        if (i == hovered_) {
+            // Highlight the hovered node with a bright accent.
+            d.color[0] = 1.0f; d.color[1] = 0.85f; d.color[2] = 0.30f; d.color[3] = 1.0f;
+        } else {
+            unpack_rgba(n.rgba[i], d.color);
+        }
+        node_inst_.push_back(d);
+    }
+
+    // Edges visible if either endpoint is visible this frame.
+    const auto& e = store_.edges();
+    edge_inst_.clear();
+    for (size_t k = 0; k < store_.edge_count(); ++k) {
+        const uint32_t a = e.from[k];
+        const uint32_t b = e.to[k];
+        if (vis_stamp_[a] != frame_ && vis_stamp_[b] != frame_) continue;
+        EdgeInstance d;
+        d.ends[0] = n.cx[a]; d.ends[1] = n.cy[a];
+        d.ends[2] = n.cx[b]; d.ends[3] = n.cy[b];
+        d.color[0] = 0.45f; d.color[1] = 0.50f; d.color[2] = 0.58f;
+        d.color[3] = kEdgeThicknessPx;
+        edge_inst_.push_back(d);
+    }
+
+    last_vis_nodes_ = static_cast<uint32_t>(node_inst_.size());
+    last_vis_edges_ = static_cast<uint32_t>(edge_inst_.size());
+
+    GraphPushConstants pc{};
+    Camera2D::build_proj(pc.proj, vw, vh);
+    camera_.build_view(pc.view, vw, vh);
+    pc.params[0] = z;
+
+    renderer_.draw(cmd, bounds_, pc, flight,
+                   node_inst_.data(), last_vis_nodes_,
+                   edge_inst_.data(), last_vis_edges_);
+}
+
+} // namespace pictor::graph
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/graph_view.h
+++ b/demo/graph/graph_view.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <vector>
+
+#include "camera2d.h"
+#include "graph_instances.h"
+#include "graph_renderer.h"
+#include "graph_store.h"
+#include "spatial_grid.h"
+
+namespace pictor {
+
+class VulkanContext;
+
+namespace graph {
+
+/// The Tier B native graph widget: owns the graph data, spatial index, camera
+/// and renderer, and draws itself into a screen rect (a dock leaf). Each frame
+/// it culls to the visible subset (O(visible)) and uploads only that to the GPU.
+/// Hit-testing (hover) goes through the same spatial grid.
+class GraphView {
+public:
+    bool initialize(VulkanContext& vk_ctx, const char* shader_dir, GraphStore store);
+    void shutdown();
+
+    /// Assign the screen rect this widget occupies (window pixels).
+    void set_bounds(VkRect2D bounds) { bounds_ = bounds; }
+    VkRect2D bounds() const { return bounds_; }
+    bool contains(float win_x, float win_y) const;
+
+    // Input — coordinates are window pixels; the widget maps them to its rect.
+    void pan(float dx, float dy);
+    void zoom_at(float win_x, float win_y, float factor);
+    void update_hover(float win_x, float win_y);
+    void clear_hover() { hovered_ = INVALID_NODE; }
+    void reset_view();
+
+    /// Cull + upload + draw, clipped to the widget's bounds.
+    void render(VkCommandBuffer cmd, uint32_t flight);
+
+    uint32_t visible_nodes() const { return last_vis_nodes_; }
+    uint32_t visible_edges() const { return last_vis_edges_; }
+    uint32_t total_nodes()   const { return static_cast<uint32_t>(store_.node_count()); }
+    uint32_t total_edges()   const { return static_cast<uint32_t>(store_.edge_count()); }
+    float    zoom()          const { return camera_.zoom(); }
+    uint32_t hovered()       const { return hovered_; }
+
+private:
+    void fit_to_bounds();
+    void to_world(float win_x, float win_y, float& wx, float& wy) const;
+
+    VkRect2D      bounds_{};
+    GraphStore    store_;
+    SpatialGrid   grid_;
+    Camera2D      camera_;
+    GraphRenderer renderer_;
+
+    // Per-frame cull scratch (reused; no per-frame allocation after warm-up).
+    std::vector<uint32_t>     vis_nodes_;
+    std::vector<NodeInstance> node_inst_;
+    std::vector<EdgeInstance> edge_inst_;
+    std::vector<uint32_t>     vis_stamp_;  // node -> frame stamp (visible this frame)
+    uint32_t                  frame_ = 0;
+
+    uint32_t hovered_ = INVALID_NODE;
+    float    fit_cx_ = 0.0f, fit_cy_ = 0.0f, fit_zoom_ = 1.0f;
+    uint32_t last_vis_nodes_ = 0, last_vis_edges_ = 0;
+};
+
+} // namespace graph
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -1,15 +1,19 @@
-/// Pictor — Iter Relation Graph Demo (Step 1)
+/// Pictor — Iter Relation Graph Demo (Step 2 + dock)
 ///
-/// Renders a large synthetic node/edge graph with an instanced/DoD pipeline to
-/// prove that ~10k boxes + edges pan/zoom smoothly on the desktop — the case
-/// web graph renderers (React Flow et al., used by Iter) choke on. Real clangd
-/// data, layout solving, labels and snippets come in later steps.
+/// A native dock shell (split / tabs / leaf, draggable splitters, persisted
+/// layout) hosting the Tier B graph widget in one leaf. The graph view culls to
+/// the visible subset each frame (O(visible)) and hit-tests hover through a
+/// spatial grid — the scale path web graph renderers (React Flow, used by Iter)
+/// lack. Panel/tab contents are solid color blocks for now (text = a later step).
 ///
 /// Controls:
-///   Drag        : pan
-///   Scroll      : zoom (towards cursor)
-///   R           : reset view
-///   Esc         : quit
+///   Drag (in graph)     : pan
+///   Scroll (in graph)   : zoom toward cursor
+///   Drag splitter       : resize panes
+///   Click tab header    : switch tab
+///   R                   : reset graph view (re-fit)
+///   S                   : save dock layout
+///   Esc                 : quit (also auto-saves layout)
 ///
 /// Args:
 ///   --nodes  N  : node count        (default 10000)
@@ -17,10 +21,13 @@
 
 #include "pictor/surface/vulkan_context.h"
 #include "pictor/surface/glfw_surface_provider.h"
-#include "graph_store.h"
-#include "graph_generator.h"
-#include "graph_renderer.h"
 #include "camera2d.h"
+#include "dock_layout.h"
+#include "graph_generator.h"
+#include "graph_instances.h"
+#include "graph_store.h"
+#include "graph_view.h"
+#include "ui_rect_renderer.h"
 
 #include <GLFW/glfw3.h>
 #include <chrono>
@@ -28,68 +35,132 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <vector>
 
 using namespace pictor;
 using namespace pictor::graph;
 
-// ─── Input state ─────────────────────────────────────────────
+namespace {
+
+// Panel ids and their placeholder chrome colors (graph panel draws itself).
+constexpr int kPanelGraph     = 0;
+constexpr int kPanelInspector = 1;
+constexpr int kPanelConsole   = 2;
+const char*   kLayoutFile     = "dock_layout.txt";
 
 struct AppState {
-    Camera2D camera;
-    bool     dragging     = false;
-    double   last_mouse_x = 0.0;
-    double   last_mouse_y = 0.0;
-    float    viewport_w   = 1280.0f;
-    float    viewport_h   = 720.0f;
-    bool     reset_view   = false;
+    GraphView*  graph = nullptr;
+    DockLayout* dock  = nullptr;
 
-    // Initial "fit whole graph" framing, captured at startup so R re-fits.
-    float    fit_cx       = 0.0f;
-    float    fit_cy       = 0.0f;
-    float    fit_zoom     = 1.0f;
+    bool   graph_panning = false;
+    bool   dock_dragging = false;
+    double last_x = 0.0, last_y = 0.0;
+    double cursor_x = 0.0, cursor_y = 0.0;
+
+    bool   save_request  = false;
+    bool   reset_request = false;
 };
 
-static AppState g_state;
+AppState g_state;
 
-static void mouse_button_callback(GLFWwindow* win, int button, int action, int) {
-    if (button == GLFW_MOUSE_BUTTON_LEFT) {
-        g_state.dragging = (action == GLFW_PRESS);
-        if (g_state.dragging)
-            glfwGetCursorPos(win, &g_state.last_mouse_x, &g_state.last_mouse_y);
+uint32_t panel_color(int panel_id) {
+    switch (panel_id) {
+    case kPanelInspector: return 0x1B2230FF; // dark slate
+    case kPanelConsole:   return 0x15181EFF; // near-black
+    default:              return 0x101218FF; // neutral dark
     }
 }
 
-static void cursor_pos_callback(GLFWwindow*, double x, double y) {
-    if (!g_state.dragging) return;
-    const float dx = static_cast<float>(x - g_state.last_mouse_x);
-    const float dy = static_cast<float>(y - g_state.last_mouse_y);
-    g_state.camera.pan_pixels(dx, dy);
-    g_state.last_mouse_x = x;
-    g_state.last_mouse_y = y;
+void unpack(uint32_t rgba, float out[4]) {
+    out[0] = ((rgba >> 24) & 0xFF) / 255.0f;
+    out[1] = ((rgba >> 16) & 0xFF) / 255.0f;
+    out[2] = ((rgba >> 8)  & 0xFF) / 255.0f;
+    out[3] = ( rgba        & 0xFF) / 255.0f;
 }
 
-static void scroll_callback(GLFWwindow* win, double, double yoffset) {
-    double mx = 0.0, my = 0.0;
-    glfwGetCursorPos(win, &mx, &my);
+VkRect2D to_vk(const DockRect& r) {
+    VkRect2D v;
+    v.offset.x = static_cast<int32_t>(r.x < 0 ? 0 : r.x);
+    v.offset.y = static_cast<int32_t>(r.y < 0 ? 0 : r.y);
+    v.extent.width  = static_cast<uint32_t>(r.w < 0 ? 0 : r.w);
+    v.extent.height = static_cast<uint32_t>(r.h < 0 ? 0 : r.h);
+    return v;
+}
+
+void push_rect(std::vector<UiRect>& out, const DockRect& r, uint32_t rgba) {
+    UiRect u;
+    u.rect[0] = r.x; u.rect[1] = r.y; u.rect[2] = r.w; u.rect[3] = r.h;
+    unpack(rgba, u.color);
+    out.push_back(u);
+}
+
+// ─── GLFW callbacks ──────────────────────────────────────────
+
+void mouse_button_callback(GLFWwindow* win, int button, int action, int) {
+    if (button != GLFW_MOUSE_BUTTON_LEFT) return;
+    double x = g_state.cursor_x, y = g_state.cursor_y;
+    glfwGetCursorPos(win, &x, &y);
+
+    if (action == GLFW_PRESS) {
+        const float fx = static_cast<float>(x), fy = static_cast<float>(y);
+        if (g_state.dock->begin_drag(fx, fy)) {
+            g_state.dock_dragging = true;
+        } else if (g_state.dock->on_click(fx, fy)) {
+            // tab switched
+        } else if (g_state.graph->contains(fx, fy)) {
+            g_state.graph_panning = true;
+            g_state.last_x = x;
+            g_state.last_y = y;
+        }
+    } else { // RELEASE
+        g_state.graph_panning = false;
+        g_state.dock_dragging = false;
+        g_state.dock->end_drag();
+    }
+}
+
+void cursor_pos_callback(GLFWwindow*, double x, double y) {
+    g_state.cursor_x = x;
+    g_state.cursor_y = y;
+    const float fx = static_cast<float>(x), fy = static_cast<float>(y);
+
+    if (g_state.dock_dragging) {
+        g_state.dock->drag_to(fx, fy);
+    } else if (g_state.graph_panning) {
+        g_state.graph->pan(static_cast<float>(x - g_state.last_x),
+                           static_cast<float>(y - g_state.last_y));
+        g_state.last_x = x;
+        g_state.last_y = y;
+    }
+
+    if (g_state.graph->contains(fx, fy))
+        g_state.graph->update_hover(fx, fy);
+    else
+        g_state.graph->clear_hover();
+}
+
+void scroll_callback(GLFWwindow* win, double, double yoffset) {
+    double x = 0, y = 0;
+    glfwGetCursorPos(win, &x, &y);
+    const float fx = static_cast<float>(x), fy = static_cast<float>(y);
+    if (!g_state.graph->contains(fx, fy)) return;
     const float factor = (yoffset > 0) ? 1.15f : (1.0f / 1.15f);
-    g_state.camera.zoom_at(static_cast<float>(mx), static_cast<float>(my),
-                           factor, g_state.viewport_w, g_state.viewport_h);
+    g_state.graph->zoom_at(fx, fy, factor);
 }
 
-static void key_callback(GLFWwindow* win, int key, int, int action, int) {
+void key_callback(GLFWwindow* win, int key, int, int action, int) {
     if (action != GLFW_PRESS) return;
-    if (key == GLFW_KEY_R)      g_state.reset_view = true;
+    if (key == GLFW_KEY_R)      g_state.reset_request = true;
+    if (key == GLFW_KEY_S)      g_state.save_request  = true;
     if (key == GLFW_KEY_ESCAPE) glfwSetWindowShouldClose(win, GLFW_TRUE);
 }
 
-// ─── Args ────────────────────────────────────────────────────
-
 struct Args {
     uint32_t nodes  = 10000;
-    uint64_t frames = 0; // 0 = run until window closed
+    uint64_t frames = 0;
 };
 
-static Args parse_args(int argc, char** argv) {
+Args parse_args(int argc, char** argv) {
     Args a;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--nodes") == 0 && i + 1 < argc)
@@ -101,86 +172,75 @@ static Args parse_args(int argc, char** argv) {
     return a;
 }
 
-// ─── Main ────────────────────────────────────────────────────
+} // namespace
 
 int main(int argc, char** argv) {
     const Args args = parse_args(argc, argv);
-    printf("=== Pictor Iter Relation Graph Demo (Step 1) ===\n");
-    printf("[init] Nodes requested: %u  (frames: %llu)\n",
-           args.nodes, static_cast<unsigned long long>(args.frames));
+    printf("=== Pictor Iter Relation Graph Demo (Step 2 + dock) ===\n");
+    printf("[init] Nodes: %u  frames: %llu\n", args.nodes,
+           static_cast<unsigned long long>(args.frames));
 
-    // ── Window ───────────────────────────────────────────────
+    // Window
     GlfwSurfaceProvider surface_provider;
     GlfwWindowConfig win_cfg;
     win_cfg.width  = 1280;
     win_cfg.height = 720;
-    win_cfg.title  = "Pictor — Iter Relation Graph (Step 1)";
+    win_cfg.title  = "Pictor — Iter Relation Graph (Step 2 + dock)";
     win_cfg.vsync  = true;
     if (!surface_provider.create(win_cfg)) {
-        fprintf(stderr, "[init] FATAL: Failed to create GLFW window\n");
+        fprintf(stderr, "[init] FATAL: window\n");
         return 1;
     }
 
-    // ── Vulkan ───────────────────────────────────────────────
+    // Vulkan
     VulkanContext vk_ctx;
     VulkanContextConfig vk_cfg;
     vk_cfg.app_name   = "Pictor Iter Graph Demo";
     vk_cfg.validation = true;
     if (!vk_ctx.initialize(&surface_provider, vk_cfg)) {
-        fprintf(stderr, "[init] FATAL: Failed to initialize Vulkan context\n");
+        fprintf(stderr, "[init] FATAL: vulkan\n");
         surface_provider.destroy();
         return 1;
     }
-    printf("[init] Vulkan ready. Swapchain: %ux%u\n",
-           vk_ctx.swapchain_extent().width, vk_ctx.swapchain_extent().height);
 
-    // ── Graph data ───────────────────────────────────────────
-    GraphStore store = generate_layered_graph(args.nodes);
-    printf("[init] Generated graph: %zu nodes, %zu edges\n",
-           store.node_count(), store.edge_count());
+    // Graph widget
+    GraphView graph;
+    if (!graph.initialize(vk_ctx, "shaders", generate_layered_graph(args.nodes))) {
+        fprintf(stderr, "[init] FATAL: graph view\n");
+        vk_ctx.shutdown();
+        surface_provider.destroy();
+        return 1;
+    }
+    printf("[init] Graph: %u nodes, %u edges\n", graph.total_nodes(), graph.total_edges());
 
-    // ── Renderer ─────────────────────────────────────────────
-    GraphRenderer graph_renderer;
-    if (!graph_renderer.initialize(vk_ctx, "shaders", store)) {
-        fprintf(stderr, "[init] FATAL: Failed to initialize graph renderer\n");
+    // Dock chrome renderer
+    UiRectRenderer ui;
+    if (!ui.initialize(vk_ctx, "shaders", 256)) {
+        fprintf(stderr, "[init] FATAL: ui renderer\n");
+        graph.shutdown();
         vk_ctx.shutdown();
         surface_provider.destroy();
         return 1;
     }
 
-    // Frame the whole graph: center the camera, pick a zoom that fits.
-    {
-        const auto& n = store.nodes();
-        float min_x = 0, max_x = 0, min_y = 0, max_y = 0;
-        if (store.node_count() > 0) {
-            min_x = max_x = n.cx[0];
-            min_y = max_y = n.cy[0];
-            for (size_t i = 1; i < store.node_count(); ++i) {
-                min_x = (n.cx[i] < min_x) ? n.cx[i] : min_x;
-                max_x = (n.cx[i] > max_x) ? n.cx[i] : max_x;
-                min_y = (n.cy[i] < min_y) ? n.cy[i] : min_y;
-                max_y = (n.cy[i] > max_y) ? n.cy[i] : max_y;
-            }
-        }
-        const float span_x = (max_x - min_x) + 200.0f;
-        const float span_y = (max_y - min_y) + 200.0f;
-        const float zx = static_cast<float>(win_cfg.width)  / span_x;
-        const float zy = static_cast<float>(win_cfg.height) / span_y;
-        g_state.fit_cx   = (min_x + max_x) * 0.5f;
-        g_state.fit_cy   = (min_y + max_y) * 0.5f;
-        g_state.fit_zoom = (zx < zy) ? zx : zy;
-        g_state.camera.reset(g_state.fit_cx, g_state.fit_cy, g_state.fit_zoom);
-    }
+    // Dock layout — load persisted, else default
+    DockLayout dock;
+    if (dock.load(kLayoutFile))
+        printf("[init] Loaded dock layout from %s\n", kLayoutFile);
+    else
+        dock.set_default(kPanelGraph, {kPanelInspector, kPanelConsole}, 0.72f);
 
-    // ── Callbacks ────────────────────────────────────────────
+    g_state.graph = &graph;
+    g_state.dock  = &dock;
+
     GLFWwindow* win = surface_provider.glfw_window();
     glfwSetMouseButtonCallback(win, mouse_button_callback);
     glfwSetCursorPosCallback(win, cursor_pos_callback);
     glfwSetScrollCallback(win, scroll_callback);
     glfwSetKeyCallback(win, key_callback);
 
-    // ── Loop ─────────────────────────────────────────────────
-    printf("[loop] Controls: Drag=pan, Scroll=zoom, R=reset, Esc=quit\n");
+    printf("[loop] Drag=pan, Scroll=zoom, drag splitter=resize, click tab=switch, R=fit, S=save, Esc=quit\n");
+
     uint64_t frame_count = 0;
     auto fps_t0 = std::chrono::steady_clock::now();
     uint64_t fps_frames = 0;
@@ -188,42 +248,57 @@ int main(int argc, char** argv) {
     while (!surface_provider.should_close()) {
         surface_provider.poll_events();
 
-        if (g_state.reset_view) {
-            // R re-fits the whole graph using the framing captured at startup.
-            g_state.reset_view = false;
-            g_state.camera.reset(g_state.fit_cx, g_state.fit_cy, g_state.fit_zoom);
-        }
+        if (g_state.reset_request) { g_state.reset_request = false; graph.reset_view(); }
+        if (g_state.save_request)  { g_state.save_request  = false; dock.save(kLayoutFile);
+                                     printf("[dock] Saved layout to %s\n", kLayoutFile); }
 
         const VkExtent2D ext = vk_ctx.swapchain_extent();
-        g_state.viewport_w = static_cast<float>(ext.width);
-        g_state.viewport_h = static_cast<float>(ext.height);
+        const float vw = static_cast<float>(ext.width);
+        const float vh = static_cast<float>(ext.height);
 
-        GraphPushConstants pc{};
-        Camera2D::build_proj(pc.proj, g_state.viewport_w, g_state.viewport_h);
-        g_state.camera.build_view(pc.view, g_state.viewport_w, g_state.viewport_h);
-        pc.params[0] = g_state.camera.zoom();
+        // Solve dock for the full window, then place the graph widget.
+        dock.solve(DockRect{0, 0, vw, vh});
+        for (const auto& p : dock.panels())
+            if (p.panel_id == kPanelGraph)
+                graph.set_bounds(to_vk(p.rect));
+
+        // Build dock chrome rects (non-graph panel backgrounds + tabs + splitters).
+        std::vector<UiRect> chrome;
+        chrome.reserve(32);
+        for (const auto& p : dock.panels())
+            if (p.panel_id != kPanelGraph)
+                push_rect(chrome, p.rect, panel_color(p.panel_id));
+        for (const auto& t : dock.tabs())
+            push_rect(chrome, t.rect, t.active ? 0x2C3850FF : 0x1A1F2AFF);
+        for (const auto& s : dock.splitters())
+            push_rect(chrome, s.handle, 0x39414FFF);
+
+        float ui_proj[16];
+        Camera2D::build_proj(ui_proj, vw, vh);
 
         const uint32_t image_idx = vk_ctx.acquire_next_image();
-        if (image_idx == UINT32_MAX) continue; // swapchain recreated
+        if (image_idx == UINT32_MAX) continue;
+        const uint32_t flight = vk_ctx.current_frame();
 
         VkCommandBuffer cmd = vk_ctx.command_buffers()[image_idx];
         vkResetCommandBuffer(cmd, 0);
-
         VkCommandBufferBeginInfo begin_info{};
         begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         vkBeginCommandBuffer(cmd, &begin_info);
 
-        VkClearValue clear_color = {{{0.09f, 0.10f, 0.13f, 1.0f}}};
-        VkRenderPassBeginInfo rp_info{};
-        rp_info.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-        rp_info.renderPass      = vk_ctx.default_render_pass();
-        rp_info.framebuffer     = vk_ctx.framebuffers()[image_idx];
-        rp_info.renderArea      = {{0, 0}, ext};
-        rp_info.clearValueCount = 1;
-        rp_info.pClearValues    = &clear_color;
-        vkCmdBeginRenderPass(cmd, &rp_info, VK_SUBPASS_CONTENTS_INLINE);
+        VkClearValue clear_color = {{{0.07f, 0.08f, 0.10f, 1.0f}}};
+        VkRenderPassBeginInfo rp{};
+        rp.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp.renderPass      = vk_ctx.default_render_pass();
+        rp.framebuffer     = vk_ctx.framebuffers()[image_idx];
+        rp.renderArea      = {{0, 0}, ext};
+        rp.clearValueCount = 1;
+        rp.pClearValues    = &clear_color;
+        vkCmdBeginRenderPass(cmd, &rp, VK_SUBPASS_CONTENTS_INLINE);
 
-        graph_renderer.render(cmd, ext, pc);
+        graph.render(cmd, flight);
+        ui.draw(cmd, ext, ui_proj, flight, chrome.data(),
+                static_cast<uint32_t>(chrome.size()));
 
         vkCmdEndRenderPass(cmd);
         vkEndCommandBuffer(cmd);
@@ -231,17 +306,16 @@ int main(int argc, char** argv) {
         VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         VkSemaphore wait_sem = vk_ctx.image_available_semaphore();
         VkSemaphore sig_sem  = vk_ctx.render_finished_semaphore();
-
-        VkSubmitInfo submit_info{};
-        submit_info.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-        submit_info.waitSemaphoreCount   = 1;
-        submit_info.pWaitSemaphores      = &wait_sem;
-        submit_info.pWaitDstStageMask    = &wait_stage;
-        submit_info.commandBufferCount   = 1;
-        submit_info.pCommandBuffers      = &cmd;
-        submit_info.signalSemaphoreCount = 1;
-        submit_info.pSignalSemaphores    = &sig_sem;
-        vkQueueSubmit(vk_ctx.graphics_queue(), 1, &submit_info, vk_ctx.in_flight_fence());
+        VkSubmitInfo submit{};
+        submit.sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit.waitSemaphoreCount   = 1;
+        submit.pWaitSemaphores      = &wait_sem;
+        submit.pWaitDstStageMask    = &wait_stage;
+        submit.commandBufferCount   = 1;
+        submit.pCommandBuffers      = &cmd;
+        submit.signalSemaphoreCount = 1;
+        submit.pSignalSemaphores    = &sig_sem;
+        vkQueueSubmit(vk_ctx.graphics_queue(), 1, &submit, vk_ctx.in_flight_fence());
 
         vk_ctx.present(image_idx);
 
@@ -250,23 +324,27 @@ int main(int argc, char** argv) {
         auto now = std::chrono::steady_clock::now();
         double elapsed = std::chrono::duration<double>(now - fps_t0).count();
         if (elapsed >= 1.0) {
-            printf("[loop] FPS: %.1f | nodes: %u edges: %u | zoom: %.3f\n",
-                   fps_frames / elapsed, graph_renderer.node_count(),
-                   graph_renderer.edge_count(), g_state.camera.zoom());
+            printf("[loop] FPS %.1f | visible %u/%u nodes, %u/%u edges | zoom %.3f | hover %d\n",
+                   fps_frames / elapsed,
+                   graph.visible_nodes(), graph.total_nodes(),
+                   graph.visible_edges(), graph.total_edges(),
+                   graph.zoom(), static_cast<int>(graph.hovered()));
             fps_t0 = now;
             fps_frames = 0;
         }
 
         if (args.frames != 0 && frame_count >= args.frames) {
-            printf("[loop] Reached --frames %llu, exiting\n",
-                   static_cast<unsigned long long>(args.frames));
+            printf("[loop] Reached --frames, exiting\n");
             break;
         }
     }
 
-    // ── Cleanup (reverse order) ──────────────────────────────
+    // Persist layout on exit.
+    dock.save(kLayoutFile);
+
     vk_ctx.device_wait_idle();
-    graph_renderer.shutdown();
+    ui.shutdown();
+    graph.shutdown();
     vk_ctx.shutdown();
     surface_provider.destroy();
     printf("[cleanup] Done. %llu frames.\n",

--- a/demo/graph/shaders/ui_rect.vert
+++ b/demo/graph/shaders/ui_rect.vert
@@ -1,0 +1,36 @@
+#version 450
+
+// Instanced screen-space solid rect (dock chrome). Geometry from gl_VertexIndex.
+
+layout(push_constant) uniform PushConstants {
+    mat4 proj;      // screen px -> clip
+} pc;
+
+struct UiRect {
+    vec4 rect;      // x, y, w, h  (pixels)
+    vec4 color;     // rgba 0..1
+};
+
+layout(std430, set = 0, binding = 0) readonly buffer Rects {
+    UiRect rects[];
+};
+
+layout(location = 0) out vec4 vColor;
+
+vec2 corner(int i) {
+    // Unit quad in [0,1], two triangles.
+    if (i == 0) return vec2(0.0, 0.0);
+    if (i == 1) return vec2(1.0, 0.0);
+    if (i == 2) return vec2(1.0, 1.0);
+    if (i == 3) return vec2(0.0, 0.0);
+    if (i == 4) return vec2(1.0, 1.0);
+    return vec2(0.0, 1.0);
+}
+
+void main() {
+    UiRect r = rects[gl_InstanceIndex];
+    vec2 q = corner(gl_VertexIndex);
+    vec2 px = r.rect.xy + q * r.rect.zw;
+    gl_Position = pc.proj * vec4(px, 0.0, 1.0);
+    vColor = r.color;
+}

--- a/demo/graph/spatial_grid.cpp
+++ b/demo/graph/spatial_grid.cpp
@@ -1,0 +1,146 @@
+#include "spatial_grid.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "graph_store.h"
+
+namespace pictor::graph {
+
+void SpatialGrid::build(const GraphStore& store) {
+    const auto& n = store.nodes();
+    const size_t count = store.node_count();
+
+    cx_.resize(count);
+    cy_.resize(count);
+    hw_.resize(count);
+    hh_.resize(count);
+
+    if (count == 0) {
+        cell_start_.assign(1, 0);
+        items_.clear();
+        nx_ = ny_ = 1;
+        return;
+    }
+
+    float min_x = n.cx[0], max_x = n.cx[0];
+    float min_y = n.cy[0], max_y = n.cy[0];
+    max_hw_ = 0.0f;
+    max_hh_ = 0.0f;
+    for (size_t i = 0; i < count; ++i) {
+        cx_[i] = n.cx[i];
+        cy_[i] = n.cy[i];
+        hw_[i] = n.w[i] * 0.5f;
+        hh_[i] = n.h[i] * 0.5f;
+        min_x = std::min(min_x, n.cx[i]);
+        max_x = std::max(max_x, n.cx[i]);
+        min_y = std::min(min_y, n.cy[i]);
+        max_y = std::max(max_y, n.cy[i]);
+        max_hw_ = std::max(max_hw_, hw_[i]);
+        max_hh_ = std::max(max_hh_, hh_[i]);
+    }
+
+    // Aim for roughly 1-2 nodes per cell on average.
+    const float span_x = std::max(1.0f, max_x - min_x);
+    const float span_y = std::max(1.0f, max_y - min_y);
+    const float area    = span_x * span_y;
+    const float target  = std::sqrt(area / static_cast<float>(count)); // ~cell for 1/cell
+    cell_size_ = std::max(target, std::max(max_hw_, max_hh_) * 2.0f);
+    cell_size_ = std::max(cell_size_, 1.0f);
+
+    origin_x_ = min_x;
+    origin_y_ = min_y;
+    nx_ = std::max(1, static_cast<int>(std::floor(span_x / cell_size_)) + 1);
+    ny_ = std::max(1, static_cast<int>(std::floor(span_y / cell_size_)) + 1);
+    const int cells = nx_ * ny_;
+
+    // Counting sort into CSR.
+    cell_start_.assign(cells + 1, 0);
+    std::vector<int> cell_of(count);
+    for (size_t i = 0; i < count; ++i) {
+        const int c = cell_index(cx_[i], cy_[i]);
+        cell_of[i] = c;
+        ++cell_start_[c + 1];
+    }
+    for (int c = 0; c < cells; ++c)
+        cell_start_[c + 1] += cell_start_[c];
+
+    items_.resize(count);
+    std::vector<uint32_t> cursor(cell_start_.begin(), cell_start_.end() - 1);
+    for (size_t i = 0; i < count; ++i) {
+        const int c = cell_of[i];
+        items_[cursor[c]++] = static_cast<uint32_t>(i);
+    }
+}
+
+int SpatialGrid::cell_index(float x, float y) const {
+    int ix = static_cast<int>(std::floor((x - origin_x_) / cell_size_));
+    int iy = static_cast<int>(std::floor((y - origin_y_) / cell_size_));
+    ix = std::clamp(ix, 0, nx_ - 1);
+    iy = std::clamp(iy, 0, ny_ - 1);
+    return iy * nx_ + ix;
+}
+
+void SpatialGrid::query_visible(float min_x, float min_y, float max_x, float max_y,
+                                std::vector<uint32_t>& out) const {
+    out.clear();
+    if (cx_.empty()) return;
+
+    // Pad the query so boxes whose center is just outside the view but whose
+    // body overlaps still get gathered, then refine per node.
+    const float qminx = min_x - max_hw_;
+    const float qminy = min_y - max_hh_;
+    const float qmaxx = max_x + max_hw_;
+    const float qmaxy = max_y + max_hh_;
+
+    int ix0 = static_cast<int>(std::floor((qminx - origin_x_) / cell_size_));
+    int iy0 = static_cast<int>(std::floor((qminy - origin_y_) / cell_size_));
+    int ix1 = static_cast<int>(std::floor((qmaxx - origin_x_) / cell_size_));
+    int iy1 = static_cast<int>(std::floor((qmaxy - origin_y_) / cell_size_));
+    ix0 = std::clamp(ix0, 0, nx_ - 1);
+    iy0 = std::clamp(iy0, 0, ny_ - 1);
+    ix1 = std::clamp(ix1, 0, nx_ - 1);
+    iy1 = std::clamp(iy1, 0, ny_ - 1);
+
+    for (int iy = iy0; iy <= iy1; ++iy) {
+        for (int ix = ix0; ix <= ix1; ++ix) {
+            const int c = iy * nx_ + ix;
+            for (uint32_t k = cell_start_[c]; k < cell_start_[c + 1]; ++k) {
+                const uint32_t i = items_[k];
+                // Exact box-vs-view rect overlap.
+                if (cx_[i] + hw_[i] < min_x || cx_[i] - hw_[i] > max_x) continue;
+                if (cy_[i] + hh_[i] < min_y || cy_[i] - hh_[i] > max_y) continue;
+                out.push_back(i);
+            }
+        }
+    }
+}
+
+uint32_t SpatialGrid::pick(float world_x, float world_y) const {
+    if (cx_.empty()) return 0xFFFFFFFFu;
+
+    // A node's box can extend max_h* beyond its center cell, so scan a small
+    // neighborhood of cells around the point.
+    const int rx = static_cast<int>(std::ceil(max_hw_ / cell_size_));
+    const int ry = static_cast<int>(std::ceil(max_hh_ / cell_size_));
+    int cix = static_cast<int>(std::floor((world_x - origin_x_) / cell_size_));
+    int ciy = static_cast<int>(std::floor((world_y - origin_y_) / cell_size_));
+
+    uint32_t best = 0xFFFFFFFFu;
+    for (int iy = ciy - ry; iy <= ciy + ry; ++iy) {
+        if (iy < 0 || iy >= ny_) continue;
+        for (int ix = cix - rx; ix <= cix + rx; ++ix) {
+            if (ix < 0 || ix >= nx_) continue;
+            const int c = iy * nx_ + ix;
+            for (uint32_t k = cell_start_[c]; k < cell_start_[c + 1]; ++k) {
+                const uint32_t i = items_[k];
+                if (world_x < cx_[i] - hw_[i] || world_x > cx_[i] + hw_[i]) continue;
+                if (world_y < cy_[i] - hh_[i] || world_y > cy_[i] + hh_[i]) continue;
+                if (best == 0xFFFFFFFFu || i > best) best = i;  // topmost = drawn last
+            }
+        }
+    }
+    return best;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/spatial_grid.h
+++ b/demo/graph/spatial_grid.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace pictor::graph {
+
+class GraphStore;
+
+/// Uniform spatial grid over the graph's node boxes (built once; positions are
+/// static in Step 2). Backs the two scale-critical operations:
+///   - viewport cull: query_visible() returns exactly the nodes whose box meets
+///     the view rect, so draw work is O(visible) not O(total).
+///   - hit-test: pick() maps a world point to the topmost node under it.
+///
+/// Storage is CSR (counts -> prefix-sum offsets -> packed handle array), and the
+/// grid keeps its own flat copy of node box extents so queries are self-contained
+/// and cache-local (DoD: no pointer-chasing into the store on the hot path).
+class SpatialGrid {
+public:
+    void build(const GraphStore& store);
+
+    /// Append handles of nodes whose box intersects [min,max] (world) to `out`.
+    /// `out` is cleared first. Result is exact (box-vs-rect refined).
+    void query_visible(float min_x, float min_y, float max_x, float max_y,
+                       std::vector<uint32_t>& out) const;
+
+    /// Topmost (largest handle) node whose box contains the world point, or
+    /// 0xFFFFFFFF if none.
+    uint32_t pick(float world_x, float world_y) const;
+
+    size_t node_count() const { return cx_.size(); }
+
+private:
+    int cell_index(float x, float y) const;
+
+    // Flat copies of node box centers / sizes (index == NodeHandle).
+    std::vector<float> cx_, cy_, hw_, hh_;  // half-width / half-height
+
+    // CSR buckets.
+    std::vector<uint32_t> cell_start_;  // size = cells + 1
+    std::vector<uint32_t> items_;       // size = node count
+
+    float  origin_x_ = 0.0f, origin_y_ = 0.0f;
+    float  cell_size_ = 256.0f;
+    int    nx_ = 1, ny_ = 1;
+    float  max_hw_ = 0.0f, max_hh_ = 0.0f;  // padding for boundary boxes
+};
+
+} // namespace pictor::graph

--- a/demo/graph/ui_rect_renderer.cpp
+++ b/demo/graph/ui_rect_renderer.cpp
@@ -1,0 +1,121 @@
+#include "ui_rect_renderer.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include "pictor/surface/vulkan_context.h"
+
+#include <cstdio>
+#include <string>
+
+namespace pictor::graph {
+
+UiRectRenderer::~UiRectRenderer() {
+    if (initialized_) shutdown();
+}
+
+bool UiRectRenderer::initialize(VulkanContext& vk_ctx, const char* shader_dir,
+                                uint32_t capacity) {
+    vk_ctx_  = &vk_ctx;
+    device_  = vk_ctx.device();
+    flights_ = vk_ctx.frames_in_flight();
+    if (capacity == 0) capacity = 1;
+
+    VkDescriptorSetLayoutBinding binding{};
+    binding.binding         = 0;
+    binding.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    binding.descriptorCount = 1;
+    binding.stageFlags      = VK_SHADER_STAGE_VERTEX_BIT;
+    VkDescriptorSetLayoutCreateInfo li{};
+    li.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    li.bindingCount = 1;
+    li.pBindings    = &binding;
+    if (vkCreateDescriptorSetLayout(device_, &li, nullptr, &desc_set_layout_) != VK_SUCCESS)
+        return false;
+
+    VkDescriptorPoolSize ps{};
+    ps.type            = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    ps.descriptorCount = flights_;
+    VkDescriptorPoolCreateInfo pi{};
+    pi.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+    pi.maxSets       = flights_;
+    pi.poolSizeCount = 1;
+    pi.pPoolSizes    = &ps;
+    if (vkCreateDescriptorPool(device_, &pi, nullptr, &desc_pool_) != VK_SUCCESS)
+        return false;
+
+    if (!buf_.initialize(vk_ctx, flights_, VkDeviceSize(capacity) * sizeof(UiRect),
+                         desc_set_layout_, desc_pool_))
+        return false;
+
+    VkPushConstantRange pcr{};
+    pcr.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    pcr.offset     = 0;
+    pcr.size       = sizeof(UiPushConstants);
+    VkPipelineLayoutCreateInfo pli{};
+    pli.sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pli.setLayoutCount         = 1;
+    pli.pSetLayouts            = &desc_set_layout_;
+    pli.pushConstantRangeCount = 1;
+    pli.pPushConstantRanges    = &pcr;
+    if (vkCreatePipelineLayout(device_, &pli, nullptr, &pipeline_layout_) != VK_SUCCESS)
+        return false;
+
+    const std::string dir  = shader_dir;
+    const std::string vert = dir + "/ui_rect.vert.spv";
+    const std::string frag = dir + "/graph_flat.frag.spv";
+    pipeline_ = create_instanced_pipeline(device_, vk_ctx.default_render_pass(),
+                                          pipeline_layout_, vert.c_str(), frag.c_str());
+    if (!pipeline_) {
+        fprintf(stderr, "[UiRect] Failed to create pipeline\n");
+        return false;
+    }
+
+    initialized_ = true;
+    return true;
+}
+
+void UiRectRenderer::shutdown() {
+    if (!vk_ctx_) return;
+    vkDeviceWaitIdle(device_);
+    buf_.destroy(device_);
+    if (pipeline_)        vkDestroyPipeline(device_, pipeline_, nullptr);
+    if (pipeline_layout_) vkDestroyPipelineLayout(device_, pipeline_layout_, nullptr);
+    if (desc_pool_)       vkDestroyDescriptorPool(device_, desc_pool_, nullptr);
+    if (desc_set_layout_) vkDestroyDescriptorSetLayout(device_, desc_set_layout_, nullptr);
+    pipeline_        = VK_NULL_HANDLE;
+    pipeline_layout_ = VK_NULL_HANDLE;
+    desc_pool_       = VK_NULL_HANDLE;
+    desc_set_layout_ = VK_NULL_HANDLE;
+    initialized_     = false;
+}
+
+void UiRectRenderer::draw(VkCommandBuffer cmd, VkExtent2D extent, const float proj[16],
+                          uint32_t flight, const UiRect* rects, uint32_t count) {
+    if (!initialized_ || count == 0) return;
+
+    buf_.upload(flight, rects, VkDeviceSize(count) * sizeof(UiRect));
+
+    VkViewport viewport{};
+    viewport.width    = static_cast<float>(extent.width);
+    viewport.height   = static_cast<float>(extent.height);
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+    vkCmdSetViewport(cmd, 0, 1, &viewport);
+    VkRect2D scissor = {{0, 0}, extent};
+    vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+    UiPushConstants pc{};
+    for (int i = 0; i < 16; ++i) pc.proj[i] = proj[i];
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_);
+    vkCmdPushConstants(cmd, pipeline_layout_, VK_SHADER_STAGE_VERTEX_BIT,
+                       0, sizeof(UiPushConstants), &pc);
+    VkDescriptorSet set = buf_.set(flight);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                            pipeline_layout_, 0, 1, &set, 0, nullptr);
+    vkCmdDraw(cmd, 6, count, 0, 0);
+}
+
+} // namespace pictor::graph
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/ui_rect_renderer.h
+++ b/demo/graph/ui_rect_renderer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+#include "graph_instances.h"
+#include "vk_util.h"
+
+namespace pictor {
+
+class VulkanContext;
+
+namespace graph {
+
+struct UiPushConstants {
+    float proj[16];   // screen px -> clip
+};
+
+/// Instanced solid-rect renderer for the dock chrome (panel backgrounds,
+/// splitter handles, tab headers). Screen-space; rebuilt each frame into a
+/// per-flight dynamic buffer (counts are tiny).
+class UiRectRenderer {
+public:
+    UiRectRenderer() = default;
+    ~UiRectRenderer();
+
+    UiRectRenderer(const UiRectRenderer&)            = delete;
+    UiRectRenderer& operator=(const UiRectRenderer&) = delete;
+
+    bool initialize(VulkanContext& vk_ctx, const char* shader_dir, uint32_t capacity);
+    void shutdown();
+
+    void draw(VkCommandBuffer cmd, VkExtent2D extent, const float proj[16],
+              uint32_t flight, const UiRect* rects, uint32_t count);
+
+private:
+    VulkanContext* vk_ctx_ = nullptr;
+    VkDevice       device_ = VK_NULL_HANDLE;
+    uint32_t       flights_ = 1;
+
+    VkDescriptorSetLayout desc_set_layout_ = VK_NULL_HANDLE;
+    VkDescriptorPool      desc_pool_       = VK_NULL_HANDLE;
+    VkPipelineLayout      pipeline_layout_ = VK_NULL_HANDLE;
+    VkPipeline            pipeline_        = VK_NULL_HANDLE;
+
+    DynamicInstanceBuffers buf_;
+    bool initialized_ = false;
+};
+
+} // namespace graph
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/vk_util.cpp
+++ b/demo/graph/vk_util.cpp
@@ -1,0 +1,226 @@
+#include "vk_util.h"
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include "pictor/surface/vulkan_context.h"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+
+namespace pictor::graph {
+
+VkShaderModule load_shader_module(VkDevice device, const char* spv_path) {
+    std::ifstream file(spv_path, std::ios::ate | std::ios::binary);
+    if (!file.is_open()) {
+        fprintf(stderr, "[vk_util] Cannot open shader: %s\n", spv_path);
+        return VK_NULL_HANDLE;
+    }
+    const size_t size = static_cast<size_t>(file.tellg());
+    std::vector<char> code(size);
+    file.seekg(0);
+    file.read(code.data(), static_cast<std::streamsize>(size));
+
+    VkShaderModuleCreateInfo info{};
+    info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    info.codeSize = size;
+    info.pCode    = reinterpret_cast<const uint32_t*>(code.data());
+
+    VkShaderModule mod = VK_NULL_HANDLE;
+    if (vkCreateShaderModule(device, &info, nullptr, &mod) != VK_SUCCESS)
+        fprintf(stderr, "[vk_util] Failed to create shader module: %s\n", spv_path);
+    return mod;
+}
+
+uint32_t find_memory_type(VkPhysicalDevice phys, uint32_t type_filter,
+                          VkMemoryPropertyFlags props) {
+    VkPhysicalDeviceMemoryProperties mp;
+    vkGetPhysicalDeviceMemoryProperties(phys, &mp);
+    for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+        if ((type_filter & (1u << i)) &&
+            (mp.memoryTypes[i].propertyFlags & props) == props)
+            return i;
+    }
+    fprintf(stderr, "[vk_util] No suitable memory type\n");
+    return 0;
+}
+
+VkPipeline create_instanced_pipeline(VkDevice device, VkRenderPass render_pass,
+                                     VkPipelineLayout layout,
+                                     const char* vert_spv, const char* frag_spv) {
+    VkShaderModule vert = load_shader_module(device, vert_spv);
+    VkShaderModule frag = load_shader_module(device, frag_spv);
+    if (!vert || !frag) {
+        if (vert) vkDestroyShaderModule(device, vert, nullptr);
+        if (frag) vkDestroyShaderModule(device, frag, nullptr);
+        return VK_NULL_HANDLE;
+    }
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = vert;
+    stages[0].pName  = "main";
+    stages[1].sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage  = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = frag;
+    stages[1].pName  = "main";
+
+    VkPipelineVertexInputStateCreateInfo vertex_input{};
+    vertex_input.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vp{};
+    vp.sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vp.viewportCount = 1;
+    vp.scissorCount  = 1;
+
+    VkPipelineRasterizationStateCreateInfo raster{};
+    raster.sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    raster.polygonMode = VK_POLYGON_MODE_FILL;
+    raster.cullMode    = VK_CULL_MODE_NONE;
+    raster.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    raster.lineWidth   = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{};
+    ds.sType            = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    ds.depthTestEnable  = VK_FALSE;
+    ds.depthWriteEnable = VK_FALSE;
+
+    VkPipelineColorBlendAttachmentState blend_att{};
+    blend_att.blendEnable         = VK_TRUE;
+    blend_att.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
+    blend_att.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+    blend_att.colorBlendOp        = VK_BLEND_OP_ADD;
+    blend_att.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
+    blend_att.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+    blend_att.alphaBlendOp        = VK_BLEND_OP_ADD;
+    blend_att.colorWriteMask      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                                    VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
+    VkPipelineColorBlendStateCreateInfo blend{};
+    blend.sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    blend.attachmentCount = 1;
+    blend.pAttachments    = &blend_att;
+
+    VkDynamicState dyn_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo dyn{};
+    dyn.sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn.dynamicStateCount = 2;
+    dyn.pDynamicStates    = dyn_states;
+
+    VkGraphicsPipelineCreateInfo pi{};
+    pi.sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pi.stageCount          = 2;
+    pi.pStages             = stages;
+    pi.pVertexInputState   = &vertex_input;
+    pi.pInputAssemblyState = &ia;
+    pi.pViewportState      = &vp;
+    pi.pRasterizationState = &raster;
+    pi.pMultisampleState   = &ms;
+    pi.pDepthStencilState  = &ds;
+    pi.pColorBlendState    = &blend;
+    pi.pDynamicState       = &dyn;
+    pi.layout              = layout;
+    pi.renderPass          = render_pass;
+    pi.subpass             = 0;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    VkResult result = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pi, nullptr, &pipeline);
+    vkDestroyShaderModule(device, vert, nullptr);
+    vkDestroyShaderModule(device, frag, nullptr);
+    if (result != VK_SUCCESS) {
+        fprintf(stderr, "[vk_util] vkCreateGraphicsPipelines failed (%d)\n", result);
+        return VK_NULL_HANDLE;
+    }
+    return pipeline;
+}
+
+// ─── DynamicInstanceBuffers ──────────────────────────────────
+
+bool DynamicInstanceBuffers::initialize(VulkanContext& vk_ctx, uint32_t flights,
+                                        VkDeviceSize capacity_bytes,
+                                        VkDescriptorSetLayout set_layout,
+                                        VkDescriptorPool pool) {
+    VkDevice device = vk_ctx.device();
+    capacity_ = capacity_bytes;
+    buffers_.resize(flights, VK_NULL_HANDLE);
+    memories_.resize(flights, VK_NULL_HANDLE);
+    mapped_.resize(flights, nullptr);
+    sets_.resize(flights, VK_NULL_HANDLE);
+
+    for (uint32_t f = 0; f < flights; ++f) {
+        VkBufferCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+        info.size  = capacity_bytes;
+        info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        if (vkCreateBuffer(device, &info, nullptr, &buffers_[f]) != VK_SUCCESS)
+            return false;
+
+        VkMemoryRequirements req;
+        vkGetBufferMemoryRequirements(device, buffers_[f], &req);
+
+        VkMemoryAllocateInfo alloc{};
+        alloc.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+        alloc.allocationSize  = req.size;
+        alloc.memoryTypeIndex = find_memory_type(
+            vk_ctx.physical_device(), req.memoryTypeBits,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        if (vkAllocateMemory(device, &alloc, nullptr, &memories_[f]) != VK_SUCCESS)
+            return false;
+        vkBindBufferMemory(device, buffers_[f], memories_[f], 0);
+        vkMapMemory(device, memories_[f], 0, capacity_bytes, 0, &mapped_[f]);
+
+        VkDescriptorSetAllocateInfo sa{};
+        sa.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        sa.descriptorPool     = pool;
+        sa.descriptorSetCount = 1;
+        sa.pSetLayouts        = &set_layout;
+        if (vkAllocateDescriptorSets(device, &sa, &sets_[f]) != VK_SUCCESS)
+            return false;
+
+        VkDescriptorBufferInfo bi{};
+        bi.buffer = buffers_[f];
+        bi.offset = 0;
+        bi.range  = VK_WHOLE_SIZE;
+
+        VkWriteDescriptorSet write{};
+        write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        write.dstSet          = sets_[f];
+        write.dstBinding      = 0;
+        write.descriptorCount = 1;
+        write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        write.pBufferInfo     = &bi;
+        vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
+    }
+    return true;
+}
+
+void DynamicInstanceBuffers::upload(uint32_t flight, const void* data, VkDeviceSize bytes) {
+    if (bytes == 0 || data == nullptr) return;
+    if (bytes > capacity_) bytes = capacity_;   // never overrun the buffer
+    std::memcpy(mapped_[flight], data, static_cast<size_t>(bytes));
+}
+
+void DynamicInstanceBuffers::destroy(VkDevice device) {
+    for (size_t f = 0; f < buffers_.size(); ++f) {
+        if (memories_[f]) vkUnmapMemory(device, memories_[f]);
+        if (buffers_[f])  vkDestroyBuffer(device, buffers_[f], nullptr);
+        if (memories_[f]) vkFreeMemory(device, memories_[f], nullptr);
+    }
+    buffers_.clear();
+    memories_.clear();
+    mapped_.clear();
+    sets_.clear();
+}
+
+} // namespace pictor::graph
+
+#endif // PICTOR_HAS_VULKAN

--- a/demo/graph/vk_util.h
+++ b/demo/graph/vk_util.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#ifdef PICTOR_HAS_VULKAN
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <vector>
+
+namespace pictor {
+
+class VulkanContext;
+
+namespace graph {
+
+/// Shared Vulkan helpers for the demo's instanced renderers (graph + dock UI).
+/// Keeps the boilerplate in one place so each renderer only describes what is
+/// unique to it (its shaders, push constants and instance layout).
+
+VkShaderModule load_shader_module(VkDevice device, const char* spv_path);
+
+uint32_t find_memory_type(VkPhysicalDevice phys, uint32_t type_filter,
+                          VkMemoryPropertyFlags props);
+
+/// Standard 2D pipeline used by every demo instanced renderer:
+///   - no vertex input (geometry from gl_VertexIndex)
+///   - triangle list, no cull, no depth
+///   - straight alpha blend
+///   - dynamic viewport + scissor
+/// The caller owns `layout` (push constant + descriptor layout) and `render_pass`.
+VkPipeline create_instanced_pipeline(VkDevice device, VkRenderPass render_pass,
+                                     VkPipelineLayout layout,
+                                     const char* vert_spv, const char* frag_spv);
+
+/// Per-frame-in-flight, host-visible, persistently-mapped storage buffers plus a
+/// descriptor set each, for instance data that is rebuilt every frame (cull /
+/// dock layout). Rotating by flight index makes CPU writes safe against the GPU
+/// still reading an earlier frame (the acquire fence gates reuse).
+class DynamicInstanceBuffers {
+public:
+    bool initialize(VulkanContext& vk_ctx, uint32_t flights, VkDeviceSize capacity_bytes,
+                    VkDescriptorSetLayout set_layout, VkDescriptorPool pool);
+    void destroy(VkDevice device);
+
+    /// Copy `bytes` of instance data into the given flight's mapped buffer.
+    void upload(uint32_t flight, const void* data, VkDeviceSize bytes);
+
+    VkDescriptorSet set(uint32_t flight) const { return sets_[flight]; }
+    VkDeviceSize    capacity() const { return capacity_; }
+
+private:
+    std::vector<VkBuffer>        buffers_;
+    std::vector<VkDeviceMemory>  memories_;
+    std::vector<void*>           mapped_;
+    std::vector<VkDescriptorSet> sets_;
+    VkDeviceSize                 capacity_ = 0;
+};
+
+} // namespace graph
+} // namespace pictor
+
+#endif // PICTOR_HAS_VULKAN


### PR DESCRIPTION
Iter 関連グラフ native renderer の **Step 2 (規模耐性)** と **dock layouter (d)**。
グラフを **Tier B widget** 化し、native dock の leaf に載せた。 (#89 の続き)

## Step 2 — 描画量を視界に比例
- `spatial_grid.{h,cpp}` — CSR 一様グリッド。`query_visible` で view AABB と交差する
  ノードだけ返す (**O(visible)**)、`pick` で world 点→最前面ノード (hit-test)
- `graph_view.{h,cpp}` — **Tier B widget**。store+grid+camera+renderer を束ね、毎フレーム
  cull → 可視サブセットのみ GPU へ upload。edge は端点可視を frame-stamp で判定。hover は
  `pick` で highlight。自身の leaf rect 内に描画
- `graph_renderer` 改 — **per-flight 動的インスタンスバッファ + 任意 region(scissor) 描画**へ
  作り替え (Step1 の full SSBO 一括 → 可視のみ upload)
- `vk_util.{h,cpp}` — 共通 Vulkan ヘルパ (instanced pipeline 生成 / per-flight
  `DynamicInstanceBuffers`) を切り出し、3 renderer の重複を排除
- `graph_instances.h` — Node/Edge/Ui インスタンス構造体を共有

## dock (d) — native layouter
- `dock_layout.{h,cpp}` — split/tabs/leaf ツリー (Vulkan 非依存の `DockRect`)。`solve` で
  panel/splitter/tab 矩形算出、**splitter ドラッグで ratio 調整・タブクリックで切替・
  テキスト永続 (load/save `dock_layout.txt`)**。Corpus `DockComponent` 準拠
- `ui_rect_renderer.{h,cpp}` + `shaders/ui_rect.vert` — dock chrome (パネル背景/splitter/
  タブヘッダ) の screen-space solid rect 描画。**テキストは後段(Step4)のため当面は色面**
- `main` 改 — dock を解いて graph leaf に GraphView を配置、入力を dock(splitter/tab) と
  graph(pan/zoom/hover) に振り分け。起動時 layout 復元・終了時保存

## 操作
Drag(graph)=pan / Scroll=zoom / splitter ドラッグ=分割比 / タブクリック=切替 /
R=再フィット / S=layout 保存 / Esc=終了(自動保存)。 `--nodes N` `--frames N`

## ビルド
```
cmake -S . -B build && cmake --build build --target pictor_graph_demo --config Debug
```
→ `demo/graph` は **warning 0**、`ui_rect.vert.spv` 含む全 SPIR-V 生成、exe 生成。
実行確認は Pictor 規約によりユーザ側。

## 次段
Sugiyama layout (worker, double-buffer) → glyph atlas + monospace LABEL LOD →
snippet 遅延取得(LRU) → incremental expand → clangd 実データ結線 (IDataChannel)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)