### PR TITLE
feat(graph-demo): Step6 incremental expand + lerp / IDataChannel / edge cull / dock desc (#397 #398 #400)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,8 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
             demo/graph/graph_view.cpp
             demo/graph/ui_rect_renderer.cpp
             demo/graph/dock_layout.cpp
+            demo/graph/synthetic_data_channel.cpp
+            demo/graph/clangd_data_channel.cpp
         )
         target_include_directories(pictor_graph_demo PRIVATE demo/graph)
         target_link_libraries(pictor_graph_demo PRIVATE pictor)

--- a/demo/graph/HANDOFF.md
+++ b/demo/graph/HANDOFF.md
@@ -41,7 +41,7 @@ per-frame の流れ (GraphView::render):
 
 描画は anim 位置 (レイアウト lerp 中)、cull/hit-test は target 位置 (grid)。
 
-## 3. 進捗 (すべて origin/main にマージ済み)
+## 3. 進捗
 
 | Step | 内容 | PR | commit |
 |---|---|---|---|
@@ -51,15 +51,21 @@ per-frame の流れ (GraphView::render):
 | 3 | Sugiyama layered layout (worker + lerp 整列) | #91 | 993b312 |
 | 4 | テキスト + LABEL LOD (BitmapTextRenderer 再利用) | #92 | 2a69d46 |
 | 5 | NEAR-LOD snippet カード + LRU 遅延取得 | #93 | 63479ff |
+| 6 | incremental expand + lerp / IDataChannel / edge cull / dock desc / click-jump 抑制 | #397/#398/#400 | feat/pictor-397-400 |
 
-LOD 描画パイプライン（点 → 名前 → コード）は完成。
+LOD 描画パイプライン（点 → 名前 → コード）は完成。Step 6 で **クリック展開**
+(IDataChannel 経由で子取得→`id_to_index` で append-only マージ→親位置から lerp、
+GPU バッファ動的再確保) と既知課題 (edge cull / dock descriptor / click-jump) を解消。
 
 ## 4. ファイルマップ (`demo/graph/`)
 
 | ファイル | 役割 |
 |---|---|
 | `main.cpp` | window/loop/入力、dock 解決→graph leaf 配置、text バッチ |
-| `graph_store.{h,cpp}` | SoA ストア (append-only)、`set_positions`、`label` |
+| `graph_store.{h,cpp}` | SoA ストア (append-only)、`set_positions`、`label`、`id`/`find`/`id_of` (expand dedup) |
+| `data_channel.h` | `IDataChannel` + `{nodes,edges}` 契約 (GraphData/Node/Edge desc)。データ源境界 |
+| `synthetic_data_channel.{h,cpp}` | 決定的合成 `IDataChannel` (initial + request_children) |
+| `clangd_data_channel.{h,cpp}` | clangd callHierarchy 契約ミラー + `{nodes,edges}` 変換 + 注入 fetch 境界 (Iter IPC) |
 | `graph_generator.{h,cpp}` | 決定的合成グラフ + シンボル名。`--scatter` で初期散布 |
 | `spatial_grid.{h,cpp}` | CSR 一様グリッド (cull / pick) |
 | `camera2d.{h,cpp}` | pan/zoom カメラ、world↔screen 行列 |
@@ -88,20 +94,35 @@ FPS 行に `visible u/total`・`zoom`・`hover`・`snip$`(キャッシュ件数)
 
 ## 6. 残作業 (Memoria タスク登録済み)
 
-- **Step 6: incremental expand + lerp** — ノードクリックで子取得→`id_to_index` で
-  append-only マージ→影響部のみ再 layout→lerp。`DynamicInstanceBuffers` は容量=総数固定
-  なので、expand で総数が増える場合のバッファ再確保が必要。
-- **clangd 実データ結線 + Iter 実連携** — 合成ジェネレータを実データへ。clangd
-  callHierarchy の `{nodes,edges}` 契約と `request_children` の IPC/FFI 境界 (IDataChannel)。
-  Iter の OS 子窓の1つを Pictor native surface 化し、Monaco/ControlPanel は Web のまま合成。
-- **実行時検証 (確認作業)** — exe を起動し cull(visible/total)・splitter・タブ・hover・
-  layout 整列・LABEL/snippet を目視確認 (Pictor no-run のため未実施)。
-- **既知課題** —
-  - エッジ cull の取りこぼし: 両端点が画面外で線分だけ視界を横切るエッジは未描画
-    (frame-stamp が端点可視判定)。必要なら線分×view AABB 交差判定を追加。
-  - dock の floating / closable / ドラッグ再ドック / 新規分割生成が未実装 (resize+タブ切替のみ)。
-  - ノード click→選択 / ソースジャンプ未配線 (hover highlight のみ)。
-  - Tier A 宣言的レンダラ (corpus-renderer-native 本体) は未着手 (概念のみ)。
+### 解決済み (Step 6 / feat/pictor-397-400)
+
+- **#397 incremental expand + lerp** — ノードクリック (press+release without drag) で
+  `IDataChannel::request_children`→`GraphStore::find` (`id_to_index`) で append-only
+  マージ→新ノードは親の anim 位置から fan-out 目標へ lerp。総数増加時は
+  `GraphRenderer::ensure_capacity`→`DynamicInstanceBuffers::ensure_capacity` で per-flight
+  バッファを device idle 後に再確保 (descriptor set はそのまま rebind、pool 枯渇なし)。
+- **#398 IDataChannel + clangd 契約** — `data_channel.h` に `{nodes,edges}` 契約と
+  `IDataChannel`。`SyntheticDataChannel` (合成) と `ClangdDataChannel` (clangd
+  callHierarchy ミラー→GraphData 変換、`std::function` fetch が Rust(Iter)↔C++(Pictor)
+  IPC 境界)。Pictor は Tauri/serde 非依存のまま。**実 IPC 配線 (Iter Rust 側の
+  `graph_request_children` コマンド + fetch 注入) は未着手** — Pictor 側の型と境界は確定。
+- **#400 edge cull** — `segment_intersects_rect` (Liang-Barsky) を追加。両端点 off-screen
+  でも線分が view を横切るエッジを描画。
+- **#400 dock_layout** — `DockDesc` (Corpus `DockLayoutNode` ミラー: leaf/split/tabs) +
+  `DockLayout::set_layout` で宣言的ツリーから構築。`set_default` も set_layout 経由に。
+- **#400 click-jump 抑制** — ノードクリックで `select`+`expand_node` するが camera は
+  一切動かさない (fit/reset 呼ばない)。drag (slop 超え) は pan のみで選択しない。
+
+### 未着手
+
+- **clangd 実 IPC 配線** — Iter Rust に `graph_request_children` を追加し、
+  `ClangdDataChannel` の fetch にバインド。Iter の OS 子窓を Pictor native surface 化し
+  Monaco/ControlPanel は Web のまま合成。
+- **実行時検証 (確認作業)** — exe 起動し expand lerp / edge cull / dock / hover / layout を
+  目視確認 (Pictor no-run のため未実施)。
+- **dock**: floating / closable / ドラッグ再ドック / 新規分割生成 (現状 resize+タブ+宣言構築)。
+- **ノード source ジャンプ** 未配線 (select highlight + expand のみ)。
+- **Tier A 宣言的レンダラ** (corpus-renderer-native 本体) は未着手 (概念のみ)。
 
 ## 7. 設計判断 / 落とし穴
 

--- a/demo/graph/clangd_data_channel.cpp
+++ b/demo/graph/clangd_data_channel.cpp
@@ -1,0 +1,81 @@
+#include "clangd_data_channel.h"
+
+namespace pictor::graph {
+
+namespace {
+
+// FNV-1a over the symbol's identifying triple; cheap and stable across runs.
+uint64_t fnv1a(const std::string& s, uint64_t h) {
+    for (const char c : s) {
+        h ^= static_cast<uint8_t>(c);
+        h *= 0x100000001B3ull;
+    }
+    return h;
+}
+
+uint64_t id_for(const ClangdItem& item) {
+    return clangd_node_id(item.uri, item.selectionRange.start.line, item.name);
+}
+
+} // namespace
+
+uint64_t clangd_node_id(const std::string& uri, int line, const std::string& name) {
+    uint64_t h = 0xCBF29CE484222325ull;
+    h = fnv1a(uri, h);
+    h ^= static_cast<uint64_t>(static_cast<uint32_t>(line));
+    h *= 0x100000001B3ull;
+    h = fnv1a(name, h);
+    return h;
+}
+
+NodeKind clangd_kind_to_node_kind(int symbol_kind) {
+    switch (symbol_kind) {
+    case 12: return NodeKind::Function;            // Function
+    case 6:  return NodeKind::Method;              // Method
+    case 9:  return NodeKind::Method;              // Constructor
+    case 8:  return NodeKind::Variable;            // Field
+    case 13: return NodeKind::Variable;            // Variable
+    case 5:  return NodeKind::Type;                // Class
+    case 23: return NodeKind::Type;                // Struct
+    case 10: return NodeKind::Type;                // Enum
+    case 11: return NodeKind::Type;                // Interface
+    default: return NodeKind::Other;
+    }
+}
+
+GraphData clangd_relation_to_graph_data(const ClangdRelation& rel) {
+    GraphData out;
+
+    const uint64_t origin_id = id_for(rel.origin);
+    out.nodes.push_back({origin_id, rel.origin.name,
+                         clangd_kind_to_node_kind(rel.origin.kind)});
+
+    for (const auto& c : rel.incoming) {
+        const uint64_t id = id_for(c.from);
+        out.nodes.push_back({id, c.from.name, clangd_kind_to_node_kind(c.from.kind)});
+        out.edges.push_back({id, origin_id, EdgeKind::Call});       // caller -> origin
+    }
+    for (const auto& c : rel.outgoing) {
+        const uint64_t id = id_for(c.to);
+        out.nodes.push_back({id, c.to.name, clangd_kind_to_node_kind(c.to.kind)});
+        out.edges.push_back({origin_id, id, EdgeKind::Call});       // origin -> callee
+    }
+    for (const auto& r : rel.references) {
+        const uint64_t id = clangd_node_id(r.uri, r.range.start.line, r.uri);
+        out.nodes.push_back({id, std::string{}, NodeKind::Other});
+        out.edges.push_back({origin_id, id, EdgeKind::Reference});  // origin -> ref
+    }
+    return out;
+}
+
+GraphData ClangdDataChannel::initial() {
+    if (!fetch_) return {};
+    return clangd_relation_to_graph_data(fetch_(root_id_));
+}
+
+GraphData ClangdDataChannel::request_children(uint64_t node_id) {
+    if (!fetch_) return {};
+    return clangd_relation_to_graph_data(fetch_(node_id));
+}
+
+} // namespace pictor::graph

--- a/demo/graph/clangd_data_channel.h
+++ b/demo/graph/clangd_data_channel.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "data_channel.h"
+
+namespace pictor::graph {
+
+/// ── clangd call-hierarchy contract (mirrors Iter's `lsp.ts`) ──
+/// These structs are the on-the-wire shape Iter already produces from clangd's
+/// `callHierarchy/{incomingCalls,outgoingCalls}` + `textDocument/references`.
+/// They are plain data so the host can fill them from JSON without Pictor ever
+/// depending on Tauri / serde.
+
+struct ClangdPosition { int line = 0; int character = 0; };
+struct ClangdRange    { ClangdPosition start; ClangdPosition end; };
+
+struct ClangdItem {
+    std::string name;
+    int         kind = 0;     // LSP SymbolKind
+    std::string detail;
+    std::string uri;          // file:// URI
+    ClangdRange range;
+    ClangdRange selectionRange;
+};
+
+struct ClangdIncomingCall { ClangdItem from; };  // caller -> origin
+struct ClangdOutgoingCall { ClangdItem to;   };  // origin -> callee
+struct ClangdReference    { std::string uri; ClangdRange range; };
+
+/// One node's neighbourhood as returned by a single fetch.
+struct ClangdRelation {
+    ClangdItem                     origin;
+    std::vector<ClangdIncomingCall> incoming;
+    std::vector<ClangdOutgoingCall> outgoing;
+    std::vector<ClangdReference>    references;
+};
+
+/// Stable node id from a symbol location (uri + definition line + name). Equal
+/// symbols across fetches hash equal, so duplicate callers/callees collapse.
+uint64_t clangd_node_id(const std::string& uri, int line, const std::string& name);
+
+/// LSP SymbolKind -> graph NodeKind (color / synthetic-snippet shape).
+NodeKind clangd_kind_to_node_kind(int symbol_kind);
+
+/// Pure mapping of one clangd neighbourhood to the `{nodes, edges}` contract.
+/// Edge direction follows call semantics: caller -> origin, origin -> callee,
+/// origin -> reference.
+GraphData clangd_relation_to_graph_data(const ClangdRelation& rel);
+
+/// IDataChannel backed by clangd over an injected fetch. The fetch is the
+/// Rust(Iter) <-> C++(Pictor) IPC boundary: given a node id it returns that
+/// node's clangd neighbourhood (the host implements it by invoking the Tauri
+/// command and parsing the JSON envelope). Pictor never sees the transport.
+class ClangdDataChannel : public IDataChannel {
+public:
+    using Fetch = std::function<ClangdRelation(uint64_t node_id)>;
+
+    ClangdDataChannel(uint64_t root_id, Fetch fetch)
+        : root_id_(root_id), fetch_(std::move(fetch)) {}
+
+    GraphData initial() override;
+    GraphData request_children(uint64_t node_id) override;
+
+private:
+    uint64_t root_id_;
+    Fetch    fetch_;
+};
+
+} // namespace pictor::graph

--- a/demo/graph/data_channel.h
+++ b/demo/graph/data_channel.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "graph_store.h"
+
+namespace pictor::graph {
+
+/// One node in the relation-graph contract. `id` is the stable identity used to
+/// dedup across fetches (a clangd symbol's USR/location hash on the real path).
+struct GraphNodeDesc {
+    uint64_t    id;
+    std::string name;
+    NodeKind    kind = NodeKind::Other;
+};
+
+/// One directed relation. Endpoints reference node ids (not handles) so the
+/// payload is position- and order-independent across the IPC boundary.
+struct GraphEdgeDesc {
+    uint64_t from_id;
+    uint64_t to_id;
+    EdgeKind kind = EdgeKind::Call;
+};
+
+/// The `{nodes, edges}` contract exchanged with the data source. Equivalent to
+/// Iter's React-Flow `{ nodes, edges }`, but flattened to plain ids so both the
+/// synthetic generator and the clangd bridge speak the same shape.
+struct GraphData {
+    std::vector<GraphNodeDesc> nodes;
+    std::vector<GraphEdgeDesc> edges;
+};
+
+/// Source of relation-graph data for the Tier B widget. Decouples the view from
+/// where the contract is produced: a deterministic generator today, the clangd
+/// call-hierarchy bridge (Iter, over IPC) tomorrow. Keeping this an interface is
+/// the Rust(Iter) <-> C++(Pictor) boundary — only the `{nodes, edges}` payload
+/// crosses it, never Vulkan or Tauri types (Pictor stays the lowest layer).
+class IDataChannel {
+public:
+    virtual ~IDataChannel() = default;
+
+    /// Roots plus their first level — the graph shown before any expand.
+    virtual GraphData initial() = 0;
+
+    /// Callees / callers / references of one node, addressed by its stable id.
+    /// Returned nodes already present (by id) are reused by the caller; only the
+    /// genuinely new ones are appended (incremental expand).
+    virtual GraphData request_children(uint64_t node_id) = 0;
+};
+
+} // namespace pictor::graph

--- a/demo/graph/dock_layout.cpp
+++ b/demo/graph/dock_layout.cpp
@@ -13,36 +13,38 @@ int DockLayout::add_node(const Node& n) {
     return static_cast<int>(nodes_.size()) - 1;
 }
 
+int DockLayout::build_desc(const DockDesc& desc) {
+    switch (desc.kind) {
+    case DockDesc::Kind::Leaf: {
+        Node n; n.kind = Kind::Leaf; n.panel_id = desc.panel;
+        return add_node(n);
+    }
+    case DockDesc::Kind::Tabs: {
+        Node n; n.kind = Kind::Tabs; n.tab_panels = desc.tabs; n.active = desc.active;
+        return add_node(n);
+    }
+    case DockDesc::Kind::Split: {
+        const int a = desc.first  ? build_desc(*desc.first)  : -1;
+        const int b = desc.second ? build_desc(*desc.second) : -1;
+        Node n; n.kind = Kind::Split; n.orient = desc.orient; n.ratio = desc.ratio;
+        n.first = a; n.second = b;
+        return add_node(n);
+    }
+    }
+    return -1;
+}
+
+void DockLayout::set_layout(const DockDesc& root) {
+    nodes_.clear();
+    root_ = build_desc(root);
+}
+
 void DockLayout::set_default(int graph_panel, const std::vector<int>& tab_panels,
                              float split_ratio) {
-    nodes_.clear();
-
-    Node leaf;
-    leaf.kind = Kind::Leaf;
-    leaf.panel_id = graph_panel;
-    const int left = add_node(leaf);
-
-    int right;
-    if (tab_panels.empty()) {
-        Node empty;
-        empty.kind = Kind::Leaf;
-        empty.panel_id = graph_panel;
-        right = add_node(empty);
-    } else {
-        Node tabs;
-        tabs.kind = Kind::Tabs;
-        tabs.tab_panels = tab_panels;
-        tabs.active = 0;
-        right = add_node(tabs);
-    }
-
-    Node split;
-    split.kind = Kind::Split;
-    split.orient = DockOrient::Horizontal;
-    split.ratio = split_ratio;
-    split.first = left;
-    split.second = right;
-    root_ = add_node(split);
+    const DockDesc right = tab_panels.empty() ? DockDesc::leaf(graph_panel)
+                                              : DockDesc::tabset(tab_panels, 0);
+    set_layout(DockDesc::split(DockOrient::Horizontal, split_ratio,
+                               DockDesc::leaf(graph_panel), right));
 }
 
 // ─── Solve ───────────────────────────────────────────────────

--- a/demo/graph/dock_layout.h
+++ b/demo/graph/dock_layout.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace pictor::graph {
@@ -15,6 +16,38 @@ struct DockRect {
 
 enum class DockOrient : uint8_t { Horizontal, Vertical }; // H = side-by-side, V = stacked
 
+/// Declarative layout node — the C++ mirror of Corpus's `DockLayoutNode`
+/// (leaf / split / tabs) from its DockComponent descriptor. Lets the same
+/// declarative tree that drives the web dock construct the native one, so the
+/// "descriptor is the contract" boundary holds across Web (Tier A) and native
+/// (Tier B). `ratio` is the first child's share (Corpus DockSplitNode.ratio).
+struct DockDesc {
+    enum class Kind : uint8_t { Leaf, Split, Tabs };
+
+    Kind       kind   = Kind::Leaf;
+    int        panel  = 0;                          // Leaf: panel id
+    DockOrient orient = DockOrient::Horizontal;     // Split
+    float      ratio  = 0.5f;                        // Split: first-side share
+    std::shared_ptr<DockDesc> first, second;        // Split children
+    std::vector<int> tabs;                            // Tabs: panel ids
+    int        active = 0;                            // Tabs: active index
+
+    static DockDesc leaf(int panel_id) {
+        DockDesc d; d.kind = Kind::Leaf; d.panel = panel_id; return d;
+    }
+    static DockDesc split(DockOrient orient, float ratio,
+                          const DockDesc& a, const DockDesc& b) {
+        DockDesc d; d.kind = Kind::Split; d.orient = orient; d.ratio = ratio;
+        d.first  = std::make_shared<DockDesc>(a);
+        d.second = std::make_shared<DockDesc>(b);
+        return d;
+    }
+    static DockDesc tabset(const std::vector<int>& panel_ids, int active_index = 0) {
+        DockDesc d; d.kind = Kind::Tabs; d.tabs = panel_ids; d.active = active_index;
+        return d;
+    }
+};
+
 /// Native dock layouter: a split / tabs / leaf tree that arranges panels, with
 /// draggable splitters, clickable tab headers and text persistence. Mirrors the
 /// semantics of Corpus's DockComponent (DockLayoutNode: leaf / split / tabs).
@@ -25,8 +58,11 @@ public:
     struct SolvedSplitter{ int   node;     DockOrient orient; DockRect handle; DockRect area; };
     struct SolvedTab     { int   node;     int panel_id; DockRect rect; bool active; };
 
+    /// Build the layout from a Corpus-shaped declarative descriptor tree.
+    void set_layout(const DockDesc& root);
+
     /// Build the default layout: `graph` leaf on the left, a tabs container with
-    /// `tab_panels` on the right.
+    /// `tab_panels` on the right. Thin wrapper over set_layout().
     void set_default(int graph_panel, const std::vector<int>& tab_panels, float split_ratio = 0.72f);
 
     bool load(const char* path);
@@ -64,6 +100,7 @@ private:
     };
 
     int  add_node(const Node& n);
+    int  build_desc(const DockDesc& desc);   // recursively materialize a DockDesc tree
     void solve_node(int idx, DockRect rect);
 
     std::vector<Node> nodes_;

--- a/demo/graph/graph_renderer.cpp
+++ b/demo/graph/graph_renderer.cpp
@@ -112,6 +112,13 @@ void GraphRenderer::shutdown() {
     initialized_     = false;
 }
 
+void GraphRenderer::ensure_capacity(uint32_t node_count, uint32_t edge_count) {
+    if (!initialized_) return;
+    vkDeviceWaitIdle(device_);
+    node_buf_.ensure_capacity(VkDeviceSize(node_count) * sizeof(NodeInstance));
+    edge_buf_.ensure_capacity(VkDeviceSize(edge_count) * sizeof(EdgeInstance));
+}
+
 void GraphRenderer::draw(VkCommandBuffer cmd, VkRect2D region, const GraphPushConstants& pc,
                          uint32_t flight,
                          const NodeInstance* nodes, uint32_t node_count,

--- a/demo/graph/graph_renderer.h
+++ b/demo/graph/graph_renderer.h
@@ -48,6 +48,11 @@ public:
               const NodeInstance* nodes, uint32_t node_count,
               const EdgeInstance* edges, uint32_t edge_count);
 
+    /// Grow the per-flight instance buffers to hold up to `node_count` nodes and
+    /// `edge_count` edges. Called by incremental expand when the total grows past
+    /// the initial capacity; waits for the device to idle before reallocating.
+    void ensure_capacity(uint32_t node_count, uint32_t edge_count);
+
     bool is_initialized() const { return initialized_; }
 
 private:

--- a/demo/graph/graph_store.cpp
+++ b/demo/graph/graph_store.cpp
@@ -13,6 +13,8 @@ void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
     nodes_.kind.reserve(node_capacity);
     nodes_.flags.reserve(node_capacity);
     nodes_.label.reserve(node_capacity);
+    nodes_.id.reserve(node_capacity);
+    id_to_index_.reserve(node_capacity);
 
     edges_.from.reserve(edge_capacity);
     edges_.to.reserve(edge_capacity);
@@ -20,8 +22,10 @@ void GraphStore::reserve(size_t node_capacity, size_t edge_capacity) {
 }
 
 NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
-                                uint32_t rgba, NodeKind kind, std::string label) {
+                                uint32_t rgba, NodeKind kind, std::string label,
+                                uint64_t node_id) {
     const NodeHandle handle = static_cast<NodeHandle>(nodes_.cx.size());
+    if (node_id == AUTO_NODE_ID) node_id = handle;
     nodes_.cx.push_back(cx);
     nodes_.cy.push_back(cy);
     nodes_.w.push_back(w);
@@ -30,7 +34,14 @@ NodeHandle GraphStore::add_node(float cx, float cy, float w, float h,
     nodes_.kind.push_back(static_cast<uint8_t>(kind));
     nodes_.flags.push_back(0);
     nodes_.label.push_back(std::move(label));
+    nodes_.id.push_back(node_id);
+    id_to_index_.emplace(node_id, handle);
     return handle;
+}
+
+NodeHandle GraphStore::find(uint64_t node_id) const {
+    const auto it = id_to_index_.find(node_id);
+    return (it == id_to_index_.end()) ? INVALID_NODE : it->second;
 }
 
 void GraphStore::set_positions(const std::vector<float>& xs, const std::vector<float>& ys) {

--- a/demo/graph/graph_store.h
+++ b/demo/graph/graph_store.h
@@ -2,12 +2,18 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace pictor::graph {
 
 using NodeHandle = uint32_t;
 constexpr NodeHandle INVALID_NODE = 0xFFFFFFFFu;
+
+/// Sentinel passed to add_node to request an auto-assigned stable id (== handle).
+/// A caller wiring real data (clangd symbols, Step 6 expand) passes its own id so
+/// duplicate children collapse onto the existing node via id_to_index().
+constexpr uint64_t AUTO_NODE_ID = 0xFFFFFFFFFFFFFFFFull;
 
 /// Semantic kind of a graph node (drives default color). Mirrors the
 /// caller/callee/reference vocabulary Iter surfaces from clangd.
@@ -45,6 +51,7 @@ public:
         std::vector<uint8_t>  kind;     // NodeKind
         std::vector<uint8_t>  flags;    // selected/hovered/... (Step 1: unused)
         std::vector<std::string> label; // symbol name (cold; only NEAR-LOD labels read it)
+        std::vector<uint64_t> id;       // stable external id (cold; expand/dedup only)
     };
 
     struct Edges {
@@ -56,8 +63,16 @@ public:
     void reserve(size_t node_capacity, size_t edge_capacity);
 
     NodeHandle add_node(float cx, float cy, float w, float h,
-                        uint32_t rgba, NodeKind kind, std::string label = {});
+                        uint32_t rgba, NodeKind kind, std::string label = {},
+                        uint64_t node_id = AUTO_NODE_ID);
     void       add_edge(NodeHandle from, NodeHandle to, EdgeKind kind = EdgeKind::Call);
+
+    /// Handle previously registered for `node_id`, or INVALID_NODE if unseen.
+    /// Lets incremental expand collapse duplicate children onto existing nodes.
+    NodeHandle find(uint64_t node_id) const;
+
+    /// Stable external id of a node (the value passed to add_node).
+    uint64_t   id_of(NodeHandle handle) const { return nodes_.id[handle]; }
 
     /// Overwrite all node centers (e.g. with a freshly computed layout). Sizes
     /// must match node_count(); mismatched input is ignored.
@@ -71,6 +86,7 @@ public:
 private:
     Nodes nodes_;
     Edges edges_;
+    std::unordered_map<uint64_t, NodeHandle> id_to_index_;  // cold; build/expand only
 };
 
 } // namespace pictor::graph

--- a/demo/graph/graph_view.cpp
+++ b/demo/graph/graph_view.cpp
@@ -19,6 +19,45 @@ inline void unpack_rgba(uint32_t rgba, float out[4]) {
 }
 constexpr float kEdgeThicknessPx = 1.5f;
 
+// True if segment a-b meets the axis-aligned view rect. Catches edges whose
+// endpoints are both off-screen but whose line crosses the viewport (the
+// frame-stamp endpoint test alone misses these). Liang-Barsky parametric clip.
+bool segment_intersects_rect(float ax, float ay, float bx, float by,
+                             float min_x, float min_y, float max_x, float max_y) {
+    if (ax >= min_x && ax <= max_x && ay >= min_y && ay <= max_y) return true;
+    if (bx >= min_x && bx <= max_x && by >= min_y && by <= max_y) return true;
+    const float dx = bx - ax;
+    const float dy = by - ay;
+    float t0 = 0.0f, t1 = 1.0f;
+    const float p[4] = {-dx, dx, -dy, dy};
+    const float q[4] = {ax - min_x, max_x - ax, ay - min_y, max_y - ay};
+    for (int i = 0; i < 4; ++i) {
+        if (p[i] == 0.0f) {
+            if (q[i] < 0.0f) return false;   // parallel and outside this edge
+        } else {
+            const float r = q[i] / p[i];
+            if (p[i] < 0.0f) { if (r > t1) return false; if (r > t0) t0 = r; }
+            else             { if (r < t0) return false; if (r < t1) t1 = r; }
+        }
+    }
+    return t0 <= t1;
+}
+
+// Box size of expand-spawned child nodes (matches the generator's nodes).
+constexpr float kChildW = 120.0f;
+constexpr float kChildH = 44.0f;
+
+// Palette indexed by NodeKind (matches graph_generator's colors).
+uint32_t kind_color(NodeKind kind) {
+    switch (kind) {
+    case NodeKind::Function: return 0x4FA3FFFFu; // blue
+    case NodeKind::Method:   return 0x6BD389FFu; // green
+    case NodeKind::Variable: return 0xE0B04AFFu; // amber
+    case NodeKind::Type:     return 0xC080F0FFu; // violet
+    default:                 return 0x9AA0A6FFu; // grey
+    }
+}
+
 // Synthetic code snippet for a node (placeholder for clangd read_snippet).
 // Deterministic from the symbol name + kind. Shaped as a few short lines so it
 // reads like a definition inside the node card.
@@ -164,6 +203,59 @@ void GraphView::reset_view() {
     fit_to_bounds();
 }
 
+NodeHandle GraphView::pick(float win_x, float win_y) const {
+    float wx, wy;
+    to_world(win_x, win_y, wx, wy);
+    return grid_.pick(wx, wy);
+}
+
+void GraphView::expand_node(NodeHandle h) {
+    if (h == INVALID_NODE || h >= store_.node_count()) return;
+    if (!layout_applied_ || channel_ == nullptr) return;   // wait for the settle / source
+    const uint64_t parent_id = store_.id_of(h);
+    if (!expanded_.insert(parent_id).second) return;       // expand each node once
+
+    const GraphData kids = channel_->request_children(parent_id);
+    if (kids.nodes.empty() && kids.edges.empty()) return;
+
+    // Spawn point = the parent's current animated position, so children appear to
+    // grow out of it; their target is a fan one layer below the parent.
+    const float px  = store_.nodes().cx[h];
+    const float py  = store_.nodes().cy[h];
+    const float apx = anim_x_[h];
+    const float apy = anim_y_[h];
+
+    std::vector<const GraphNodeDesc*> fresh;
+    fresh.reserve(kids.nodes.size());
+    for (const auto& nd : kids.nodes)
+        if (store_.find(nd.id) == INVALID_NODE) fresh.push_back(&nd);
+
+    const LayoutParams lp;
+    const float layer_y = py + lp.layer_gap;
+    const float half    = (fresh.size() > 0) ? (static_cast<float>(fresh.size()) - 1.0f) * 0.5f : 0.0f;
+    for (size_t i = 0; i < fresh.size(); ++i) {
+        const float tx = px + (static_cast<float>(i) - half) * lp.node_gap;
+        store_.add_node(tx, layer_y, kChildW, kChildH, kind_color(fresh[i]->kind),
+                        fresh[i]->kind, fresh[i]->name, fresh[i]->id);
+        anim_x_.push_back(apx);
+        anim_y_.push_back(apy);
+    }
+
+    for (const auto& ed : kids.edges) {
+        const NodeHandle f = store_.find(ed.from_id);
+        const NodeHandle t = store_.find(ed.to_id);
+        if (f != INVALID_NODE && t != INVALID_NODE) store_.add_edge(f, t, ed.kind);
+    }
+
+    // Re-index and grow GPU capacity for the new totals. Camera is left as-is so
+    // the click never jumps the view.
+    grid_.build(store_);
+    vis_stamp_.assign(store_.node_count(), 0);
+    renderer_.ensure_capacity(static_cast<uint32_t>(store_.node_count()),
+                              static_cast<uint32_t>(store_.edge_count()));
+    if (!fresh.empty()) animating_ = true;
+}
+
 void GraphView::fit_to_bounds() {
     const auto& n = store_.nodes();
     float min_x = 0, max_x = 0, min_y = 0, max_y = 0;
@@ -219,7 +311,10 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
         d.rect[1] = anim_y_[i];
         d.rect[2] = n.w[i];
         d.rect[3] = n.h[i];
-        if (i == hovered_) {
+        if (i == selected_) {
+            // Selected (last clicked) node: strong orange accent.
+            d.color[0] = 1.0f; d.color[1] = 0.55f; d.color[2] = 0.18f; d.color[3] = 1.0f;
+        } else if (i == hovered_) {
             // Highlight the hovered node with a bright accent.
             d.color[0] = 1.0f; d.color[1] = 0.85f; d.color[2] = 0.30f; d.color[3] = 1.0f;
         } else {
@@ -228,13 +323,17 @@ void GraphView::render(VkCommandBuffer cmd, uint32_t flight) {
         node_inst_.push_back(d);
     }
 
-    // Edges visible if either endpoint is visible this frame.
+    // Edges visible if either endpoint is visible this frame, or — for long edges
+    // whose endpoints are both off-screen — if the segment itself crosses the view.
     const auto& e = store_.edges();
     edge_inst_.clear();
     for (size_t k = 0; k < store_.edge_count(); ++k) {
         const uint32_t a = e.from[k];
         const uint32_t b = e.to[k];
-        if (vis_stamp_[a] != frame_ && vis_stamp_[b] != frame_) continue;
+        if (vis_stamp_[a] != frame_ && vis_stamp_[b] != frame_ &&
+            !segment_intersects_rect(anim_x_[a], anim_y_[a], anim_x_[b], anim_y_[b],
+                                     min_x, min_y, max_x, max_y))
+            continue;
         EdgeInstance d;
         d.ends[0] = anim_x_[a]; d.ends[1] = anim_y_[a];
         d.ends[2] = anim_x_[b]; d.ends[3] = anim_y_[b];

--- a/demo/graph/graph_view.h
+++ b/demo/graph/graph_view.h
@@ -6,10 +6,12 @@
 #include <atomic>
 #include <cstdint>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "pictor/profiler/bitmap_text_renderer.h"
 #include "camera2d.h"
+#include "data_channel.h"
 #include "graph_instances.h"
 #include "graph_renderer.h"
 #include "graph_store.h"
@@ -32,6 +34,9 @@ public:
     bool initialize(VulkanContext& vk_ctx, const char* shader_dir, GraphStore store);
     void shutdown();
 
+    /// Source of children for incremental expand. Not owned; outlives the view.
+    void set_data_channel(IDataChannel* channel) { channel_ = channel; }
+
     /// Assign the screen rect this widget occupies (window pixels).
     void set_bounds(VkRect2D bounds) { bounds_ = bounds; }
     VkRect2D bounds() const { return bounds_; }
@@ -43,6 +48,20 @@ public:
     void update_hover(float win_x, float win_y);
     void clear_hover() { hovered_ = INVALID_NODE; }
     void reset_view();
+
+    /// Node under a window-space point, or INVALID_NODE. Used to turn a click
+    /// (press+release without drag) into a selection / expand.
+    NodeHandle pick(float win_x, float win_y) const;
+
+    /// Mark a node selected (highlight only — deliberately does NOT move the
+    /// camera, so clicking a node never jumps the view).
+    void select(NodeHandle handle) { selected_ = handle; }
+
+    /// Fetch a node's children from the data channel and merge them append-only:
+    /// existing ids are reused, new ones spawn from the parent and lerp out to a
+    /// fan below it. The camera is left untouched. No-op until the initial layout
+    /// has settled, when there is no channel, or when the node was expanded.
+    void expand_node(NodeHandle handle);
 
     /// Cull + upload + draw, clipped to the widget's bounds. Also advances the
     /// layout-in animation and applies a finished worker layout.
@@ -95,8 +114,13 @@ private:
     uint32_t                  frame_ = 0;
 
     uint32_t hovered_ = INVALID_NODE;
+    uint32_t selected_ = INVALID_NODE;
     float    fit_cx_ = 0.0f, fit_cy_ = 0.0f, fit_zoom_ = 1.0f;
     uint32_t last_vis_nodes_ = 0, last_vis_edges_ = 0;
+
+    // ── Incremental expand (Step 6) ──
+    IDataChannel*               channel_ = nullptr;  // not owned
+    std::unordered_set<uint64_t> expanded_;          // node ids already expanded
 
     // NEAR-LOD snippet cards: lazily fetched, LRU-bounded.
     SnippetCache snippets_{256};

--- a/demo/graph/main.cpp
+++ b/demo/graph/main.cpp
@@ -28,6 +28,7 @@
 #include "graph_instances.h"
 #include "graph_store.h"
 #include "graph_view.h"
+#include "synthetic_data_channel.h"
 #include "ui_rect_renderer.h"
 
 #include <GLFW/glfw3.h>
@@ -58,9 +59,15 @@ struct AppState {
     double last_x = 0.0, last_y = 0.0;
     double cursor_x = 0.0, cursor_y = 0.0;
 
+    // Click vs drag discrimination for node select / expand.
+    double     press_x = 0.0, press_y = 0.0;
+    NodeHandle press_node = INVALID_NODE;
+
     bool   save_request  = false;
     bool   reset_request = false;
 };
+
+constexpr float kClickSlopPx = 4.0f;  // movement under this = click, not pan
 
 AppState g_state;
 
@@ -121,8 +128,22 @@ void mouse_button_callback(GLFWwindow* win, int button, int action, int) {
             g_state.graph_panning = true;
             g_state.last_x = x;
             g_state.last_y = y;
+            g_state.press_x = x;
+            g_state.press_y = y;
+            g_state.press_node = g_state.graph->pick(fx, fy);
         }
     } else { // RELEASE
+        // A press+release on a node without dragging = select + expand it. Pure
+        // pan drags (cursor moved past the slop) never select, so the view is
+        // not jumped by an accidental click.
+        const double mdx = x - g_state.press_x;
+        const double mdy = y - g_state.press_y;
+        const bool is_click = (mdx * mdx + mdy * mdy) <= kClickSlopPx * kClickSlopPx;
+        if (g_state.graph_panning && is_click && g_state.press_node != INVALID_NODE) {
+            g_state.graph->select(g_state.press_node);
+            g_state.graph->expand_node(g_state.press_node);
+        }
+        g_state.press_node    = INVALID_NODE;
         g_state.graph_panning = false;
         g_state.dock_dragging = false;
         g_state.dock->end_drag();
@@ -226,6 +247,11 @@ int main(int argc, char** argv) {
     }
     printf("[init] Graph: %u nodes, %u edges\n", graph.total_nodes(), graph.total_edges());
 
+    // Source of children for click-to-expand (Step 6). Synthetic today; swap for
+    // ClangdDataChannel once Iter's IPC bridge is wired.
+    SyntheticDataChannel channel(args.nodes, 1u);
+    graph.set_data_channel(&channel);
+
     // Dock chrome renderer
     UiRectRenderer ui;
     if (!ui.initialize(vk_ctx, "shaders", 256)) {
@@ -264,7 +290,7 @@ int main(int argc, char** argv) {
     glfwSetScrollCallback(win, scroll_callback);
     glfwSetKeyCallback(win, key_callback);
 
-    printf("[loop] Drag=pan, Scroll=zoom, drag splitter=resize, click tab=switch, R=fit, S=save, Esc=quit\n");
+    printf("[loop] Drag=pan, Scroll=zoom, click node=select+expand, drag splitter=resize, click tab=switch, R=fit, S=save, Esc=quit\n");
 
     uint64_t frame_count = 0;
     auto fps_t0 = std::chrono::steady_clock::now();

--- a/demo/graph/synthetic_data_channel.cpp
+++ b/demo/graph/synthetic_data_channel.cpp
@@ -1,0 +1,66 @@
+#include "synthetic_data_channel.h"
+
+#include <string>
+
+#include "graph_generator.h"
+#include "graph_store.h"
+
+namespace pictor::graph {
+
+namespace {
+
+constexpr const char* kKindPrefix[static_cast<int>(NodeKind::Count)] = {
+    "fn_", "m_", "var_", "Type_", "sym_"
+};
+
+// SplitMix64: cheap, well-distributed 64-bit hash for deterministic id/kind
+// derivation without any shared state.
+uint64_t mix64(uint64_t x) {
+    x += 0x9E3779B97F4A7C15ull;
+    x = (x ^ (x >> 30)) * 0xBF58476D1CE4E5B9ull;
+    x = (x ^ (x >> 27)) * 0x94D049BB133111EBull;
+    return x ^ (x >> 31);
+}
+
+// Children live in the high id namespace so they never collide with the initial
+// level's auto-ids (0 .. node_count).
+constexpr uint64_t kExpandBit = 1ull << 63;
+
+} // namespace
+
+GraphData SyntheticDataChannel::initial() {
+    GraphData out;
+    const GraphStore store = generate_layered_graph(node_count_, seed_, false);
+
+    const auto& n = store.nodes();
+    out.nodes.reserve(store.node_count());
+    for (size_t i = 0; i < store.node_count(); ++i)
+        out.nodes.push_back({store.id_of(static_cast<NodeHandle>(i)), n.label[i],
+                             static_cast<NodeKind>(n.kind[i])});
+
+    const auto& e = store.edges();
+    out.edges.reserve(store.edge_count());
+    for (size_t k = 0; k < store.edge_count(); ++k)
+        out.edges.push_back({store.id_of(e.from[k]), store.id_of(e.to[k]),
+                             static_cast<EdgeKind>(e.kind[k])});
+    return out;
+}
+
+GraphData SyntheticDataChannel::request_children(uint64_t node_id) {
+    GraphData out;
+    const uint64_t h0 = mix64(node_id ^ (seed_ + 1u));
+    const uint32_t fanout = 1u + static_cast<uint32_t>(h0 % 3u);  // 1..3 children
+
+    for (uint32_t f = 0; f < fanout; ++f) {
+        const uint64_t h = mix64(h0 + f);
+        const uint64_t child_id = (h >> 1) | kExpandBit;
+        const auto kind = static_cast<NodeKind>(h % static_cast<uint64_t>(NodeKind::Count));
+        std::string name = std::string(kKindPrefix[static_cast<int>(kind)]) +
+                           std::to_string(child_id % 100000ull);
+        out.nodes.push_back({child_id, std::move(name), kind});
+        out.edges.push_back({node_id, child_id, EdgeKind::Call});
+    }
+    return out;
+}
+
+} // namespace pictor::graph

--- a/demo/graph/synthetic_data_channel.h
+++ b/demo/graph/synthetic_data_channel.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+#include "data_channel.h"
+
+namespace pictor::graph {
+
+/// Deterministic stand-in for the clangd bridge: a synthetic call graph whose
+/// initial level mirrors the demo generator and whose children are derived
+/// reproducibly from a parent id (so re-expanding a node is idempotent). Replace
+/// with ClangdDataChannel once Iter's IPC is wired.
+class SyntheticDataChannel : public IDataChannel {
+public:
+    SyntheticDataChannel(uint32_t node_count, uint32_t seed)
+        : node_count_(node_count ? node_count : 1), seed_(seed) {}
+
+    GraphData initial() override;
+    GraphData request_children(uint64_t node_id) override;
+
+private:
+    uint32_t node_count_;
+    uint32_t seed_;
+};
+
+} // namespace pictor::graph

--- a/demo/graph/vk_util.cpp
+++ b/demo/graph/vk_util.cpp
@@ -145,11 +145,50 @@ VkPipeline create_instanced_pipeline(VkDevice device, VkRenderPass render_pass,
 
 // ─── DynamicInstanceBuffers ──────────────────────────────────
 
+bool DynamicInstanceBuffers::create_storage(uint32_t f, VkDeviceSize bytes) {
+    VkBufferCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    info.size  = bytes;
+    info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    if (vkCreateBuffer(device_, &info, nullptr, &buffers_[f]) != VK_SUCCESS)
+        return false;
+
+    VkMemoryRequirements req;
+    vkGetBufferMemoryRequirements(device_, buffers_[f], &req);
+
+    VkMemoryAllocateInfo alloc{};
+    alloc.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    alloc.allocationSize  = req.size;
+    alloc.memoryTypeIndex = find_memory_type(
+        phys_, req.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (vkAllocateMemory(device_, &alloc, nullptr, &memories_[f]) != VK_SUCCESS)
+        return false;
+    vkBindBufferMemory(device_, buffers_[f], memories_[f], 0);
+    vkMapMemory(device_, memories_[f], 0, bytes, 0, &mapped_[f]);
+
+    VkDescriptorBufferInfo bi{};
+    bi.buffer = buffers_[f];
+    bi.offset = 0;
+    bi.range  = VK_WHOLE_SIZE;
+
+    VkWriteDescriptorSet write{};
+    write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    write.dstSet          = sets_[f];
+    write.dstBinding      = 0;
+    write.descriptorCount = 1;
+    write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    write.pBufferInfo     = &bi;
+    vkUpdateDescriptorSets(device_, 1, &write, 0, nullptr);
+    return true;
+}
+
 bool DynamicInstanceBuffers::initialize(VulkanContext& vk_ctx, uint32_t flights,
                                         VkDeviceSize capacity_bytes,
                                         VkDescriptorSetLayout set_layout,
                                         VkDescriptorPool pool) {
-    VkDevice device = vk_ctx.device();
+    device_   = vk_ctx.device();
+    phys_     = vk_ctx.physical_device();
     capacity_ = capacity_bytes;
     buffers_.resize(flights, VK_NULL_HANDLE);
     memories_.resize(flights, VK_NULL_HANDLE);
@@ -157,49 +196,34 @@ bool DynamicInstanceBuffers::initialize(VulkanContext& vk_ctx, uint32_t flights,
     sets_.resize(flights, VK_NULL_HANDLE);
 
     for (uint32_t f = 0; f < flights; ++f) {
-        VkBufferCreateInfo info{};
-        info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-        info.size  = capacity_bytes;
-        info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-        if (vkCreateBuffer(device, &info, nullptr, &buffers_[f]) != VK_SUCCESS)
-            return false;
-
-        VkMemoryRequirements req;
-        vkGetBufferMemoryRequirements(device, buffers_[f], &req);
-
-        VkMemoryAllocateInfo alloc{};
-        alloc.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-        alloc.allocationSize  = req.size;
-        alloc.memoryTypeIndex = find_memory_type(
-            vk_ctx.physical_device(), req.memoryTypeBits,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-        if (vkAllocateMemory(device, &alloc, nullptr, &memories_[f]) != VK_SUCCESS)
-            return false;
-        vkBindBufferMemory(device, buffers_[f], memories_[f], 0);
-        vkMapMemory(device, memories_[f], 0, capacity_bytes, 0, &mapped_[f]);
-
         VkDescriptorSetAllocateInfo sa{};
         sa.sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         sa.descriptorPool     = pool;
         sa.descriptorSetCount = 1;
         sa.pSetLayouts        = &set_layout;
-        if (vkAllocateDescriptorSets(device, &sa, &sets_[f]) != VK_SUCCESS)
+        if (vkAllocateDescriptorSets(device_, &sa, &sets_[f]) != VK_SUCCESS)
             return false;
-
-        VkDescriptorBufferInfo bi{};
-        bi.buffer = buffers_[f];
-        bi.offset = 0;
-        bi.range  = VK_WHOLE_SIZE;
-
-        VkWriteDescriptorSet write{};
-        write.sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        write.dstSet          = sets_[f];
-        write.dstBinding      = 0;
-        write.descriptorCount = 1;
-        write.descriptorType  = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        write.pBufferInfo     = &bi;
-        vkUpdateDescriptorSets(device, 1, &write, 0, nullptr);
+        if (!create_storage(f, capacity_bytes))
+            return false;
     }
+    return true;
+}
+
+bool DynamicInstanceBuffers::ensure_capacity(VkDeviceSize bytes) {
+    if (bytes <= capacity_) return true;
+    // Grow with headroom (1.5x of the request) to amortize repeated expands.
+    const VkDeviceSize new_cap = bytes + bytes / 2;
+    for (size_t f = 0; f < buffers_.size(); ++f) {
+        if (mapped_[f])   vkUnmapMemory(device_, memories_[f]);
+        if (buffers_[f])  vkDestroyBuffer(device_, buffers_[f], nullptr);
+        if (memories_[f]) vkFreeMemory(device_, memories_[f], nullptr);
+        buffers_[f]  = VK_NULL_HANDLE;
+        memories_[f] = VK_NULL_HANDLE;
+        mapped_[f]   = nullptr;
+        if (!create_storage(static_cast<uint32_t>(f), new_cap))
+            return false;
+    }
+    capacity_ = new_cap;
     return true;
 }
 

--- a/demo/graph/vk_util.h
+++ b/demo/graph/vk_util.h
@@ -41,6 +41,13 @@ public:
                     VkDescriptorSetLayout set_layout, VkDescriptorPool pool);
     void destroy(VkDevice device);
 
+    /// Grow every flight's buffer so it can hold at least `bytes`, re-pointing the
+    /// existing descriptor sets at the new storage. No-op when already large
+    /// enough. The caller MUST have made the device idle (incremental expand grows
+    /// the total node/edge count between frames). Returns false on allocation
+    /// failure.
+    bool ensure_capacity(VkDeviceSize bytes);
+
     /// Copy `bytes` of instance data into the given flight's mapped buffer.
     void upload(uint32_t flight, const void* data, VkDeviceSize bytes);
 
@@ -48,6 +55,12 @@ public:
     VkDeviceSize    capacity() const { return capacity_; }
 
 private:
+    // Create buffer + memory + mapping for one flight and bind it to sets_[f].
+    bool create_storage(uint32_t flight, VkDeviceSize bytes);
+
+    VkDevice         device_ = VK_NULL_HANDLE;
+    VkPhysicalDevice phys_   = VK_NULL_HANDLE;
+
     std::vector<VkBuffer>        buffers_;
     std::vector<VkDeviceMemory>  memories_;
     std::vector<void*>           mapped_;


### PR DESCRIPTION
Iter 関連グラフ native renderer の Step 6 一式。`demo/graph/HANDOFF.md` の残作業 (#397/#398/#400) を実装。

## #397 incremental expand + lerp
- `GraphStore` に stable id (`find` / `id_of` / `id_to_index`) を追加し append-only マージで子展開を dedup
- ノードクリック (press+release without drag) で `IDataChannel::request_children` → 新ノードを親の anim 位置から fan-out 目標へ lerp
- 総数増加時 `GraphRenderer::ensure_capacity` → `DynamicInstanceBuffers::ensure_capacity` で per-flight バッファを device idle 後に再確保 (descriptor set は rebind、pool 枯渇なし)

## #398 IDataChannel + clangd 契約
- `data_channel.h` に `{nodes,edges}` 契約と `IDataChannel` 境界
- `SyntheticDataChannel` (決定的合成) / `ClangdDataChannel` (clangd callHierarchy ミラー → GraphData 変換、`std::function` fetch が Rust(Iter)↔C++(Pictor) IPC 境界)
- Pictor は Tauri/serde 非依存のまま。**実 IPC 配線 (Iter Rust 側 `graph_request_children`) は未着手** — Pictor 側の型と境界は確定

## #400 既知課題
- **edge cull**: `segment_intersects_rect` (Liang-Barsky) で両端点 off-screen でも view を横切るエッジを描画
- **dock_layout**: `DockDesc` (Corpus `DockLayoutNode` ミラー leaf/split/tabs) + `set_layout` で宣言的構築。`set_default` も経由化
- **click-jump 抑制**: クリックで select+expand するが camera は不動 (drag は pan のみで選択しない)

## ビルド
`cmake --build build --target pictor_graph_demo --config Debug` → **error 0** (pictor_graph_demo.exe 生成)。Pictor no-run 規約により実行確認は未実施。