### PR TITLE
feat(graph-demo): Sugiyama layered layout (worker + lerp 整列) — Step3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,6 +416,7 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
             demo/graph/graph_store.cpp
             demo/graph/camera2d.cpp
             demo/graph/graph_generator.cpp
+            demo/graph/layout_engine.cpp
             demo/graph/vk_util.cpp
             demo/graph/spatial_grid.cpp
             demo/graph/graph_renderer.cpp

--- a/demo/graph/graph_generator.cpp
+++ b/demo/graph/graph_generator.cpp
@@ -33,7 +33,7 @@ constexpr uint32_t kKindColor[static_cast<int>(NodeKind::Count)] = {
 
 } // namespace
 
-GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed) {
+GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed, bool scatter) {
     GraphStore store;
     if (node_count == 0) return store;
 
@@ -43,6 +43,8 @@ GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed) {
     const uint32_t per_layer =
         std::max(1u, static_cast<uint32_t>(std::sqrt(static_cast<double>(node_count))));
     const uint32_t layer_count = (node_count + per_layer - 1u) / per_layer;
+    // Scatter box half-extent (used only for initial positions when scatter=true).
+    const float scatter_r = static_cast<float>(per_layer) * 100.0f;
 
     constexpr float kNodeW    = 120.0f;
     constexpr float kNodeH    = 44.0f;
@@ -68,11 +70,17 @@ GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed) {
         const float y     = static_cast<float>(layer) * stride_y;
 
         for (uint32_t i = 0; i < in_this; ++i) {
-            const float x = x0 + static_cast<float>(i) * stride_x;
-            // Slight jitter so the grid does not look mechanical.
-            const float jx = (rng.unit() - 0.5f) * kGapX * 0.5f;
-            const auto  kind = static_cast<NodeKind>(rng.below(static_cast<uint32_t>(NodeKind::Count)));
-            store.add_node(x + jx, y, kNodeW, kNodeH,
+            const auto kind = static_cast<NodeKind>(rng.below(static_cast<uint32_t>(NodeKind::Count)));
+            float px, py;
+            if (scatter) {
+                px = (rng.unit() - 0.5f) * 2.0f * scatter_r;
+                py = (rng.unit() - 0.5f) * 2.0f * scatter_r;
+            } else {
+                // Slight jitter so the grid does not look mechanical.
+                px = x0 + static_cast<float>(i) * stride_x + (rng.unit() - 0.5f) * kGapX * 0.5f;
+                py = y;
+            }
+            store.add_node(px, py, kNodeW, kNodeH,
                            kKindColor[static_cast<int>(kind)], kind);
             ++made;
         }

--- a/demo/graph/graph_generator.h
+++ b/demo/graph/graph_generator.h
@@ -6,13 +6,14 @@
 
 namespace pictor::graph {
 
-/// Generate a deterministic, layered synthetic graph for the Step 1 stress
-/// test (no real clangd data yet). Positions are fixed at generation time
-/// (Sugiyama layout is a later step); the goal is only to prove that N boxes +
-/// edges pan/zoom without melting.
+/// Generate a deterministic synthetic graph (no real clangd data yet). The
+/// topology is layered — each node connects forward to a few nodes in the next
+/// layer, approximating a call-hierarchy fan-out.
 ///
-/// Nodes are laid out in horizontal layers; each node connects forward to a
-/// few nodes in the next layer, approximating a call hierarchy fan-out.
-GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed = 1u);
+/// `scatter` only affects the *initial* node positions: when false they are
+/// placed in tidy layers; when true they start randomly so the Sugiyama layout
+/// (Step 3) visibly snaps them into place. The topology is identical either way.
+GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed = 1u,
+                                  bool scatter = false);
 
 } // namespace pictor::graph

--- a/demo/graph/graph_store.cpp
+++ b/demo/graph/graph_store.cpp
@@ -29,6 +29,12 @@ NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
     return handle;
 }
 
+void GraphStore::set_positions(const std::vector<float>& xs, const std::vector<float>& ys) {
+    if (xs.size() != nodes_.cx.size() || ys.size() != nodes_.cy.size()) return;
+    nodes_.cx = xs;
+    nodes_.cy = ys;
+}
+
 void GraphStore::add_edge(NodeHandle from, NodeHandle to, EdgeKind kind) {
     edges_.from.push_back(from);
     edges_.to.push_back(to);

--- a/demo/graph/graph_store.h
+++ b/demo/graph/graph_store.h
@@ -57,6 +57,10 @@ public:
                         uint32_t rgba, NodeKind kind);
     void       add_edge(NodeHandle from, NodeHandle to, EdgeKind kind = EdgeKind::Call);
 
+    /// Overwrite all node centers (e.g. with a freshly computed layout). Sizes
+    /// must match node_count(); mismatched input is ignored.
+    void set_positions(const std::vector<float>& xs, const std::vector<float>& ys);
+
     size_t       node_count() const { return nodes_.cx.size(); }
     size_t       edge_count() const { return edges_.from.size(); }
     const Nodes& nodes()      const { return nodes_; }

--- a/demo/graph/graph_view.cpp
+++ b/demo/graph/graph_view.cpp
@@ -31,12 +31,65 @@ bool GraphView::initialize(VulkanContext& vk_ctx, const char* shader_dir, GraphS
     edge_inst_.reserve(edges);
     vis_stamp_.assign(nodes, 0);
 
+    // Render starts at the generator positions and animates to the layout the
+    // worker computes.
+    anim_x_ = store_.nodes().cx;
+    anim_y_ = store_.nodes().cy;
+
     fit_to_bounds();
+    start_layout_worker();
     return true;
 }
 
 void GraphView::shutdown() {
+    if (layout_thread_.joinable()) layout_thread_.join();
     renderer_.shutdown();
+}
+
+void GraphView::start_layout_worker() {
+    // Copy topology so the worker is independent of any later store mutation.
+    const uint32_t n = static_cast<uint32_t>(store_.node_count());
+    std::vector<uint32_t> from = store_.edges().from;
+    std::vector<uint32_t> to   = store_.edges().to;
+    layout_thread_ = std::thread([this, n, from = std::move(from), to = std::move(to)]() {
+        LayoutResult r = compute_layered_layout(n, from, to, {});
+        layout_result_ = std::move(r);
+        layout_ready_.store(true, std::memory_order_release);
+    });
+}
+
+void GraphView::maybe_apply_layout() {
+    if (layout_applied_) return;
+    if (!layout_ready_.load(std::memory_order_acquire)) return;
+    if (layout_thread_.joinable()) layout_thread_.join();
+    layout_applied_ = true;
+    if (!layout_result_.ok) return;
+
+    // Target positions become authoritative; cull/hit-test use them immediately.
+    store_.set_positions(layout_result_.x, layout_result_.y);
+    grid_.build(store_);
+    fit_to_bounds();           // re-frame to the new layout
+    animating_ = true;         // render lerps anim_ -> store positions
+}
+
+void GraphView::advance_animation() {
+    if (!animating_) return;
+    const auto& n = store_.nodes();
+    const float k = 0.18f;     // per-frame approach factor
+    float max_delta = 0.0f;
+    for (size_t i = 0; i < n.cx.size(); ++i) {
+        const float dx = n.cx[i] - anim_x_[i];
+        const float dy = n.cy[i] - anim_y_[i];
+        anim_x_[i] += dx * k;
+        anim_y_[i] += dy * k;
+        const float ad = (dx < 0 ? -dx : dx) + (dy < 0 ? -dy : dy);
+        if (ad > max_delta) max_delta = ad;
+    }
+    if (max_delta < 0.5f) {    // settled — snap and stop the O(N) update
+        anim_x_ = n.cx;
+        anim_y_ = n.cy;
+        animating_ = false;
+    }
 }
 
 bool GraphView::contains(float win_x, float win_y) const {
@@ -104,6 +157,9 @@ void GraphView::fit_to_bounds() {
 }
 
 void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
+    maybe_apply_layout();
+    advance_animation();
+
     if (bounds_.extent.width == 0 || bounds_.extent.height == 0) return;
 
     const float vw = static_cast<float>(bounds_.extent.width);
@@ -125,8 +181,9 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
     for (uint32_t i : vis_nodes_) {
         vis_stamp_[i] = frame_;
         NodeInstance d;
-        d.rect[0] = n.cx[i];
-        d.rect[1] = n.cy[i];
+        // Render at the animated position (lerps to the layout target).
+        d.rect[0] = anim_x_[i];
+        d.rect[1] = anim_y_[i];
         d.rect[2] = n.w[i];
         d.rect[3] = n.h[i];
         if (i == hovered_) {
@@ -146,8 +203,8 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
         const uint32_t b = e.to[k];
         if (vis_stamp_[a] != frame_ && vis_stamp_[b] != frame_) continue;
         EdgeInstance d;
-        d.ends[0] = n.cx[a]; d.ends[1] = n.cy[a];
-        d.ends[2] = n.cx[b]; d.ends[3] = n.cy[b];
+        d.ends[0] = anim_x_[a]; d.ends[1] = anim_y_[a];
+        d.ends[2] = anim_x_[b]; d.ends[3] = anim_y_[b];
         d.color[0] = 0.45f; d.color[1] = 0.50f; d.color[2] = 0.58f;
         d.color[3] = kEdgeThicknessPx;
         edge_inst_.push_back(d);

--- a/demo/graph/graph_view.h
+++ b/demo/graph/graph_view.h
@@ -3,13 +3,16 @@
 #ifdef PICTOR_HAS_VULKAN
 
 #include <vulkan/vulkan.h>
+#include <atomic>
 #include <cstdint>
+#include <thread>
 #include <vector>
 
 #include "camera2d.h"
 #include "graph_instances.h"
 #include "graph_renderer.h"
 #include "graph_store.h"
+#include "layout_engine.h"
 #include "spatial_grid.h"
 
 namespace pictor {
@@ -39,8 +42,12 @@ public:
     void clear_hover() { hovered_ = INVALID_NODE; }
     void reset_view();
 
-    /// Cull + upload + draw, clipped to the widget's bounds.
+    /// Cull + upload + draw, clipped to the widget's bounds. Also advances the
+    /// layout-in animation and applies a finished worker layout.
     void render(VkCommandBuffer cmd, uint32_t flight);
+
+    bool layout_pending() const { return !layout_applied_; }
+    bool animating()      const { return animating_; }
 
     uint32_t visible_nodes() const { return last_vis_nodes_; }
     uint32_t visible_edges() const { return last_vis_edges_; }
@@ -52,12 +59,23 @@ public:
 private:
     void fit_to_bounds();
     void to_world(float win_x, float win_y, float& wx, float& wy) const;
+    void start_layout_worker();
+    void maybe_apply_layout();
+    void advance_animation();
 
     VkRect2D      bounds_{};
     GraphStore    store_;
     SpatialGrid   grid_;
     Camera2D      camera_;
     GraphRenderer renderer_;
+
+    // ── Layout (Sugiyama) computed on a worker thread, animated into place ──
+    std::thread        layout_thread_;
+    std::atomic<bool>  layout_ready_{false};
+    LayoutResult       layout_result_;        // written by worker, read after ready
+    bool               layout_applied_ = false;
+    std::vector<float> anim_x_, anim_y_;       // animated render positions (lerp -> store)
+    bool               animating_ = false;
 
     // Per-frame cull scratch (reused; no per-frame allocation after warm-up).
     std::vector<uint32_t>     vis_nodes_;

--- a/demo/graph/layout_engine.cpp
+++ b/demo/graph/layout_engine.cpp
@@ -1,0 +1,176 @@
+#include "layout_engine.h"
+
+#include <algorithm>
+#include <numeric>
+
+namespace pictor::graph {
+
+namespace {
+
+// CSR adjacency built from an edge subset.
+struct Csr {
+    std::vector<uint32_t> start;  // size n+1
+    std::vector<uint32_t> items;  // size edge_count
+};
+
+Csr build_csr(uint32_t n, const std::vector<uint32_t>& src, const std::vector<uint32_t>& dst) {
+    Csr c;
+    c.start.assign(n + 1, 0);
+    for (uint32_t v : src) ++c.start[v + 1];
+    for (uint32_t i = 0; i < n; ++i) c.start[i + 1] += c.start[i];
+    c.items.resize(src.size());
+    std::vector<uint32_t> cur(c.start.begin(), c.start.end() - 1);
+    for (size_t e = 0; e < src.size(); ++e)
+        c.items[cur[src[e]]++] = dst[e];
+    return c;
+}
+
+} // namespace
+
+LayoutResult compute_layered_layout(uint32_t n,
+                                    const std::vector<uint32_t>& from,
+                                    const std::vector<uint32_t>& to,
+                                    const LayoutParams& p) {
+    LayoutResult result;
+    if (n == 0) { result.ok = true; return result; }
+    result.x.assign(n, 0.0f);
+    result.y.assign(n, 0.0f);
+
+    // ── 1. Cycle removal: iterative DFS that keeps every edge except those
+    // pointing at a node currently on the DFS stack (back edges). The acyclic
+    // edge subset (af/at) is collected directly during traversal so its order
+    // is self-consistent (no separate index mapping).
+    const Csr out_all = build_csr(n, from, to);
+    std::vector<uint8_t> color(n, 0);      // 0=white, 1=on-stack(gray), 2=done(black)
+    std::vector<uint32_t> af, at;
+    af.reserve(from.size());
+    at.reserve(to.size());
+
+    struct Frame { uint32_t node; uint32_t cursor; };
+    std::vector<Frame> stack;
+    stack.reserve(64);
+    for (uint32_t s = 0; s < n; ++s) {
+        if (color[s] != 0) continue;
+        color[s] = 1;
+        stack.push_back({s, out_all.start[s]});
+        while (!stack.empty()) {
+            Frame& f = stack.back();
+            if (f.cursor < out_all.start[f.node + 1]) {
+                const uint32_t u = f.node;
+                const uint32_t v = out_all.items[f.cursor];
+                ++f.cursor;                      // advance before any push (f may dangle after)
+                if (color[v] == 1) {
+                    // back edge -> drop
+                } else {
+                    af.push_back(u);             // tree / forward / cross edge -> keep
+                    at.push_back(v);
+                    if (color[v] == 0) {
+                        color[v] = 1;
+                        stack.push_back({v, out_all.start[v]});
+                    }
+                }
+            } else {
+                color[f.node] = 2;
+                stack.pop_back();
+            }
+        }
+    }
+
+    // ── 2. Layer assignment via longest path (Kahn topo order on the DAG).
+    const Csr out_acyc = build_csr(n, af, at);
+    std::vector<uint32_t> indeg(n, 0);
+    for (uint32_t v : at) ++indeg[v];
+
+    std::vector<uint32_t> order;            // topological order
+    order.reserve(n);
+    std::vector<uint32_t> queue;
+    queue.reserve(n);
+    for (uint32_t v = 0; v < n; ++v)
+        if (indeg[v] == 0) queue.push_back(v);
+    std::vector<uint32_t> indeg_work = indeg;
+    for (size_t qi = 0; qi < queue.size(); ++qi) {
+        const uint32_t u = queue[qi];
+        order.push_back(u);
+        for (uint32_t k = out_acyc.start[u]; k < out_acyc.start[u + 1]; ++k) {
+            const uint32_t v = out_acyc.items[k];
+            if (--indeg_work[v] == 0) queue.push_back(v);
+        }
+    }
+    // Any nodes left out (shouldn't happen after cycle removal) get appended.
+    if (order.size() < n) {
+        std::vector<uint8_t> seen(n, 0);
+        for (uint32_t v : order) seen[v] = 1;
+        for (uint32_t v = 0; v < n; ++v) if (!seen[v]) order.push_back(v);
+    }
+
+    std::vector<int> layer(n, 0);
+    int max_layer = 0;
+    for (uint32_t u : order) {
+        for (uint32_t k = out_acyc.start[u]; k < out_acyc.start[u + 1]; ++k) {
+            const uint32_t v = out_acyc.items[k];
+            if (layer[u] + 1 > layer[v]) layer[v] = layer[u] + 1;
+            if (layer[v] > max_layer) max_layer = layer[v];
+        }
+    }
+
+    // ── 3. Group into layers; barycenter crossing reduction.
+    std::vector<std::vector<uint32_t>> layers(max_layer + 1);
+    for (uint32_t v = 0; v < n; ++v) layers[layer[v]].push_back(v);
+
+    std::vector<uint32_t> pos(n, 0);        // order index within layer
+    auto reindex = [&](const std::vector<uint32_t>& lyr) {
+        for (uint32_t i = 0; i < lyr.size(); ++i) pos[lyr[i]] = i;
+    };
+    for (auto& lyr : layers) reindex(lyr);
+
+    // Neighbour CSR using acyclic edges, both directions.
+    const Csr in_acyc = build_csr(n, at, af);  // reversed
+
+    auto barycenter = [&](uint32_t node, bool use_predecessors) -> float {
+        const Csr& adj = use_predecessors ? in_acyc : out_acyc;
+        const uint32_t b = adj.start[node];
+        const uint32_t e = adj.start[node + 1];
+        if (e == b) return static_cast<float>(pos[node]); // keep place if isolated
+        float sum = 0.0f;
+        for (uint32_t k = b; k < e; ++k) sum += static_cast<float>(pos[adj.items[k]]);
+        return sum / static_cast<float>(e - b);
+    };
+
+    for (int s = 0; s < p.sweeps; ++s) {
+        const bool downward = (s % 2 == 0); // even: order by predecessors (top-down)
+        if (downward) {
+            for (int L = 1; L <= max_layer; ++L) {
+                auto& lyr = layers[L];
+                std::stable_sort(lyr.begin(), lyr.end(), [&](uint32_t a, uint32_t b) {
+                    return barycenter(a, true) < barycenter(b, true);
+                });
+                reindex(lyr);
+            }
+        } else {
+            for (int L = max_layer - 1; L >= 0; --L) {
+                auto& lyr = layers[L];
+                std::stable_sort(lyr.begin(), lyr.end(), [&](uint32_t a, uint32_t b) {
+                    return barycenter(a, false) < barycenter(b, false);
+                });
+                reindex(lyr);
+            }
+        }
+    }
+
+    // ── 4. Coordinate assignment (centered per layer).
+    for (int L = 0; L <= max_layer; ++L) {
+        const auto& lyr = layers[L];
+        const float count = static_cast<float>(lyr.size());
+        const float x0 = -(count - 1.0f) * 0.5f * p.node_gap;
+        for (uint32_t i = 0; i < lyr.size(); ++i) {
+            const uint32_t v = lyr[i];
+            result.x[v] = x0 + static_cast<float>(i) * p.node_gap;
+            result.y[v] = static_cast<float>(L) * p.layer_gap;
+        }
+    }
+
+    result.ok = true;
+    return result;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/layout_engine.h
+++ b/demo/graph/layout_engine.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace pictor::graph {
+
+struct LayoutParams {
+    float layer_gap = 140.0f;  // vertical distance between layers (world units)
+    float node_gap  = 190.0f;  // horizontal distance between nodes in a layer
+    int   sweeps    = 4;       // barycenter crossing-reduction passes
+};
+
+struct LayoutResult {
+    std::vector<float> x;
+    std::vector<float> y;
+    bool ok = false;
+};
+
+/// Sugiyama-style layered layout for a directed graph (Iter call hierarchy).
+/// Pure / thread-safe (no shared state) so it can run on a worker thread:
+///   1. remove cycles (DFS back-edge detection)
+///   2. assign layers by longest path on the acyclic DAG
+///   3. reduce edge crossings with barycenter sweeps
+///   4. assign coordinates (layer -> y, order-in-layer -> x, centered)
+///
+/// `from` / `to` are parallel edge arrays of node handles in [0, node_count).
+LayoutResult compute_layered_layout(uint32_t node_count,
+                                    const std::vector<uint32_t>& from,
+                                    const std::vector<uint32_t>& to,
+                                    const LayoutParams& params = {});
+
+} // namespace pictor::graph

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -156,8 +156,9 @@ void key_callback(GLFWwindow* win, int key, int, int action, int) {
 }
 
 struct Args {
-    uint32_t nodes  = 10000;
-    uint64_t frames = 0;
+    uint32_t nodes   = 10000;
+    uint64_t frames  = 0;
+    bool     scatter = false;
 };
 
 Args parse_args(int argc, char** argv) {
@@ -167,6 +168,8 @@ Args parse_args(int argc, char** argv) {
             a.nodes = static_cast<uint32_t>(std::strtoul(argv[++i], nullptr, 10));
         else if (std::strcmp(argv[i], "--frames") == 0 && i + 1 < argc)
             a.frames = std::strtoull(argv[++i], nullptr, 10);
+        else if (std::strcmp(argv[i], "--scatter") == 0)
+            a.scatter = true;
     }
     if (a.nodes == 0) a.nodes = 1;
     return a;
@@ -176,16 +179,16 @@ Args parse_args(int argc, char** argv) {
 
 int main(int argc, char** argv) {
     const Args args = parse_args(argc, argv);
-    printf("=== Pictor Iter Relation Graph Demo (Step 2 + dock) ===\n");
-    printf("[init] Nodes: %u  frames: %llu\n", args.nodes,
-           static_cast<unsigned long long>(args.frames));
+    printf("=== Pictor Iter Relation Graph Demo (Step 3: layered layout) ===\n");
+    printf("[init] Nodes: %u  frames: %llu  scatter: %s\n", args.nodes,
+           static_cast<unsigned long long>(args.frames), args.scatter ? "yes" : "no");
 
     // Window
     GlfwSurfaceProvider surface_provider;
     GlfwWindowConfig win_cfg;
     win_cfg.width  = 1280;
     win_cfg.height = 720;
-    win_cfg.title  = "Pictor — Iter Relation Graph (Step 2 + dock)";
+    win_cfg.title  = "Pictor — Iter Relation Graph (Step 3: layered layout)";
     win_cfg.vsync  = true;
     if (!surface_provider.create(win_cfg)) {
         fprintf(stderr, "[init] FATAL: window\n");
@@ -205,7 +208,7 @@ int main(int argc, char** argv) {
 
     // Graph widget
     GraphView graph;
-    if (!graph.initialize(vk_ctx, "shaders", generate_layered_graph(args.nodes))) {
+    if (!graph.initialize(vk_ctx, "shaders", generate_layered_graph(args.nodes, 1u, args.scatter))) {
         fprintf(stderr, "[init] FATAL: graph view\n");
         vk_ctx.shutdown();
         surface_provider.destroy();


### PR DESCRIPTION
Iter 関連グラフ native renderer の **Step 3**。合成固定座標を、グラフのトポロジから
計算した**層状レイアウト**に置き換え、**worker スレッド**で焼いて **lerp で整列**させる。 (#89 #90 の続き)

## 実装
- `layout_engine.{h,cpp}` — **Sugiyama 風 層状レイアウト**（pure / スレッドセーフ、共有状態なし）:
  1. サイクル除去 = 反復 DFS の back-edge 検出
  2. 最長路で層割当（Kahn topo order）
  3. **barycenter sweep** で交差削減
  4. 層→y / 層内順→x の座標割当（中央寄せ）
- `graph_view` 改 — init で worker 起動（generator 位置を anim 開始点に複製）。完了を
  `atomic` acquire で検知 → store 位置に適用（target）、grid 再構築 + 再フィット、anim を
  毎フレーム lerp（settle で O(N) 更新停止）。**cull/hit-test は target、描画は anim 位置**。
  shutdown で join
- `graph_store` — `set_positions` 追加（レイアウト結果で全 center を上書き）
- `graph_generator` — `--scatter` 追加。**トポロジは不変**のまま初期位置のみランダム散布にし、
  層状レイアウトへの整列を視認しやすくする
- `main` — `--scatter` 配線、タイトル/ログを Step3 表記に

## 自己レビューでの修正
`layout_engine` のサイクル除去で back-edge を CSR item index で記録し原配列 index で読む
**index 不整合**があったため、acyclic 辺集合を **DFS 中に直接構築**する形へ修正
（反復 DFS の frame 参照は push 前に値退避して dangling 回避）。

## ビルド
```
cmake -S . -B build && cmake --build build --target pictor_graph_demo --config Debug
```
→ `demo/graph` は **warning 0**、exe 生成。実行確認は Pictor 規約によりユーザ側
（`--scatter` で整列アニメが明瞭：散布→層へ snap）。

## 次段
Step 4 glyph atlas + monospace LABEL LOD（パネル/タブ/ノードにテキストが乗る）→
Step 5 snippet → Step 6 incremental expand / clangd 実データ結線。

🤖 Generated with [Claude Code](https://claude.com/claude-code)