### PR TITLE
feat(graph-demo): NEAR-LOD snippet カード + LRU 遅延取得 (Step5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,7 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
             demo/graph/camera2d.cpp
             demo/graph/graph_generator.cpp
             demo/graph/layout_engine.cpp
+            demo/graph/snippet_cache.cpp
             demo/graph/vk_util.cpp
             demo/graph/spatial_grid.cpp
             demo/graph/graph_renderer.cpp

--- a/demo/graph/graph_view.cpp
+++ b/demo/graph/graph_view.cpp
@@ -5,6 +5,7 @@
 #include "pictor/surface/vulkan_context.h"
 
 #include <algorithm>
+#include <string>
 #include <utility>
 
 namespace pictor::graph {
@@ -17,6 +18,37 @@ inline void unpack_rgba(uint32_t rgba, float out[4]) {
     out[3] = static_cast<float>( rgba        & 0xFFu) / 255.0f;
 }
 constexpr float kEdgeThicknessPx = 1.5f;
+
+// Synthetic code snippet for a node (placeholder for clangd read_snippet).
+// Deterministic from the symbol name + kind. Shaped as a few short lines so it
+// reads like a definition inside the node card.
+std::string make_synthetic_snippet(const std::string& name, uint8_t kind) {
+    const char* ret = "void";
+    switch (static_cast<NodeKind>(kind)) {
+    case NodeKind::Function: ret = "int";    break;
+    case NodeKind::Method:   ret = "auto";   break;
+    case NodeKind::Variable: ret = "static"; break;
+    case NodeKind::Type:     ret = "struct"; break;
+    default:                 ret = "void";   break;
+    }
+    std::string s;
+    if (static_cast<NodeKind>(kind) == NodeKind::Type) {
+        s += "struct " + name + " {\n";
+        s += "  int   id;\n";
+        s += "  float value;\n";
+        s += "};";
+    } else if (static_cast<NodeKind>(kind) == NodeKind::Variable) {
+        s += "static " + name + " =\n";
+        s += "    compute();";
+    } else {
+        s += std::string(ret) + " " + name + "(int n) {\n";
+        s += "  if (n <= 0) return 0;\n";
+        s += "  return work(n) +\n";
+        s += "         " + name + "(n - 1);\n";
+        s += "}";
+    }
+    return s;
+}
 } // namespace
 
 bool GraphView::initialize(VulkanContext& vk_ctx, const char* shader_dir, GraphStore store) {
@@ -224,7 +256,7 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
                    edge_inst_.data(), last_vis_edges_);
 }
 
-void GraphView::draw_labels(BitmapTextRenderer& text) const {
+void GraphView::draw_labels(BitmapTextRenderer& text) {
     if (bounds_.extent.width == 0 || bounds_.extent.height == 0) return;
 
     const auto& n = store_.nodes();
@@ -236,29 +268,62 @@ void GraphView::draw_labels(BitmapTextRenderer& text) const {
     const float cx = camera_.center_x();
     const float cy = camera_.center_y();
 
-    constexpr float kLabelMinPx = 48.0f;  // LABEL LOD: hide when a node is smaller
-    constexpr int   kMaxLabels  = 350;    // keep within the text batch budget
-    int drawn = 0;
+    constexpr float kLabelMinPx   = 48.0f;   // >= this: show the symbol name
+    constexpr float kSnippetMinPx = 200.0f;  // >= this: show the code snippet card
+    int char_budget = 3600;                  // keep under BitmapTextRenderer's batch cap
 
-    // vis_nodes_ holds this frame's visible handles (from render()); labels track
-    // the animated positions so they follow the layout-in motion.
     for (uint32_t i : vis_nodes_) {
+        if (char_budget <= 0) break;
         const float w_px = n.w[i] * z;
-        if (w_px < kLabelMinPx) continue;          // too small to read
-        const std::string& s = n.label[i];
-        if (s.empty()) continue;
+        if (w_px < kLabelMinPx) continue;            // too small to read
+        const std::string& name = n.label[i];
+        if (name.empty()) continue;
 
-        const float sx = ox + (anim_x_[i] - cx) * z + ew * 0.5f;
-        const float sy = oy + (anim_y_[i] - cy) * z + eh * 0.5f;
-        if (sx < ox || sx > ox + ew || sy < oy || sy > oy + eh) continue; // outside leaf
+        // Node center -> screen (animated position).
+        const float scx = ox + (anim_x_[i] - cx) * z + ew * 0.5f;
+        const float scy = oy + (anim_y_[i] - cy) * z + eh * 0.5f;
+        if (scx < ox || scx > ox + ew || scy < oy || scy > oy + eh) continue;
 
-        const float scale = std::clamp(n.h[i] * z * 0.42f / 16.0f, 0.6f, 2.2f);
-        const float tw = static_cast<float>(s.size()) * 8.0f * scale;
-        const float th = 16.0f * scale;
-        text.set_scale(scale);
-        text.draw_text(sx - tw * 0.5f, sy - th * 0.5f, s.c_str(),
-                       0.92f, 0.95f, 1.0f, 1.0f);
-        if (++drawn >= kMaxLabels) break;
+        const float h_px = n.h[i] * z;
+
+        if (w_px < kSnippetMinPx) {
+            // ── LABEL LOD: centered symbol name ──
+            const float scale = std::clamp(h_px * 0.42f / 16.0f, 0.6f, 2.2f);
+            const float tw = static_cast<float>(name.size()) * 8.0f * scale;
+            const float th = 16.0f * scale;
+            text.set_scale(scale);
+            text.draw_text(scx - tw * 0.5f, scy - th * 0.5f, name.c_str(),
+                           0.92f, 0.95f, 1.0f, 1.0f);
+            char_budget -= static_cast<int>(name.size());
+        } else {
+            // ── NEAR LOD: lazily-fetched snippet card (LRU-cached) ──
+            const uint8_t kind = n.kind[i];
+            std::string snip = snippets_.get(i, [&]() {
+                return make_synthetic_snippet(name, kind);
+            });
+            const float scale = std::clamp(h_px / (7.0f * 16.0f * 1.25f), 0.7f, 1.6f);
+            const float line_h = 16.0f * scale * 1.25f;
+            const float left   = scx - w_px * 0.5f + 8.0f;
+            float       ty     = scy - h_px * 0.5f + 6.0f;
+            const float bottom = scy + h_px * 0.5f - 4.0f;
+
+            size_t start = 0;
+            while (start <= snip.size() && ty + line_h <= bottom && char_budget > 0) {
+                size_t nl = snip.find('\n', start);
+                const size_t end = (nl == std::string::npos) ? snip.size() : nl;
+                std::string line = snip.substr(start, end - start);
+                text.set_scale(scale);
+                // First line (signature) brighter, body dimmer.
+                if (start == 0)
+                    text.draw_text(left, ty, line.c_str(), 0.95f, 0.97f, 1.0f, 1.0f);
+                else
+                    text.draw_text(left, ty, line.c_str(), 0.62f, 0.78f, 0.66f, 1.0f);
+                char_budget -= static_cast<int>(line.size());
+                ty += line_h;
+                if (nl == std::string::npos) break;
+                start = nl + 1;
+            }
+        }
     }
 }
 

--- a/demo/graph/graph_view.h
+++ b/demo/graph/graph_view.h
@@ -14,6 +14,7 @@
 #include "graph_renderer.h"
 #include "graph_store.h"
 #include "layout_engine.h"
+#include "snippet_cache.h"
 #include "spatial_grid.h"
 
 namespace pictor {
@@ -47,10 +48,13 @@ public:
     /// layout-in animation and applies a finished worker layout.
     void render(VkCommandBuffer cmd, uint32_t flight);
 
-    /// Draw symbol labels for the nodes that are visible *and* large enough on
-    /// screen (LABEL LOD), using the shared text renderer. Call after render()
-    /// within the frame's text batch (begin/end). Bounded by the visible set.
-    void draw_labels(BitmapTextRenderer& text) const;
+    /// Draw text overlays for visible nodes via LOD: nothing when small, the
+    /// symbol name when mid-size (LABEL LOD), and a lazily-fetched code snippet
+    /// card when large (NEAR LOD, LRU-cached). Call after render() within the
+    /// frame's text batch (begin/end). Bounded by the visible set + a char budget.
+    void draw_labels(BitmapTextRenderer& text);
+
+    uint32_t snippet_cache_size() const { return static_cast<uint32_t>(snippets_.size()); }
 
     bool layout_pending() const { return !layout_applied_; }
     bool animating()      const { return animating_; }
@@ -93,6 +97,9 @@ private:
     uint32_t hovered_ = INVALID_NODE;
     float    fit_cx_ = 0.0f, fit_cy_ = 0.0f, fit_zoom_ = 1.0f;
     uint32_t last_vis_nodes_ = 0, last_vis_edges_ = 0;
+
+    // NEAR-LOD snippet cards: lazily fetched, LRU-bounded.
+    SnippetCache snippets_{256};
 };
 
 } // namespace graph

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -189,7 +189,7 @@ Args parse_args(int argc, char** argv) {
 
 int main(int argc, char** argv) {
     const Args args = parse_args(argc, argv);
-    printf("=== Pictor Iter Relation Graph Demo (Step 4: labels / text LOD) ===\n");
+    printf("=== Pictor Iter Relation Graph Demo (Step 5: snippet LOD + LRU) ===\n");
     printf("[init] Nodes: %u  frames: %llu  scatter: %s\n", args.nodes,
            static_cast<unsigned long long>(args.frames), args.scatter ? "yes" : "no");
 
@@ -198,7 +198,7 @@ int main(int argc, char** argv) {
     GlfwWindowConfig win_cfg;
     win_cfg.width  = 1280;
     win_cfg.height = 720;
-    win_cfg.title  = "Pictor — Iter Relation Graph (Step 4: labels / text LOD)";
+    win_cfg.title  = "Pictor — Iter Relation Graph (Step 5: snippet LOD + LRU)";
     win_cfg.vsync  = true;
     if (!surface_provider.create(win_cfg)) {
         fprintf(stderr, "[init] FATAL: window\n");
@@ -368,11 +368,12 @@ int main(int argc, char** argv) {
         auto now = std::chrono::steady_clock::now();
         double elapsed = std::chrono::duration<double>(now - fps_t0).count();
         if (elapsed >= 1.0) {
-            printf("[loop] FPS %.1f | visible %u/%u nodes, %u/%u edges | zoom %.3f | hover %d\n",
+            printf("[loop] FPS %.1f | visible %u/%u nodes, %u/%u edges | zoom %.3f | hover %d | snip$ %u\n",
                    fps_frames / elapsed,
                    graph.visible_nodes(), graph.total_nodes(),
                    graph.visible_edges(), graph.total_edges(),
-                   graph.zoom(), static_cast<int>(graph.hovered()));
+                   graph.zoom(), static_cast<int>(graph.hovered()),
+                   graph.snippet_cache_size());
             fps_t0 = now;
             fps_frames = 0;
         }

--- a/demo/graph/snippet_cache.cpp
+++ b/demo/graph/snippet_cache.cpp
@@ -1,0 +1,25 @@
+#include "snippet_cache.h"
+
+namespace pictor::graph {
+
+const std::string& SnippetCache::get(uint64_t key,
+                                     const std::function<std::string()>& miss) {
+    auto it = map_.find(key);
+    if (it != map_.end()) {
+        // Hit: promote to MRU.
+        lru_.splice(lru_.begin(), lru_, it->second);
+        return it->second->second;
+    }
+
+    // Miss: fetch, insert at MRU, evict LRU if over capacity.
+    lru_.emplace_front(key, miss());
+    map_[key] = lru_.begin();
+    if (map_.size() > capacity_) {
+        const Entry& victim = lru_.back();
+        map_.erase(victim.first);
+        lru_.pop_back();
+    }
+    return lru_.front().second;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/snippet_cache.h
+++ b/demo/graph/snippet_cache.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <list>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace pictor::graph {
+
+/// Bounded LRU cache of code snippets keyed by node id.
+///
+/// Models the NEAR-LOD snippet path: snippets are fetched lazily (only when a
+/// node is on screen and large enough) and a fixed number are kept resident —
+/// the rest are evicted, so memory stays bounded regardless of graph size. The
+/// miss callback stands in for the (later async) clangd `read_snippet`.
+class SnippetCache {
+public:
+    explicit SnippetCache(size_t capacity = 256) : capacity_(capacity ? capacity : 1) {}
+
+    /// Return the snippet for `key`, computing it via `miss` on a cache miss.
+    /// The reference is valid until the next get() call (callers consume it
+    /// immediately). A hit promotes the entry to most-recently-used.
+    const std::string& get(uint64_t key, const std::function<std::string()>& miss);
+
+    size_t size()     const { return map_.size(); }
+    size_t capacity() const { return capacity_; }
+
+private:
+    using Entry = std::pair<uint64_t, std::string>;
+
+    size_t capacity_;
+    std::list<Entry> lru_;   // front = most-recently-used
+    std::unordered_map<uint64_t, std::list<Entry>::iterator> map_;
+};
+
+} // namespace pictor::graph


### PR DESCRIPTION
Iter 関連グラフ native renderer の **Step 5**（React Flow パリティ到達点）。ノードを
十分ズームしたとき**内部にコード snippet を表示**。描画量を視界に比例させる方針どおり、
snippet は **「視界内 × NEAR-LOD」のノードだけ遅延取得**し **LRU で有界保持**。 (#89〜#92 の続き)

## 実装
- `snippet_cache.{h,cpp}` — **bounded LRU**（`list`+`unordered_map`, front=MRU）。`get(key, miss)` で
  ミス時のみ `miss()` 取得→挿入→容量超過で末尾退避。`miss` は将来の clangd `read_snippet` の
  **async 境界を模す**（現状は同期の合成生成）
- `graph_view` — `draw_labels` を **3 段 LOD** 化：小=なし / 中=シンボル名(LABEL) /
  **大(screen 幅 ≥ 200px)=snippet カード**。NEAR ノードのみ `snippets_.get` で取得し、ノード screen
  矩形内に複数行を clip 描画（1 行目=シグネチャ明、本体=暗）。`char_budget` でテキストバッチ上限を保護。
  合成 snippet は kind 別（fn / struct / static）
- `main` — FPS ログに snippet キャッシュ件数（`snip$`）追加、タイトル/ヘッダを Step5 表記に

## DoD / メモリ有界
snippet は NEAR でしか出ない＝件数が小さく、LRU(256) で resident 上限 → **グラフ規模に依らず
メモリ有界**。TextRun キャッシュ最適化は LOD で件数が抑えられるため代替済み。

## ビルド
```
cmake -S . -B build && cmake --build build --target pictor_graph_demo --config Debug
```
→ `demo/graph` は **warning 0**、exe 生成。実行確認は Pictor 規約によりユーザ側
（深くズームするとノード内にコードが出る／`snip$` がキャッシュ件数を表示）。

## 次段
Step 6 incremental expand + lerp（ノードクリックで子取得→append-only マージ→影響部のみ
再 layout）/ clangd 実データ結線（IDataChannel）→ Iter 実連携。

🤖 Generated with [Claude Code](https://claude.com/claude-code)