### PR TITLE
feat(graph-demo): ノード/タブ/パネルにテキスト + LABEL LOD (Step4)

### DIFF
--- a/demo/graph/graph_generator.cpp
+++ b/demo/graph/graph_generator.cpp
@@ -2,11 +2,17 @@
 
 #include <algorithm>
 #include <cmath>
+#include <string>
 #include <vector>
 
 namespace pictor::graph {
 
 namespace {
+
+// Per-kind name prefix for synthetic symbol labels (until real clangd data).
+constexpr const char* kKindPrefix[static_cast<int>(NodeKind::Count)] = {
+    "fn_", "m_", "var_", "Type_", "sym_"
+};
 
 /// Small deterministic LCG so the demo graph is reproducible across runs
 /// without pulling in <random> (and without any global state).
@@ -80,8 +86,9 @@ GraphStore generate_layered_graph(uint32_t node_count, uint32_t seed, bool scatt
                 px = x0 + static_cast<float>(i) * stride_x + (rng.unit() - 0.5f) * kGapX * 0.5f;
                 py = y;
             }
+            std::string label = kKindPrefix[static_cast<int>(kind)] + std::to_string(made);
             store.add_node(px, py, kNodeW, kNodeH,
-                           kKindColor[static_cast<int>(kind)], kind);
+                           kKindColor[static_cast<int>(kind)], kind, std::move(label));
             ++made;
         }
     }

--- a/demo/graph/graph_store.cpp
+++ b/demo/graph/graph_store.cpp
@@ -1,5 +1,7 @@
 #include "graph_store.h"
 
+#include <utility>
+
 namespace pictor::graph {
 
 void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
@@ -10,6 +12,7 @@ void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
     nodes_.rgba.reserve(node_capacity);
     nodes_.kind.reserve(node_capacity);
     nodes_.flags.reserve(node_capacity);
+    nodes_.label.reserve(node_capacity);
 
     edges_.from.reserve(edge_capacity);
     edges_.to.reserve(edge_capacity);
@@ -17,7 +20,7 @@ void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
 }
 
 NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
-                                uint32_t rgba, NodeKind kind) {
+                                uint32_t rgba, NodeKind kind, std::string label) {
     const NodeHandle handle = static_cast<NodeHandle>(nodes_.cx.size());
     nodes_.cx.push_back(cx);
     nodes_.cy.push_back(cy);
@@ -26,6 +29,7 @@ NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
     nodes_.rgba.push_back(rgba);
     nodes_.kind.push_back(static_cast<uint8_t>(kind));
     nodes_.flags.push_back(0);
+    nodes_.label.push_back(std::move(label));
     return handle;
 }
 

--- a/demo/graph/graph_store.h
+++ b/demo/graph/graph_store.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace pictor::graph {
@@ -43,6 +44,7 @@ public:
         std::vector<uint32_t> rgba;     // packed 0xRRGGBBAA
         std::vector<uint8_t>  kind;     // NodeKind
         std::vector<uint8_t>  flags;    // selected/hovered/... (Step 1: unused)
+        std::vector<std::string> label; // symbol name (cold; only NEAR-LOD labels read it)
     };
 
     struct Edges {
@@ -54,7 +56,7 @@ public:
     void reserve(size_t node_capacity, size_t edge_capacity);
 
     NodeHandle add_node(float cx, float cy, float w, float h,
-                        uint32_t rgba, NodeKind kind);
+                        uint32_t rgba, NodeKind kind, std::string label = {});
     void       add_edge(NodeHandle from, NodeHandle to, EdgeKind kind = EdgeKind::Call);
 
     /// Overwrite all node centers (e.g. with a freshly computed layout). Sizes

--- a/demo/graph/graph_view.cpp
+++ b/demo/graph/graph_view.cpp
@@ -4,6 +4,7 @@
 
 #include "pictor/surface/vulkan_context.h"
 
+#include <algorithm>
 #include <utility>
 
 namespace pictor::graph {
@@ -221,6 +222,44 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
     renderer_.draw(cmd, bounds_, pc, flight,
                    node_inst_.data(), last_vis_nodes_,
                    edge_inst_.data(), last_vis_edges_);
+}
+
+void GraphView::draw_labels(BitmapTextRenderer& text) const {
+    if (bounds_.extent.width == 0 || bounds_.extent.height == 0) return;
+
+    const auto& n = store_.nodes();
+    const float z  = camera_.zoom();
+    const float ox = static_cast<float>(bounds_.offset.x);
+    const float oy = static_cast<float>(bounds_.offset.y);
+    const float ew = static_cast<float>(bounds_.extent.width);
+    const float eh = static_cast<float>(bounds_.extent.height);
+    const float cx = camera_.center_x();
+    const float cy = camera_.center_y();
+
+    constexpr float kLabelMinPx = 48.0f;  // LABEL LOD: hide when a node is smaller
+    constexpr int   kMaxLabels  = 350;    // keep within the text batch budget
+    int drawn = 0;
+
+    // vis_nodes_ holds this frame's visible handles (from render()); labels track
+    // the animated positions so they follow the layout-in motion.
+    for (uint32_t i : vis_nodes_) {
+        const float w_px = n.w[i] * z;
+        if (w_px < kLabelMinPx) continue;          // too small to read
+        const std::string& s = n.label[i];
+        if (s.empty()) continue;
+
+        const float sx = ox + (anim_x_[i] - cx) * z + ew * 0.5f;
+        const float sy = oy + (anim_y_[i] - cy) * z + eh * 0.5f;
+        if (sx < ox || sx > ox + ew || sy < oy || sy > oy + eh) continue; // outside leaf
+
+        const float scale = std::clamp(n.h[i] * z * 0.42f / 16.0f, 0.6f, 2.2f);
+        const float tw = static_cast<float>(s.size()) * 8.0f * scale;
+        const float th = 16.0f * scale;
+        text.set_scale(scale);
+        text.draw_text(sx - tw * 0.5f, sy - th * 0.5f, s.c_str(),
+                       0.92f, 0.95f, 1.0f, 1.0f);
+        if (++drawn >= kMaxLabels) break;
+    }
 }
 
 } // namespace pictor::graph

--- a/demo/graph/graph_view.h
+++ b/demo/graph/graph_view.h
@@ -8,6 +8,7 @@
 #include <thread>
 #include <vector>
 
+#include "pictor/profiler/bitmap_text_renderer.h"
 #include "camera2d.h"
 #include "graph_instances.h"
 #include "graph_renderer.h"
@@ -45,6 +46,11 @@ public:
     /// Cull + upload + draw, clipped to the widget's bounds. Also advances the
     /// layout-in animation and applies a finished worker layout.
     void render(VkCommandBuffer cmd, uint32_t flight);
+
+    /// Draw symbol labels for the nodes that are visible *and* large enough on
+    /// screen (LABEL LOD), using the shared text renderer. Call after render()
+    /// within the frame's text batch (begin/end). Bounded by the visible set.
+    void draw_labels(BitmapTextRenderer& text) const;
 
     bool layout_pending() const { return !layout_applied_; }
     bool animating()      const { return animating_; }

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -21,6 +21,7 @@
 
 #include "pictor/surface/vulkan_context.h"
 #include "pictor/surface/glfw_surface_provider.h"
+#include "pictor/profiler/bitmap_text_renderer.h"
 #include "camera2d.h"
 #include "dock_layout.h"
 #include "graph_generator.h"
@@ -68,6 +69,15 @@ uint32_t panel_color(int panel_id) {
     case kPanelInspector: return 0x1B2230FF; // dark slate
     case kPanelConsole:   return 0x15181EFF; // near-black
     default:              return 0x101218FF; // neutral dark
+    }
+}
+
+const char* panel_name(int panel_id) {
+    switch (panel_id) {
+    case kPanelGraph:     return "Graph";
+    case kPanelInspector: return "Inspector";
+    case kPanelConsole:   return "Console";
+    default:              return "Panel";
     }
 }
 
@@ -179,7 +189,7 @@ Args parse_args(int argc, char** argv) {
 
 int main(int argc, char** argv) {
     const Args args = parse_args(argc, argv);
-    printf("=== Pictor Iter Relation Graph Demo (Step 3: layered layout) ===\n");
+    printf("=== Pictor Iter Relation Graph Demo (Step 4: labels / text LOD) ===\n");
     printf("[init] Nodes: %u  frames: %llu  scatter: %s\n", args.nodes,
            static_cast<unsigned long long>(args.frames), args.scatter ? "yes" : "no");
 
@@ -188,7 +198,7 @@ int main(int argc, char** argv) {
     GlfwWindowConfig win_cfg;
     win_cfg.width  = 1280;
     win_cfg.height = 720;
-    win_cfg.title  = "Pictor — Iter Relation Graph (Step 3: layered layout)";
+    win_cfg.title  = "Pictor — Iter Relation Graph (Step 4: labels / text LOD)";
     win_cfg.vsync  = true;
     if (!surface_provider.create(win_cfg)) {
         fprintf(stderr, "[init] FATAL: window\n");
@@ -220,6 +230,18 @@ int main(int argc, char** argv) {
     UiRectRenderer ui;
     if (!ui.initialize(vk_ctx, "shaders", 256)) {
         fprintf(stderr, "[init] FATAL: ui renderer\n");
+        graph.shutdown();
+        vk_ctx.shutdown();
+        surface_provider.destroy();
+        return 1;
+    }
+
+    // Text renderer (embedded 8x16 monospace bitmap font) — labels for nodes
+    // (LABEL LOD) and dock chrome (tab / panel names).
+    BitmapTextRenderer text;
+    if (!text.initialize(vk_ctx, "shaders")) {
+        fprintf(stderr, "[init] FATAL: text renderer\n");
+        ui.shutdown();
         graph.shutdown();
         vk_ctx.shutdown();
         surface_provider.destroy();
@@ -303,6 +325,25 @@ int main(int argc, char** argv) {
         ui.draw(cmd, ext, ui_proj, flight, chrome.data(),
                 static_cast<uint32_t>(chrome.size()));
 
+        // Text pass: dock chrome labels (tab + panel names) then node labels.
+        text.begin(cmd, ext);
+        text.set_scale(1.0f);
+        for (const auto& t : dock.tabs()) {
+            const char* nm = panel_name(t.panel_id);
+            const float tw = static_cast<float>(std::strlen(nm)) * 8.0f;
+            const float tx = t.rect.x + (t.rect.w - tw) * 0.5f;
+            const float ty = t.rect.y + (t.rect.h - 16.0f) * 0.5f;
+            if (t.active) text.draw_text(tx, ty, nm, 0.92f, 0.96f, 1.0f, 1.0f);
+            else          text.draw_text(tx, ty, nm, 0.55f, 0.60f, 0.68f, 1.0f);
+        }
+        for (const auto& p : dock.panels()) {
+            if (p.panel_id == kPanelGraph) continue;
+            text.draw_text(p.rect.x + 10.0f, p.rect.y + 8.0f, panel_name(p.panel_id),
+                           0.70f, 0.76f, 0.86f, 1.0f);
+        }
+        graph.draw_labels(text);
+        text.end();
+
         vkCmdEndRenderPass(cmd);
         vkEndCommandBuffer(cmd);
 
@@ -346,6 +387,7 @@ int main(int argc, char** argv) {
     dock.save(kLayoutFile);
 
     vk_ctx.device_wait_idle();
+    text.shutdown();
     ui.shutdown();
     graph.shutdown();
     vk_ctx.shutdown();


### PR DESCRIPTION
Iter 関連グラフ native renderer の **Step 4**。Pictor 既存の **`BitmapTextRenderer`**
（8x16 monospace 埋め込みフォント）を再利用し、**初めてテキストを載せる**。 (#89 #90 #91 の続き)

## 実装
- `graph_store` — `Nodes.label`（symbol 名）追加（cold; NEAR-LOD ラベルのみ参照）、`add_node` に label 引数
- `graph_generator` — kind 別プレフィックス + id で合成シンボル名（`fn_`/`m_`/`var_`/`Type_`/`sym_`）。実 clangd データ前のプレースホルダ
- `graph_view` — **`draw_labels(BitmapTextRenderer&)`** 追加。**visible かつ画面上で十分大きいノード（screen 幅 ≥ 48px = LABEL LOD）のみ**、world→screen 変換して anim 位置にラベル描画。zoom 連動スケール、可視集合で件数有界（上限 350、text batch 予算内）
- `main` — `BitmapTextRenderer` を配線。render pass 内で `text.begin` → タブ名/パネル名（chrome）+ `graph.draw_labels` → `text.end` の **1 バッチ**

## 設計メモ
「描画量を視界に比例」方針どおりラベルは **遠景=なし / 近景=表示**。TextRun キャッシュ
（1回 shape→座標のみ）は BitmapTextRenderer の動的バッチで代替——LOD で件数が抑えられる
ため現状は再 shape でも安価（数千ラベル規模が要るなら後段で TextRun cache 化）。
**新シェーダ / 新ソース / CMake 変更なし**（text_overlay シェーダは既存、BitmapTextRenderer は pictor lib）。

## ビルド
```
cmake -S . -B build && cmake --build build --target pictor_graph_demo --config Debug
```
→ `demo/graph` は **warning 0**、exe 生成。実行確認は Pictor 規約によりユーザ側
（ズームインでノード名が出現、タブに Inspector/Console、パネルに見出し）。

## 次段
Step 5 snippet 遅延取得 + NEAR LOD + LRU（React Flow パリティ）→ Step 6 incremental
expand / clangd 実データ結線（IDataChannel）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)