### PR TITLE
feat(pipeline): compiled レンダリング経路の配線 + text-effects 修正 + demo/テストのビルド破損修復

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ add_library(pictor STATIC
     src/pipeline/render_pass_registry.cpp
     src/pipeline/framebuffer_registry.cpp
     src/pipeline/pipeline_compiler.cpp
+    src/pipeline/compiled_path_driver.cpp
+    src/pipeline/compiled_batch_recorder.cpp
 
     # Profiler
     src/profiler/cpu_timer.cpp
@@ -438,6 +440,23 @@ if(PICTOR_BUILD_DEMO AND NOT PICTOR_MOBILE)
         message(STATUS "Pictor: All demos enabled (benchmark, window, graphics, ocean, text, postprocess, texture2d, graph)")
     else()
         message(STATUS "Pictor: Only benchmark demo enabled (Vulkan + GLFW3 required for other demos)")
+    endif()
+
+    # MSVC: /utf-8 は pictor lib から demo target へ伝播しない
+    # ([[feedback_msvc_utf8_test_targets]] と同じ理由)。 公開ヘッダは日本語
+    # コメントを含む UTF-8 ソースなので、 CP932 解釈だと C4819 → 構文崩壊で
+    # コンパイルエラーになる。 全 demo target に個別指定する。
+    if(MSVC)
+        foreach(_demo
+            pictor_benchmark pictor_fbx_demo pictor_mobile_demo
+            pictor_text_effects_demo pictor_material_serializer_demo
+            pictor_fbx_viewer pictor_demo pictor_graphics_demo
+            pictor_ocean_demo pictor_text_demo pictor_postprocess_demo
+            pictor_rive_demo pictor_texture2d_demo)
+            if(TARGET ${_demo})
+                target_compile_options(${_demo} PRIVATE /utf-8)
+            endif()
+        endforeach()
     endif()
 endif()
 

--- a/demo/postprocess/main.cpp
+++ b/demo/postprocess/main.cpp
@@ -803,7 +803,10 @@ int main() {
     pp.tone_mapping.white_point = 4.0f;
     pp.tone_mapping.saturation = 1.0f;
 
-    renderer.set_postprocess_config(pp);
+    // Post-process は host-driven 化により PictorRenderer から切り離された
+    // (`pictor_renderer.h` の Post-Process 節参照)。 本 demo の視覚効果は
+    // 下の SceneUBO (dofFocusDistance / exposure 等) が担っており、 config は
+    // g_state.pp_config としてキー操作 → UBO へ毎フレーム反映される。
 
     // ---- 6. Register Scene Objects ----
     // Central emissive cube (very bright — triggers bloom)
@@ -1014,8 +1017,8 @@ int main() {
         auto now = std::chrono::high_resolution_clock::now();
         float elapsed = std::chrono::duration<float>(now - start).count();
 
-        // Update post-process config each frame (in case keys changed it)
-        renderer.set_postprocess_config(g_state.pp_config);
+        // g_state.pp_config のキー操作結果は下の SceneUBO 構築で毎フレーム
+        // 反映される (post-process は host-driven — renderer へは渡さない)。
 
         // Orbit camera
         float cos_pitch = std::cos(g_state.pitch);

--- a/demo/text/main.cpp
+++ b/demo/text/main.cpp
@@ -56,12 +56,25 @@ static const char* effect_names[] = {"No Effect", "Outline", "Drop Shadow", "Glo
 // ============================================================
 
 struct TextPushConstants {
-    int32_t  render_mode;   // 0 = textured, 1 = solid color
-    int32_t  effect_mode;   // 0..3
+    // Layout must match the GLSL push_constant block in
+    // demo/text/shaders/text_quad.frag under std430 rules:
+    //   offset  0: int   renderMode
+    //   offset  4: int   effectMode
+    //   offset  8: (8-byte pad — vec4 has 16-byte alignment)
+    //   offset 16: vec4  outlineColor
+    //   offset 32: float outlineWidth
+    // Total: 48 bytes.  The two _pad fields are required — without them
+    // the shader reads outlineColor / outlineWidth from the wrong offsets
+    // (so effects silently fall through to zero strength).
+    int32_t  render_mode;      // 0 = textured, 1 = solid color
+    int32_t  effect_mode;      // 0..3
+    int32_t  _pad0[2];         // pad to 16-byte boundary for vec4
     float    outline_color[4];
     float    outline_width;
-    float    _pad[3];       // align to 16 bytes
+    float    _pad1[3];
 };
+static_assert(sizeof(TextPushConstants) == 48,
+              "TextPushConstants layout must match text_quad.frag std430 block");
 
 // ============================================================
 // Quad vertex (must match text_quad.vert)

--- a/include/pictor/core/pictor_renderer.h
+++ b/include/pictor/core/pictor_renderer.h
@@ -11,6 +11,8 @@
 #include "pictor/gpu/gpu_driven_pipeline.h"
 #include "pictor/pipeline/pipeline_profile.h"
 #include "pictor/pipeline/render_pass_scheduler.h"
+#include "pictor/pipeline/compiled_path_driver.h"
+#include "pictor/pipeline/compiled_batch_recorder.h"
 #include "pictor/profiler/profiler.h"
 #include "pictor/profiler/overlay_renderer.h"
 #include "pictor/profiler/stats_overlay.h"
@@ -245,6 +247,51 @@ public:
     /// Access bake system
     GIBakeSystem* bake_system() { return bake_system_; }
 
+    // ---- Compiled Render Graph (系統B host-driven 経路の配線, §3.5) ----
+    //
+    // 実描画コマンドの発行は host-driven: host が VulkanContext / 3 registry
+    // を構築した上で `compile_render_graph()` を 1 回呼び、 フレームループの
+    // コマンドバッファ記録中に `render_compiled()` を呼ぶ。 プロファイル切替
+    // (set_profile / load_profile_from_file / reload_active_profile) 時は
+    // 自動で再 compile される。 swapchain resize 時は registries を再構築後、
+    // `compile_render_graph()` を呼び直すこと。
+    //
+    // Managed の `render()` (culling / batch build / custom pass) と併用する:
+    // render() がフレームの CPU 側データを組み、 render_compiled() がそれを
+    // GPU コマンドへ落とす。 draw call / triangle 統計は recorder 経由の
+    // オーバーロードが実測値を profiler へ集計する (虚偽統計の是正, D-2)。
+
+#ifdef PICTOR_HAS_VULKAN
+    /// Compile the active profile into a CompiledGraph and install it on the
+    /// scheduler. Registries / device は借用 (host 所有、 呼び出し以降も生存
+    /// 必須)。 失敗時 false (詳細は stderr)。
+    bool compile_render_graph(VkDevice                   device,
+                              const AttachmentRegistry&  attachments,
+                              const RenderPassRegistry&  render_passes,
+                              const FramebufferRegistry& framebuffers,
+                              uint32_t                   flight_count,
+                              uint32_t                   swapchain_image_count);
+
+    /// CompiledGraph の GPU リソースを解放して compiled 経路を解除する。
+    /// VkDevice 破棄前に呼ぶこと (shutdown() からも安全に呼ばれる)。
+    void release_render_graph();
+
+    /// True if a compiled graph is installed on the scheduler.
+    bool has_compiled_render_graph() const;
+
+    /// Iterate the compiled graph and record GPU commands. Host のコマンド
+    /// バッファ記録中 (begin_frame → render → ここ → end_frame) に呼ぶ。
+    /// `record` 版: pass 記録は完全に host 責務 (統計は host が profiler へ)。
+    void render_compiled(VkCommandBuffer cmd, uint32_t flight_index,
+                         uint32_t image_index,
+                         const RenderPassScheduler::PassRecordFn& record);
+
+    /// `recorder` 版: BatchBuilder のバッチを CompiledBatchRecorder で記録し、
+    /// 実測 draw call / triangle 数を profiler へ集計する。
+    void render_compiled(VkCommandBuffer cmd, uint32_t flight_index,
+                         uint32_t image_index, CompiledBatchRecorder& recorder);
+#endif // PICTOR_HAS_VULKAN
+
     // ---- Post-Process ----
     // host-driven の `pictor::PostProcessPipeline` を使う。 ホストがシーンを
     // HDR ターゲットへ描き、 自前で initialize_vulkan / record する
@@ -303,6 +350,11 @@ private:
     // 切り出したコントローラ / ファサード (initialize で生成)。
     std::unique_ptr<MobileLifecycleController> mobile_;
     std::unique_ptr<GIFacade>                  gi_facade_;
+
+    // 系統B compiled 経路: profile → CompiledGraph のライフサイクル管理
+    // (compile / プロファイル切替時の再 compile / 解放)。 headless ビルド
+    // では常に disengaged のスタブ。
+    CompiledPathDriver compiled_driver_;
 
     RendererConfig config_;
     float          delta_time_     = 0.0f;

--- a/include/pictor/gpu/gpu_driven_pipeline.h
+++ b/include/pictor/gpu/gpu_driven_pipeline.h
@@ -52,12 +52,14 @@ public:
     void set_config(const GPUDrivenConfig& config) { config_ = config; }
     const GPUDrivenConfig& config() const { return config_; }
 
-    /// Statistics
+    /// Statistics。 compute dispatch が未実装 (Phase 4) のため、 GPU 実行結果
+    /// に依存する `visible_objects` / `draw_calls` は常に 0 = 「未計測」。
+    /// 偽の推定値は入れない (§7.1 / review/2026-06-11 D-2)。
     struct Stats {
-        uint32_t total_objects   = 0;
-        uint32_t visible_objects = 0;
-        uint32_t draw_calls      = 0;
-        uint32_t workgroups      = 0;
+        uint32_t total_objects   = 0;  ///< 対象オブジェクト数 (CPU 側で実測)
+        uint32_t visible_objects = 0;  ///< 未実装: GPU cull 結果 readback 待ち
+        uint32_t draw_calls      = 0;  ///< 未実装: indirect draw 生成待ち
+        uint32_t workgroups      = 0;  ///< dispatch するはずの workgroup 数 (実測)
     };
 
     Stats get_stats() const { return stats_; }
@@ -72,6 +74,8 @@ private:
     GPUBufferManager::SSBOLayout  ssbo_layout_;
     Stats                         stats_;
     bool                          initialized_ = false;
+    /// execute() の「compute dispatch 未実装」warn を 1 回に抑えるフラグ (§7.1)。
+    bool                          warned_dispatch_unimplemented_ = false;
 };
 
 } // namespace pictor

--- a/include/pictor/pictor.h
+++ b/include/pictor/pictor.h
@@ -38,6 +38,8 @@
 #include "pictor/pipeline/pipeline_profile.h"
 #include "pictor/pipeline/pipeline_builder.h"
 #include "pictor/pipeline/render_pass_scheduler.h"
+#include "pictor/pipeline/compiled_path_driver.h"
+#include "pictor/pipeline/compiled_batch_recorder.h"
 
 // Profiler
 #include "pictor/profiler/cpu_timer.h"

--- a/include/pictor/pipeline/compiled_batch_recorder.h
+++ b/include/pictor/pipeline/compiled_batch_recorder.h
@@ -1,0 +1,102 @@
+#pragma once
+
+/// CompiledBatchRecorder — CompiledGraph の pass record callback 既定実装。
+///
+/// `RenderPassScheduler::execute_compiled()` の `PassRecordFn` として動き、
+/// `BatchBuilder` が組んだ `RenderBatch` 列を実 `vkCmd*` へ落とす
+/// (`simple_renderer.cpp` の record パターン踏襲)。 メッシュ VkBuffer /
+/// VkPipeline は Pictor が所有しない (host 所有 — `rendering-extensibility-design.md`
+/// §2 「実 vkCmdBindPipeline はホスト責務」) ため、 解決は `IBatchGpuSource`
+/// 抽象を経由する (DIP: consumer に Vulkan 実体の置き場所を強制しない)。
+///
+/// 未実装 pass (SHADOW / DEPTH_ONLY) と record 対象外 pass (COMPUTE /
+/// POST_PROCESS / CUSTOM / host_recorded) は §7.1 に従い無言 skip しない —
+/// 種別ごとに 1 回だけ warn を出し、 stats に計上する。
+
+// pipeline_profile.h precedes <vulkan/vulkan.h> — see render_pass_registry.h.
+#include "pictor/pipeline/compiled_graph.h"
+#include "pictor/core/types.h"
+#include "pictor/material/base_material_builder.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace pictor {
+
+#ifdef PICTOR_HAS_VULKAN
+
+/// 1 バッチ分の GPU 実体 (host 所有ハンドルの借用ビュー)。
+struct BatchGpuResources {
+    VkPipeline  pipeline      = VK_NULL_HANDLE;
+    VkBuffer    vertex_buffer = VK_NULL_HANDLE;
+    VkBuffer    index_buffer  = VK_NULL_HANDLE;
+    VkIndexType index_type    = VK_INDEX_TYPE_UINT32;
+    uint32_t    index_count   = 0;
+};
+
+/// Host 側の GPU 実体解決 seam。 `shader_key` は material variant 解決後の
+/// pass-specific キー (recorder が MaterialRegistry を引いた結果)。
+/// 解決できないバッチは false を返す — recorder は skip を stats に計上する
+/// ので、 host は「まだアップロードしていないメッシュ」を安全に落とせる。
+class IBatchGpuSource {
+public:
+    virtual ~IBatchGpuSource() = default;
+
+    virtual bool resolve(const RenderBatch& batch,
+                         uint64_t           shader_key,
+                         PassType           pass_type,
+                         BatchGpuResources& out) = 0;
+};
+
+class CompiledBatchRecorder {
+public:
+    /// per-frame 実測統計 (§13.5 — 虚偽値を返さないための実測源)。
+    struct Stats {
+        uint32_t draw_calls          = 0;  ///< 発行した vkCmdDrawIndexed 数
+        uint32_t instances           = 0;  ///< 描画インスタンス総数
+        uint64_t triangles           = 0;  ///< index_count/3 × instance の総和
+        uint32_t batches_skipped     = 0;  ///< GPU 実体未解決で skip したバッチ
+        uint32_t passes_unimplemented = 0; ///< SHADOW/DEPTH_ONLY (未実装) の遭遇数
+        uint32_t passes_not_recorded = 0;  ///< COMPUTE/POST_PROCESS 等 record 対象外
+    };
+
+    /// `gpu_source` は借用 (host 所有)。 `material_registry` は null 可 —
+    /// null なら batch の shaderKey をそのまま使う (variant 解決なし)。
+    explicit CompiledBatchRecorder(IBatchGpuSource& gpu_source,
+                                   const MaterialRegistry* material_registry = nullptr)
+        : gpu_source_(gpu_source)
+        , material_registry_(material_registry)
+    {}
+
+    /// フレーム毎: 描画対象バッチ列を差し替え、 統計をリセットする。
+    /// `batches` は借用 — execute_compiled の間、 呼び出し側が生存保証する。
+    void begin_frame(const std::vector<RenderBatch>* batches) {
+        batches_ = batches;
+        stats_   = Stats{};
+    }
+
+    /// PassRecordFn 本体。 render pass scope 内 (execute_compiled が
+    /// Begin/End を発行済み) で呼ばれる前提。
+    void record(VkCommandBuffer cmd, const CompiledPass& cp,
+                uint32_t flight_index, uint32_t image_index);
+
+    const Stats& stats() const { return stats_; }
+
+private:
+    void record_batches_(VkCommandBuffer cmd, const CompiledPass& cp,
+                         PassType pass_type);
+
+    IBatchGpuSource&                gpu_source_;
+    const MaterialRegistry*         material_registry_ = nullptr;
+    const std::vector<RenderBatch>* batches_           = nullptr;
+    Stats                           stats_;
+
+    // §7.1: 未実装/対象外 pass の warn は毎フレーム出さず種別ごとに 1 回。
+    bool warned_shadow_       = false;
+    bool warned_depth_only_   = false;
+    bool warned_not_recorded_ = false;
+};
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/include/pictor/pipeline/compiled_path_driver.h
+++ b/include/pictor/pipeline/compiled_path_driver.h
@@ -1,0 +1,95 @@
+#pragma once
+
+/// CompiledPathDriver — profile → CompiledGraph のライフサイクル管理。
+///
+/// `spec/pipeline-system-b-config.md` §3.5 / review/2026-06-11 D-2 の配線層。
+/// `PipelineCompiler::compile()` は「起動時 / プロファイル切替 / swapchain
+/// resize の 1 回だけ」呼ぶ規約だが、 その再 compile 判断と、 旧 graph の
+/// リソース解放 (descriptor pool) を伴う差し替え手順は compile 関数自身の
+/// 責務ではない。 本クラスがその 1 責務 (SRP) を持つ:
+///
+///   engage()    — registries / device を借用して初回 compile + scheduler へ install
+///   recompile() — プロファイル切替 / swapchain resize 時のみ呼ぶ (毎フレーム不可)
+///   disengage() — graph を回収して descriptor pool を解放 (device 破棄前に必須)
+///
+/// 所有権: registries / device は借用 (host 所有)。 CompiledGraph は
+/// scheduler に move で預けるが、 解放責任は本クラスが負う (全経路で解放)。
+
+// pipeline_profile.h precedes <vulkan/vulkan.h> — see render_pass_registry.h.
+#include "pictor/pipeline/compiled_graph.h"
+#include "pictor/pipeline/pipeline_profile.h"
+
+#include <cstdint>
+
+namespace pictor {
+
+class AttachmentRegistry;
+class RenderPassRegistry;
+class FramebufferRegistry;
+class RenderPassScheduler;
+
+#ifdef PICTOR_HAS_VULKAN
+
+class CompiledPathDriver {
+public:
+    /// Compile に要る借用依存の束。 registries は host が構築済みであること。
+    /// `device == VK_NULL_HANDLE` は headless (テスト / 構造検証) モード:
+    /// descriptor pool を作らず、 VkHandle は全て VK_NULL_HANDLE のまま
+    /// graph 構造だけを組む (PipelineCompiler 側の同名ガードに対応)。
+    struct Deps {
+        VkDevice                   device                = VK_NULL_HANDLE;
+        const AttachmentRegistry*  attachments           = nullptr;
+        const RenderPassRegistry*  render_passes         = nullptr;
+        const FramebufferRegistry* framebuffers          = nullptr;
+        uint32_t                   flight_count          = 2;
+        uint32_t                   swapchain_image_count = 3;
+    };
+
+    CompiledPathDriver() = default;
+    ~CompiledPathDriver() = default;
+
+    CompiledPathDriver(const CompiledPathDriver&)            = delete;
+    CompiledPathDriver& operator=(const CompiledPathDriver&) = delete;
+
+    /// 初回 compile + scheduler への install。 依存を保持し engaged 状態にする。
+    /// registry が欠けている場合は false (§7.1: 設定不備は無言で通さない)。
+    bool engage(const Deps& deps,
+                const PipelineProfileDef& profile,
+                RenderPassScheduler& scheduler);
+
+    /// プロファイル切替 / swapchain resize 時の再 compile。
+    /// 旧 graph を scheduler から回収して解放してから差し替える。
+    /// engage() 前に呼ばれたら false。
+    bool recompile(const PipelineProfileDef& profile,
+                   RenderPassScheduler& scheduler);
+
+    /// graph を回収して descriptor pool を解放し、 disengaged に戻す。
+    /// VkDevice 破棄前に必ず呼ぶこと (リソースは全経路で解放)。
+    void disengage(RenderPassScheduler& scheduler);
+
+    bool engaged() const { return engaged_; }
+
+private:
+    /// 旧 graph 回収 → compile → install の共通手順。
+    bool compile_and_install_(const PipelineProfileDef& profile,
+                              RenderPassScheduler& scheduler);
+
+    Deps deps_{};
+    bool engaged_ = false;
+};
+
+#else // !PICTOR_HAS_VULKAN
+
+/// Headless build: API 形状だけ保つ (graph は常に空)。
+class CompiledPathDriver {
+public:
+    struct Deps {};
+    bool engage(const Deps&, const PipelineProfileDef&, RenderPassScheduler&) { return false; }
+    bool recompile(const PipelineProfileDef&, RenderPassScheduler&) { return false; }
+    void disengage(RenderPassScheduler&) {}
+    bool engaged() const { return false; }
+};
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/include/pictor/pipeline/render_pass_scheduler.h
+++ b/include/pictor/pipeline/render_pass_scheduler.h
@@ -40,11 +40,18 @@ public:
     void register_custom_pass(ICustomRenderPass* pass);
 
     /// Set material registry for pass-specific variant resolution.
-    /// When set, the scheduler resolves per-pass shader/material keys
-    /// from the registry, stripping unused features per pass.
+    /// Consumed by the host-side record path (`CompiledBatchRecorder` が
+    /// batch 単位でインライン解決する) — `material_registry()` で参照する。
     void set_material_registry(const MaterialRegistry* registry) { material_registry_ = registry; }
+    const MaterialRegistry* material_registry() const { return material_registry_; }
 
-    /// Execute all render passes in order
+    /// Managed 経路のパス巡回 — custom pass (`ICustomRenderPass`) の実行のみ。
+    ///
+    /// built-in pass (SHADOW/OPAQUE/...) の描画コマンド発行は host-driven の
+    /// `execute_compiled()` が担う (spec/pipeline-system-b-config.md §1.2 —
+    /// コマンドバッファ / メッシュ VkBuffer は host 所有)。 compiled graph
+    /// 未設置のまま built-in pass に遭遇した場合は「動いて見えて何もしない」
+    /// を避けるため 1 回だけ明示 warn を出す (§7.1 サイレント no-op 禁止)。
     void execute(const BatchBuilder& batch_builder,
                  const CullingSystem& culling,
                  GPUDrivenPipeline* gpu_pipeline);
@@ -65,6 +72,15 @@ public:
 
     /// True if a non-empty CompiledGraph is installed.
     bool has_compiled_graph() const { return !compiled_.passes.empty(); }
+
+    /// Take back ownership of the installed graph (scheduler は空 graph に
+    /// 戻る)。 再 compile / device 破棄前に `CompiledGraph::shutdown()` を
+    /// 呼ぶのは受け取った側の責務 (`CompiledPathDriver` が正規の呼び手)。
+    CompiledGraph take_compiled_graph() {
+        CompiledGraph g = std::move(compiled_);
+        compiled_ = CompiledGraph{};
+        return g;
+    }
 
     /// Read-only access to the installed graph (for diagnostics / KS-side
     /// custom recording).
@@ -103,13 +119,9 @@ private:
     std::vector<ICustomRenderPass*>  custom_passes_;
     const MaterialRegistry*          material_registry_ = nullptr;
     CompiledGraph                    compiled_;
-
-    /// Remap batch keys using pass-specific material variants.
-    /// Returns a new batch list with shader/material keys replaced by
-    /// the variant appropriate for `pass_type`.
-    std::vector<RenderBatch> remap_batches_for_pass(
-        const std::vector<RenderBatch>& batches,
-        PassType pass_type) const;
+    /// execute() の「compiled graph 未設置で built-in pass に遭遇」warn を
+    /// 毎フレーム出さないための 1 回きりフラグ (§7.1)。
+    bool                             warned_unwired_builtin_ = false;
 };
 
 } // namespace pictor

--- a/spec/feature/pipeline-system-b-config.md
+++ b/spec/feature/pipeline-system-b-config.md
@@ -337,6 +337,18 @@ public:
 
 検証: KS が無改変で起動でき、 フレーム出力が従来と pixel-equivalent。 プロファイル切替で compile が走り直して flat graph が差し替わる。 hot path に string lookup が 0 個であること (perfetto trace で `std::string`/`unordered_map` シンボルが per-frame に出ないことを確認)。
 
+#### ステップ C 配線状況 (2026-07-02, `fix/render-compiled-path-wiring`)
+
+| 項目 | 実体 | 状態 |
+|---|---|---|
+| compile の呼び出し元 | `CompiledPathDriver` (`pipeline/compiled_path_driver.{h,cpp}`) — engage / recompile / disengage で graph ライフサイクル (descriptor pool 解放含む) を管理。 `PictorRenderer::compile_render_graph()` が公開 seam、 プロファイル切替 (`apply_profile`) 時は自動再 compile (毎フレーム compile しない) | ✅ |
+| フレームループからの execute_compiled | `PictorRenderer::render_compiled(cmd, flight, image, ...)` — host のコマンドバッファ記録中に呼ぶ。 PassRecordFn 版 (完全 host record) と `CompiledBatchRecorder` 版 (RenderBatch → vkCmdDrawIndexed + 実測統計) の 2 オーバーロード | ✅ |
+| record_batches 相当 | `CompiledBatchRecorder` — OPAQUE/TRANSPARENT を `IBatchGpuSource` (host が MeshHandle/shaderKey → VkBuffer/VkPipeline を解決する seam) 経由で記録。 material variant はバッチ単位インライン解決 (per-frame alloc なし)。 SHADOW / DEPTH_ONLY は未実装 — 無言 skip せず 1 回 warn + stats 計上 (§7.1) | ✅ (SHADOW/DEPTH_ONLY は未実装を明示) |
+| 旧 managed `execute()` | custom pass 実行のみに縮退。 built-in pass は compiled graph 未設置なら 1 回だけ明示 warn (D-2 のサイレント no-op を解消)。 `remap_batches_for_pass` (M-2 per-frame alloc) は削除 | ✅ |
+| draw call / triangle 統計 | recorder の実測値を `render_compiled()` が profiler へ集計。 GPUDrivenPipeline の placeholder 統計 (visible=count / draw_calls=1) は「未計測 = 0」へ是正 | ✅ |
+| headless 統合テスト | `tests/unit_compiled_graph_wiring_test.cpp` — headless compile (device=NULL) の graph 構造 / execute_compiled の record 順序 / driver ライフサイクル / recorder 統計 / プロファイル切替再 compile | ✅ |
+| KS 側配線 | `kuzu.profile.json` + registries 構築 → `compile_render_graph()` 呼び出し | 未 (KS 側 PR、 §9) |
+
 ### 4.4 ステップ D: 既存呼び出し側の整理
 
 - `FrameComposer` を `RenderPassScheduler::execute()` 経由に統合 (HUD レイヤーは pass として scheduler 内に置く / または "post-scheduler hook" として残す)

--- a/src/core/pictor_renderer.cpp
+++ b/src/core/pictor_renderer.cpp
@@ -41,6 +41,11 @@ void PictorRenderer::shutdown() {
     if (!initialized_) return;
 
     // §12: Release all resources, GPU sync
+#ifdef PICTOR_HAS_VULKAN
+    // compiled graph の descriptor pool を先に返す (VkDevice が生きている
+    // うちに解放する契約 — host は renderer.shutdown() を device 破棄前に呼ぶ)。
+    release_render_graph();
+#endif
     gi_facade_.reset();
     mobile_.reset();
     subsystems_.shutdown();
@@ -147,16 +152,16 @@ void PictorRenderer::render(const Camera& camera) {
         profiler_->end_gpu_section("GILighting");
     }
 
-    // §11.3 Step 5-6: Encode + Submit
+    // §11.3 Step 5-6: managed パス巡回 (custom pass のみ実行)。 built-in pass
+    // の実描画は host が render_compiled() (→ execute_compiled) で記録する。
     profiler_->begin_cpu_section(CpuSection::CommandEncode);
     pass_scheduler_->execute(*batch_builder_, *culling_, gpu_pipeline_);
     profiler_->end_cpu_section(CpuSection::CommandEncode);
 
-    // draw call / triangle 統計はかつて CommandEncoder から記録していたが、
-    // CommandEncoder::encode() は実際には呼ばれておらず常に 0 を返していた
-    // (虚偽統計、 review/2026-06-11 D-2)。 実描画コマンドの発行は host-driven
-    // 経路 (execute_compiled / PostProcessPipeline) が担うため、 managed 経路は
-    // これらを集計しない (0 のまま = 「未計測」)。
+    // draw call / triangle 統計は render_compiled() の recorder オーバーロード
+    // が実測値 (発行した vkCmdDrawIndexed 数) を record_draw_calls /
+    // record_triangles で集計する (D-2 虚偽統計の是正)。 host が recorder を
+    // 使わない場合は 0 のまま = 「未計測」であり、 偽値は入らない。
 
     // Record memory stats
     auto mem_stats = memory_->get_stats();
@@ -312,7 +317,88 @@ void PictorRenderer::apply_profile(const PipelineProfileDef& profile) {
     subsystems_.apply_profile(profile);
     // gpu_pipeline_ / gi_system_ が再生成・破棄され得るため alias を取り直す。
     sync_subsystem_aliases_();
+
+#ifdef PICTOR_HAS_VULKAN
+    // §3.5: compile はプロファイル切替時のみ再実行 (毎フレーム不可)。
+    // apply_profile はプロファイル切替 / reload の時だけ呼ばれるので、
+    // engaged なら新しい pass 構成で graph を差し替える。
+    if (compiled_driver_.engaged() && pass_scheduler_) {
+        compiled_driver_.recompile(profile, *pass_scheduler_);
+    }
+#endif
 }
+
+// ---- Compiled Render Graph (系統B 配線, §3.5 / D-2) ----
+
+#ifdef PICTOR_HAS_VULKAN
+
+bool PictorRenderer::compile_render_graph(VkDevice                   device,
+                                          const AttachmentRegistry&  attachments,
+                                          const RenderPassRegistry&  render_passes,
+                                          const FramebufferRegistry& framebuffers,
+                                          uint32_t                   flight_count,
+                                          uint32_t                   swapchain_image_count)
+{
+    if (!initialized_ || !pass_scheduler_) return false;
+
+    CompiledPathDriver::Deps deps;
+    deps.device                = device;
+    deps.attachments           = &attachments;
+    deps.render_passes         = &render_passes;
+    deps.framebuffers          = &framebuffers;
+    deps.flight_count          = flight_count;
+    deps.swapchain_image_count = swapchain_image_count;
+
+    if (compiled_driver_.engaged()) {
+        // 再呼び出し (swapchain resize 等) — 旧 graph を解放してから
+        // 新しい依存で組み直す。
+        compiled_driver_.disengage(*pass_scheduler_);
+    }
+    return compiled_driver_.engage(deps, profile_manager_->current_profile(),
+                                   *pass_scheduler_);
+}
+
+void PictorRenderer::release_render_graph() {
+    if (pass_scheduler_) compiled_driver_.disengage(*pass_scheduler_);
+}
+
+bool PictorRenderer::has_compiled_render_graph() const {
+    return pass_scheduler_ && pass_scheduler_->has_compiled_graph();
+}
+
+void PictorRenderer::render_compiled(VkCommandBuffer cmd, uint32_t flight_index,
+                                     uint32_t image_index,
+                                     const RenderPassScheduler::PassRecordFn& record)
+{
+    if (!initialized_ || !pass_scheduler_) return;
+    if (is_frame_work_suppressed_()) return;
+
+    pass_scheduler_->execute_compiled(cmd, flight_index, image_index, record);
+}
+
+void PictorRenderer::render_compiled(VkCommandBuffer cmd, uint32_t flight_index,
+                                     uint32_t image_index,
+                                     CompiledBatchRecorder& recorder)
+{
+    if (!initialized_ || !pass_scheduler_) return;
+    if (is_frame_work_suppressed_()) return;
+
+    // render() が組んだ当該フレームのバッチを recorder に渡して記録する。
+    recorder.begin_frame(&batch_builder_->batches());
+    pass_scheduler_->execute_compiled(
+        cmd, flight_index, image_index,
+        [&recorder](VkCommandBuffer c, const CompiledPass& cp,
+                    uint32_t flight, uint32_t image) {
+            recorder.record(c, cp, flight, image);
+        });
+
+    // 実測統計を profiler へ (D-2: 虚偽値ではなく発行済みコマンドの集計)。
+    const auto& s = recorder.stats();
+    profiler_->record_draw_calls(s.draw_calls);
+    profiler_->record_triangles(s.triangles);
+}
+
+#endif // PICTOR_HAS_VULKAN
 
 // ---- Profiler ----
 

--- a/src/gpu/gpu_driven_pipeline.cpp
+++ b/src/gpu/gpu_driven_pipeline.cpp
@@ -1,5 +1,7 @@
 ﻿#include "pictor/gpu/gpu_driven_pipeline.h"
 
+#include <cstdio>
+
 namespace pictor {
 
 GPUDrivenPipeline::GPUDrivenPipeline(GPUBufferManager& buffer_manager,
@@ -46,37 +48,22 @@ void GPUDrivenPipeline::execute(const Frustum& frustum,
     stats_.workgroups = workgroups;
     stats_.total_objects = object_count;
 
-    // §7.2: GPU Driven Pipeline Steps
-    // All steps are Compute Shader dispatches — recorded as GPU commands.
-    // Actual Vulkan dispatch calls would go here in a real implementation.
+    // §7.2 の 4 ステップ (Compute Update → Compute Cull → LOD Select →
+    // Compact + Indirect Draw) は **compute dispatch 未実装** (Phase 4)。
+    // §7.1 サイレント no-op 禁止に従い、 初回のみ明示 warn を出す。
+    if (!warned_dispatch_unimplemented_) {
+        std::fprintf(stderr,
+                     "[GPUDrivenPipeline] execute(): compute dispatch は未実装 "
+                     "(Phase 4) — GPU cull / indirect draw は発行されません "
+                     "(stats.visible_objects / draw_calls は未計測 = 0)\n");
+        warned_dispatch_unimplemented_ = true;
+    }
 
-    // Step 1: Compute Update (§5.4, §7.2)
-    // dispatch(workgroups, 1, 1) — updates gpu_transforms and gpu_bounds
-    // Input: gpu_velocities, gpu_update_params (uniform)
-    // Output: gpu_transforms, gpu_bounds
-
-    // Step 2: Compute Cull (§7.2)
-    // Frustum culling + Hi-Z occlusion culling
-    // Input: gpu_bounds
-    // Output: gpu_visibility
-
-    // Step 3: LOD Select (§7.2)
-    // Camera distance-based LOD selection
-    // Input: gpu_transforms, gpu_lod_info
-    // Output: gpu_visibility (LOD level stored)
-
-    // Step 4: Compact + Indirect Draw (§7.2)
-    // Compact visible objects and generate DrawIndexedIndirectCommand
-    // Input: gpu_visibility, gpu_mesh_info
-    // Output: IndirectDrawBuffer, DrawCountBuffer
-
-    // In a real Vulkan implementation, these would be:
-    // vkCmdDispatch(cmd, workgroups, 1, 1) for each step
-    // with appropriate barriers between steps
-
-    // Estimate visible count (actual would come from GPU readback)
-    stats_.visible_objects = object_count; // placeholder
-    stats_.draw_calls = 1; // single indirect draw call
+    // 旧実装は visible_objects = object_count / draw_calls = 1 の推定値を
+    // 返していた (review/2026-06-11 D-2 虚偽統計)。 GPU readback 実装まで
+    // 「未計測 = 0」に固定し、 偽値を統計 API に流さない。
+    stats_.visible_objects = 0;
+    stats_.draw_calls      = 0;
 }
 
 void GPUDrivenPipeline::upload_initial_data(const ObjectPool& pool) {

--- a/src/pipeline/attachment_registry.cpp
+++ b/src/pipeline/attachment_registry.cpp
@@ -376,6 +376,10 @@ VkFormat AttachmentRegistry::vk_format(uint16_t att_index) const {
 }
 
 VkExtent2D AttachmentRegistry::extent(uint16_t att_index) const {
+    // initialize_vulkan 前 (headless compile / テスト) は resources_ が空。
+    // 範囲外は「未実体化 = extent 0」を返す (FramebufferRegistry::get と同じ
+    // 防御パターン — PipelineCompiler が headless でも構造を組めるように)。
+    if (att_index >= resources_.size()) return VkExtent2D{0, 0};
     return resources_[att_index].extent;
 }
 

--- a/src/pipeline/compiled_batch_recorder.cpp
+++ b/src/pipeline/compiled_batch_recorder.cpp
@@ -1,0 +1,148 @@
+#include "pictor/pipeline/compiled_batch_recorder.h"
+
+#include <cstdio>
+
+namespace pictor {
+
+#ifdef PICTOR_HAS_VULKAN
+
+void CompiledBatchRecorder::record(VkCommandBuffer cmd, const CompiledPass& cp,
+                                   uint32_t /*flight_index*/,
+                                   uint32_t /*image_index*/)
+{
+    const PassType pass_type = static_cast<PassType>(cp.pass_type);
+
+    switch (pass_type) {
+        case PassType::OPAQUE:
+        case PassType::TRANSPARENT:
+            record_batches_(cmd, cp, pass_type);
+            break;
+
+        case PassType::SHADOW:
+            // 未実装: shadow atlas / cascade ごとの depth-only 記録は
+            // per-cascade lightViewProj と shadow 専用 pipeline が要る
+            // (GILightingSystem 側の資産が host-driven 化されるまで保留)。
+            // §7.1: 無言 skip せず 1 回だけ warn + stats へ計上する。
+            if (!warned_shadow_) {
+                std::fprintf(stderr,
+                             "[CompiledBatchRecorder] SHADOW pass '%s' は未実装 "
+                             "— 描画コマンドを発行しません (stats.passes_unimplemented)\n",
+                             cp.debug_name ? cp.debug_name : "?");
+                warned_shadow_ = true;
+            }
+            stats_.passes_unimplemented++;
+            break;
+
+        case PassType::DEPTH_ONLY:
+            // 未実装: depth pre-pass は depth-only pipeline 変種の解決が
+            // IBatchGpuSource 契約にまだ無い (pass_type 引数で拡張可能)。
+            if (!warned_depth_only_) {
+                std::fprintf(stderr,
+                             "[CompiledBatchRecorder] DEPTH_ONLY pass '%s' は未実装 "
+                             "— 描画コマンドを発行しません (stats.passes_unimplemented)\n",
+                             cp.debug_name ? cp.debug_name : "?");
+                warned_depth_only_ = true;
+            }
+            stats_.passes_unimplemented++;
+            break;
+
+        case PassType::COMPUTE:
+        case PassType::POST_PROCESS:
+        case PassType::CUSTOM:
+        default:
+            // record 対象外: COMPUTE dispatch / PostProcessPipeline chain /
+            // custom pass は host が自前の PassRecordFn で記録する契約
+            // (compiled_graph.h FLAG_IS_HOST_RECORDED 参照)。 これらを本
+            // recorder 一本で受けている構成は配線漏れの可能性があるため
+            // 1 回だけ知らせる (§7.1)。
+            if (!warned_not_recorded_) {
+                std::fprintf(stderr,
+                             "[CompiledBatchRecorder] pass '%s' (type=%u) は本 "
+                             "recorder の対象外 — host 側 PassRecordFn で記録して"
+                             "ください (stats.passes_not_recorded)\n",
+                             cp.debug_name ? cp.debug_name : "?",
+                             static_cast<unsigned>(cp.pass_type));
+                warned_not_recorded_ = true;
+            }
+            stats_.passes_not_recorded++;
+            break;
+    }
+}
+
+void CompiledBatchRecorder::record_batches_(VkCommandBuffer cmd,
+                                            const CompiledPass& cp,
+                                            PassType pass_type)
+{
+    if (!batches_ || batches_->empty()) return;
+
+    // viewport / scissor は dynamic state 前提で render_area から張る
+    // (simple_renderer.cpp と同じ手順)。 extent 0 = attachment 未実体化
+    // (headless) なので何も発行しない。
+    const bool has_area = cp.render_area.extent.width  > 0 &&
+                          cp.render_area.extent.height > 0;
+    if (has_area) {
+        VkViewport viewport{};
+        viewport.x        = static_cast<float>(cp.render_area.offset.x);
+        viewport.y        = static_cast<float>(cp.render_area.offset.y);
+        viewport.width    = static_cast<float>(cp.render_area.extent.width);
+        viewport.height   = static_cast<float>(cp.render_area.extent.height);
+        viewport.minDepth = 0.0f;
+        viewport.maxDepth = 1.0f;
+        vkCmdSetViewport(cmd, 0, 1, &viewport);
+        vkCmdSetScissor(cmd, 0, 1, &cp.render_area);
+    }
+
+    // BatchBuilder の sortKey 順 (shader/material グルーピング済み) を尊重して
+    // seq-iterate する。 per-pass の再ソート (cp.sort_mode) は per-frame alloc
+    // なしでは組めないため host 拡張に譲る (M-2 の轍を踏まない)。
+    VkPipeline bound_pipeline = VK_NULL_HANDLE;
+
+    for (const RenderBatch& batch : *batches_) {
+        // pass 別 material variant 解決 (旧 remap_batches_for_pass の
+        // vector 確保を廃し、 バッチ単位のインライン解決に置換 — M-2)。
+        uint64_t shader_key = batch.shaderKey;
+        if (material_registry_) {
+            const PassMaterialVariant* variant = material_registry_->variant_for(
+                static_cast<MaterialHandle>(batch.materialKey), pass_type);
+            if (variant) shader_key = variant->shader_key;
+        }
+
+        BatchGpuResources res;
+        if (!gpu_source_.resolve(batch, shader_key, pass_type, res) ||
+            res.pipeline      == VK_NULL_HANDLE ||
+            res.vertex_buffer == VK_NULL_HANDLE ||
+            res.index_buffer  == VK_NULL_HANDLE ||
+            res.index_count   == 0) {
+            // host がまだ GPU 実体を持たないバッチ (アップロード前など)。
+            // 計上して先へ — フレーム全体は止めない。
+            stats_.batches_skipped++;
+            continue;
+        }
+
+        // cp.pipeline は profile の shader_override による pass 単位の直値
+        // (compile 済み)。 ある場合はバッチ解決より優先する。
+        const VkPipeline pipeline =
+            (cp.pipeline != VK_NULL_HANDLE) ? cp.pipeline : res.pipeline;
+        if (pipeline != bound_pipeline) {
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+            bound_pipeline = pipeline;
+        }
+
+        VkDeviceSize offset = 0;
+        vkCmdBindVertexBuffers(cmd, 0, 1, &res.vertex_buffer, &offset);
+        vkCmdBindIndexBuffer(cmd, res.index_buffer, 0, res.index_type);
+
+        // batch.count = インスタンス数、 batch.startIndex = sorted_indices 上の
+        // 先頭 (§6.1 instanced draw)。 firstInstance に渡し、 シェーダ側は
+        // gl_InstanceIndex で instance SSBO を引く (simple_renderer と同型)。
+        vkCmdDrawIndexed(cmd, res.index_count, batch.count, 0, 0, batch.startIndex);
+
+        stats_.draw_calls++;
+        stats_.instances += batch.count;
+        stats_.triangles += static_cast<uint64_t>(res.index_count / 3u) * batch.count;
+    }
+}
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/src/pipeline/compiled_path_driver.cpp
+++ b/src/pipeline/compiled_path_driver.cpp
@@ -1,0 +1,90 @@
+#include "pictor/pipeline/compiled_path_driver.h"
+#include "pictor/pipeline/pipeline_compiler.h"
+#include "pictor/pipeline/render_pass_scheduler.h"
+
+#include <cstdio>
+
+namespace pictor {
+
+#ifdef PICTOR_HAS_VULKAN
+
+bool CompiledPathDriver::engage(const Deps& deps,
+                                const PipelineProfileDef& profile,
+                                RenderPassScheduler& scheduler)
+{
+    // §7.1: 依存不足を無言フォールバックで通さない — engage 失敗は明示する。
+    if (!deps.attachments || !deps.render_passes || !deps.framebuffers) {
+        std::fprintf(stderr,
+                     "[CompiledPathDriver] engage failed: registry deps missing "
+                     "(attachments=%p render_passes=%p framebuffers=%p)\n",
+                     static_cast<const void*>(deps.attachments),
+                     static_cast<const void*>(deps.render_passes),
+                     static_cast<const void*>(deps.framebuffers));
+        return false;
+    }
+
+    deps_    = deps;
+    engaged_ = true;
+
+    if (!compile_and_install_(profile, scheduler)) {
+        engaged_ = false;
+        return false;
+    }
+    return true;
+}
+
+bool CompiledPathDriver::recompile(const PipelineProfileDef& profile,
+                                   RenderPassScheduler& scheduler)
+{
+    if (!engaged_) {
+        std::fprintf(stderr,
+                     "[CompiledPathDriver] recompile called before engage()\n");
+        return false;
+    }
+    return compile_and_install_(profile, scheduler);
+}
+
+void CompiledPathDriver::disengage(RenderPassScheduler& scheduler) {
+    if (!engaged_) return;
+
+    // scheduler へ move した graph を回収して descriptor pool を解放する。
+    // (set_compiled_graph は所有権 move — 解放責任はこちらに残る契約。)
+    CompiledGraph old = scheduler.take_compiled_graph();
+    old.shutdown(deps_.device);
+
+    deps_    = Deps{};
+    engaged_ = false;
+}
+
+bool CompiledPathDriver::compile_and_install_(const PipelineProfileDef& profile,
+                                              RenderPassScheduler& scheduler)
+{
+    // 差し替え前に旧 graph のリソースを解放 (リークさせない — 全経路で解放)。
+    CompiledGraph old = scheduler.take_compiled_graph();
+    old.shutdown(deps_.device);
+
+    CompiledGraph g = PipelineCompiler::compile(profile,
+                                                *deps_.attachments,
+                                                *deps_.render_passes,
+                                                *deps_.framebuffers,
+                                                deps_.device,
+                                                deps_.flight_count,
+                                                deps_.swapchain_image_count);
+    if (g.passes.empty()) {
+        // compile 失敗 (詳細は PipelineCompiler が stderr 出力済み)。
+        // 空 graph を install してしまうと execute_compiled が「何もせず成功」
+        // に見えるため、 明示ログ + 未 install で返す (§7.1)。
+        std::fprintf(stderr,
+                     "[CompiledPathDriver] compile produced empty graph for "
+                     "profile '%s' — compiled path NOT installed\n",
+                     profile.profile_name.c_str());
+        return false;
+    }
+
+    scheduler.set_compiled_graph(std::move(g));
+    return true;
+}
+
+#endif // PICTOR_HAS_VULKAN
+
+} // namespace pictor

--- a/src/pipeline/pipeline_compiler.cpp
+++ b/src/pipeline/pipeline_compiler.cpp
@@ -134,7 +134,13 @@ CompiledGraph PipelineCompiler::compile(const PipelineProfileDef&  profile,
     dpci.poolSizeCount = 1;
     dpci.pPoolSizes    = &pool_size;
 
-    if (vkCreateDescriptorPool(device, &dpci, nullptr, &g.descriptor_pool) != VK_SUCCESS) {
+    // device == VK_NULL_HANDLE は headless compile (unit test / 構造検証)。
+    // vkCreateDescriptorPool を null device に投げると loader が落ちるため
+    // pool を作らず進む — passes の構造 (order / flags / clear / debug_name)
+    // は GPU 無しでも決定的に組める。 input_sets は全 NULL のまま。
+    if (device == VK_NULL_HANDLE) {
+        g.descriptor_pool = VK_NULL_HANDLE;
+    } else if (vkCreateDescriptorPool(device, &dpci, nullptr, &g.descriptor_pool) != VK_SUCCESS) {
         std::fprintf(stderr, "[PipelineCompiler] vkCreateDescriptorPool failed (max_sets=%u)\n",
                      max_sets);
         // Continue without input_sets — passes will still execute, just no

--- a/src/pipeline/render_pass_scheduler.cpp
+++ b/src/pipeline/render_pass_scheduler.cpp
@@ -1,5 +1,7 @@
 ﻿#include "pictor/pipeline/render_pass_scheduler.h"
 
+#include <cstdio>
+
 namespace pictor {
 
 RenderPassScheduler::RenderPassScheduler(const PipelineProfileDef& profile)
@@ -19,12 +21,13 @@ void RenderPassScheduler::register_custom_pass(ICustomRenderPass* pass) {
 }
 
 void RenderPassScheduler::execute(const BatchBuilder& batch_builder,
-                                   const CullingSystem& culling,
+                                   const CullingSystem& /*culling*/,
                                    GPUDrivenPipeline* gpu_pipeline) {
     const auto& batches = batch_builder.batches();
 
     for (const auto& pass_def : pass_order_) {
-        // Check for custom pass with matching name
+        // Registered custom passes run here — the only work the managed
+        // path executes itself (host-provided CPU-side logic).
         bool handled = false;
         for (auto* custom : custom_passes_) {
             if (pass_def.pass_name == custom->name()) {
@@ -35,66 +38,32 @@ void RenderPassScheduler::execute(const BatchBuilder& batch_builder,
         }
         if (handled) continue;
 
-        // Execute built-in pass types
-        switch (pass_def.pass_type) {
-            case PassType::COMPUTE:
-                if (pass_def.gpu_driven_pass && gpu_pipeline) {
-                    // GPU Driven compute passes are handled by GPUDrivenPipeline
-                    // The pipeline dispatches compute shaders for:
-                    // - ComputeUpdate, GPUCullPass, GPULODCompact
-                }
-                break;
+        // gpu_driven な COMPUTE pass は GPUDrivenPipeline::execute() が
+        // フレームループ側で別途担当する (pictor_renderer.cpp §7.2)。
+        if (pass_def.pass_type == PassType::COMPUTE &&
+            pass_def.gpu_driven_pass && gpu_pipeline) {
+            continue;
+        }
 
-            case PassType::SHADOW:
-                // Shadow pass: render shadow-casting geometry into the shadow atlas.
-                // Uses shadow-specific material variants (stripped to alpha test only).
-                //
-                // Vulkan implementation steps:
-                //   1. Remap batches to shadow pass variants (strip unused features)
-                //   2. Filter batches: only objects with CAST_SHADOW flag
-                //   3. For each cascade (0..cascadeCount-1):
-                //      a. Begin render pass (depth-only, shadow atlas layer as attachment)
-                //      b. Set viewport/scissor to cascade resolution
-                //      c. Bind shadow_depth pipeline
-                //      d. Bind cascade's lightViewProj via push constant
-                //      e. For each shadow batch:
-                //         - Push model matrix, cascade index, materialFlags, alphaCutoff
-                //         - Bind vertex/index buffers
-                //         - If alpha test: bind albedo texture to set=1, binding=0
-                //         - vkCmdDrawIndexed
-                //      f. End render pass
-                //   4. Transition shadow atlas to SHADER_READ_ONLY for fragment sampling
-                {
-                    auto shadow_batches = remap_batches_for_pass(batches, PassType::SHADOW);
-                    // Filter out non-shadow-casting batches
-                    // (materials without CAST_SHADOW feature will have zeroed shader key)
-                    (void)shadow_batches;
-                }
-                break;
+        // built-in pass の描画コマンド発行は managed 経路では行わない —
+        // コマンドバッファ / メッシュ VkBuffer / VkPipeline は host 所有
+        // (spec/pipeline-system-b-config.md §1.2)。 compiled graph が
+        // 設置済みなら host が execute_compiled() で同じ pass 構成を実描画
+        // しているので、 ここは委譲済みとして素通りしてよい。
+        if (has_compiled_graph()) continue;
 
-            case PassType::DEPTH_ONLY:
-                // Record depth-only pre-pass commands
-                break;
-
-            case PassType::OPAQUE:
-                // Record opaque geometry draw commands
-                // Shadow map is bound as set=2 for sampling
-                // Uses batches sorted front-to-back
-                break;
-
-            case PassType::TRANSPARENT:
-                // Record transparent geometry draw commands
-                // Shadow map is bound as set=2 for sampling
-                // Uses batches sorted back-to-front
-                break;
-
-            case PassType::POST_PROCESS:
-                // Execute post-process stack (full-screen passes)
-                break;
-
-            case PassType::CUSTOM:
-                // Unhandled custom pass (no matching ICustomRenderPass)
-                break;
+        // compiled graph 未設置 = 実描画経路がどこにも無い。 旧実装は空 case
+        // で無言 no-op だった (review/2026-06-11 D-2 「動いているように見えて
+        // 何もしない」)。 §7.1 に従い 1 回だけ明示 warn する。
+        if (!warned_unwired_builtin_) {
+            std::fprintf(stderr,
+                         "[RenderPassScheduler] execute(): built-in pass '%s' は "
+                         "managed 経路では描画されません。 host 側で "
+                         "PipelineCompiler::compile() (PictorRenderer::"
+                         "compile_render_graph) → execute_compiled() を配線して"
+                         "ください\n",
+                         pass_def.pass_name.c_str());
+            warned_unwired_builtin_ = true;
         }
     }
 }
@@ -169,37 +138,9 @@ void RenderPassScheduler::execute_compiled(VkCommandBuffer cmd,
 
 #endif // PICTOR_HAS_VULKAN
 
-std::vector<RenderBatch> RenderPassScheduler::remap_batches_for_pass(
-    const std::vector<RenderBatch>& batches,
-    PassType pass_type) const
-{
-    if (!material_registry_) return batches;
-
-    std::vector<RenderBatch> remapped;
-    remapped.reserve(batches.size());
-
-    for (const auto& batch : batches) {
-        RenderBatch rb = batch;
-
-        // Look up the pass-specific variant for this batch's material.
-        const auto* variant = material_registry_->variant_for(
-            static_cast<MaterialHandle>(batch.materialKey), pass_type);
-
-        if (variant) {
-            // For shadow pass: skip materials that don't cast shadows
-            if (pass_type == PassType::SHADOW &&
-                !(variant->features & MaterialFeature::CAST_SHADOW)) {
-                continue;
-            }
-
-            rb.shaderKey   = variant->shader_key;
-            rb.materialKey = variant->material_key;
-        }
-
-        remapped.push_back(rb);
-    }
-
-    return remapped;
-}
+// remap_batches_for_pass は削除 (review/2026-06-11 M-2): pass ごとの
+// std::vector 新規確保を伴う旧 managed 経路専用ヘルパで、 呼び手が D-2 の
+// 空スタブしか無かった。 pass 別 material variant 解決は
+// `CompiledBatchRecorder` がバッチ単位のインライン解決 (alloc なし) で行う。
 
 } // namespace pictor

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(PICTOR_TESTS
     unit_postprocess_chain_test
     unit_attachment_def_test
     unit_pipeline_registries_test
+    unit_compiled_graph_wiring_test
     unit_parser_dos_test
     unit_gpu_ring_flight_test
     unit_gpu_timer_test

--- a/tests/unit_animation_stub_contract_test.cpp
+++ b/tests/unit_animation_stub_contract_test.cpp
@@ -1,0 +1,64 @@
+#include "pictor/animation/lottie_animation.h"
+#include "pictor/animation/rive_animation.h"
+#include "pictor/c_api.h"
+#include "test_common.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+using namespace pictor_test;
+
+namespace {
+
+bool all_equal(const std::array<uint8_t, 16>& bytes, uint8_t value) {
+    for (uint8_t b : bytes) {
+        if (b != value) return false;
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    {
+        pictor::RiveAnimation rive;
+        const uint8_t fake_rive[] = {'R', 'I', 'V', 'E'};
+        PT_ASSERT(rive.load_memory(fake_rive, sizeof(fake_rive)), "Rive metadata load remains available");
+        PT_ASSERT(std::strstr(rive.error().c_str(), "runtime is not linked") != nullptr,
+                  "Rive load reports metadata-only mode");
+
+        std::array<uint8_t, 16> pixels;
+        pixels.fill(0x7f);
+        rive.render_to_buffer(pixels.data(), 2, 2);
+        PT_ASSERT(all_equal(pixels, 0x7f), "Rive render does not silently clear caller buffer");
+        PT_ASSERT(std::strstr(rive.error().c_str(), "unavailable") != nullptr,
+                  "Rive render reports unavailable backend");
+    }
+
+    {
+        pictor::LottieAnimation lottie;
+        PT_ASSERT(lottie.load_json(R"({"w":2,"h":2,"ip":0,"op":30,"fr":30})"),
+                  "Lottie metadata load remains available");
+        PT_ASSERT(std::strstr(lottie.error().c_str(), "runtime is not linked") != nullptr,
+                  "Lottie load reports metadata-only mode");
+
+        std::array<uint8_t, 16> pixels;
+        pixels.fill(0x55);
+        lottie.render_to_buffer(pixels.data(), 2, 2);
+        PT_ASSERT(all_equal(pixels, 0x55), "Lottie render does not silently clear caller buffer");
+        PT_ASSERT(std::strstr(lottie.error().c_str(), "unavailable") != nullptr,
+                  "Lottie render reports unavailable backend");
+    }
+
+    {
+        PictorRenderer* renderer =
+            pictor_create_renderer_vulkan(reinterpret_cast<void*>(0x1), reinterpret_cast<void*>(0x2));
+        PT_ASSERT(renderer == nullptr, "C API Vulkan renderer fails explicitly");
+        const char* err = pictor_last_error();
+        PT_ASSERT(err != nullptr && std::strstr(err, "not implemented") != nullptr,
+                  "C API Vulkan renderer reports not implemented");
+    }
+
+    return report("unit_animation_stub_contract_test");
+}

--- a/tests/unit_compiled_graph_wiring_test.cpp
+++ b/tests/unit_compiled_graph_wiring_test.cpp
@@ -1,0 +1,342 @@
+// unit_compiled_graph_wiring_test — 系統B compile → execute_compiled 配線の
+// headless 統合テスト (review/2026-06-11 D-2 / spec/pipeline-system-b-config.md §3.5)。
+//
+// 実 GPU (VkDevice) は使わない。 `PipelineCompiler::compile()` は
+// `device == VK_NULL_HANDLE` の headless モードで graph **構造** (pass 順序 /
+// pass_type / flags / clear / debug_name) を決定的に組み、
+// `execute_compiled()` は render_pass / framebuffer が VK_NULL_HANDLE の pass
+// を「record callback のみ」経路で回す — record 内容の検証までを対象とする
+// (vkCmdBeginRenderPass 等の実発行は KS / Custos の統合テスト側)。
+//
+// 検証対象:
+//   1. PipelineCompiler::compile() の headless 構造 (順序 / flags / clear)
+//   2. execute_compiled() が pass ごとに record を 1 回・宣言順で呼ぶこと
+//   3. CompiledPathDriver の engage / recompile / disengage ライフサイクル
+//   4. CompiledBatchRecorder の統計 (skip / 未実装 pass の明示計上、 §7.1)
+//   5. PictorRenderer::compile_render_graph() とプロファイル切替時の再 compile
+
+// `pipeline_profile.h` (and the core enums it pulls in) must be processed
+// before `vulkan.h` on Windows — see unit_pipeline_registries_test.cpp.
+#include "pictor/pipeline/attachment_def.h"
+#include "pictor/pipeline/pipeline_profile.h"
+
+#include "pictor/core/pictor_renderer.h"
+#include "pictor/pipeline/attachment_registry.h"
+#include "pictor/pipeline/compiled_batch_recorder.h"
+#include "pictor/pipeline/compiled_path_driver.h"
+#include "pictor/pipeline/framebuffer_registry.h"
+#include "pictor/pipeline/pipeline_compiler.h"
+#include "pictor/pipeline/render_pass_registry.h"
+#include "pictor/pipeline/render_pass_scheduler.h"
+#include "test_common.h"
+
+#include <cstring>
+#include <vector>
+
+using namespace pictor;
+using pictor_test::g_failures;
+
+#ifdef PICTOR_HAS_VULKAN
+
+namespace {
+
+// ---- fixture -------------------------------------------------------------
+
+/// OPAQUE → TRANSPARENT → POST_PROCESS(host_recorded, swapchain) → COMPUTE
+/// の 4 pass プロファイル。 built-in default attachments を使う。
+PipelineProfileDef make_test_profile() {
+    PipelineProfileDef def;
+    def.profile_name = "WiringTest";
+
+    auto atts = default_attachments();
+    def.attachments.assign(atts.begin(), atts.end());
+
+    RenderPassDef scene;
+    scene.pass_name      = "ScenePass";
+    scene.pass_type      = PassType::OPAQUE;
+    scene.render_targets = {"scene_hdr_color", "scene_depth"};
+    scene.sort_mode      = SortMode::FRONT_TO_BACK;
+    scene.filter_mask    = 0x00FF;
+
+    RenderPassDef transparent;
+    transparent.pass_name      = "TransparentPass";
+    transparent.pass_type      = PassType::TRANSPARENT;
+    transparent.render_targets = {"scene_hdr_color", "scene_depth"};
+    transparent.sort_mode      = SortMode::BACK_TO_FRONT;
+
+    RenderPassDef composite;
+    composite.pass_name      = "CompositePass";
+    composite.pass_type      = PassType::POST_PROCESS;
+    composite.render_targets = {"swapchain"};
+    composite.sort_mode      = SortMode::NONE;
+    composite.host_recorded  = true;
+
+    RenderPassDef compute;
+    compute.pass_name       = "GPUCullPass";
+    compute.pass_type       = PassType::COMPUTE;
+    compute.sort_mode       = SortMode::NONE;
+    compute.gpu_driven_pass = true;
+
+    def.render_passes = {scene, transparent, composite, compute};
+    return def;
+}
+
+struct Registries {
+    AttachmentRegistry  atts;
+    RenderPassRegistry  rps;
+    FramebufferRegistry fbs;
+
+    explicit Registries(const PipelineProfileDef& profile) {
+        atts.set_defs(profile.attachments);
+        rps.set_passes(profile.render_passes);
+        // fbs は initialize_vulkan しない (headless) — get() は常に
+        // VK_NULL_HANDLE を返し、 execute_compiled は record-only 経路になる。
+    }
+};
+
+// ---- 1. compile structure -------------------------------------------------
+
+void test_compile_structure() {
+    PipelineProfileDef profile = make_test_profile();
+    Registries reg(profile);
+
+    CompiledGraph g = PipelineCompiler::compile(profile, reg.atts, reg.rps,
+                                                reg.fbs, VK_NULL_HANDLE,
+                                                /*flight*/ 2, /*swap*/ 3);
+
+    PT_ASSERT(g.passes.size() == 4, "4 compiled passes");
+    PT_ASSERT(g.descriptor_pool == VK_NULL_HANDLE, "headless: no descriptor pool");
+    if (g.passes.size() != 4) return;
+
+    const CompiledPass& scene = g.passes[0];
+    PT_ASSERT(scene.pass_type == static_cast<uint8_t>(PassType::OPAQUE), "pass0 OPAQUE");
+    PT_ASSERT(scene.debug_name && std::strcmp(scene.debug_name, "ScenePass") == 0,
+              "pass0 debug_name");
+    PT_ASSERT(scene.filter_mask == 0x00FF, "pass0 filter_mask preserved");
+    PT_ASSERT(scene.sort_mode == static_cast<uint8_t>(SortMode::FRONT_TO_BACK),
+              "pass0 sort_mode");
+    PT_ASSERT(!scene.is_swapchain(), "pass0 not swapchain");
+    PT_ASSERT(!scene.is_compute(), "pass0 not compute");
+    PT_ASSERT(!scene.is_host_recorded(), "pass0 not host_recorded");
+    // clear 値は AttachmentDef から pre-resolve される (color + depth の 2 個)。
+    PT_ASSERT(scene.clear_count == 2, "pass0 two clear values");
+    PT_ASSERT(scene.clear_values[1].depthStencil.depth == 1.0f, "pass0 depth clear 1.0");
+
+    const CompiledPass& transparent = g.passes[1];
+    PT_ASSERT(transparent.pass_type == static_cast<uint8_t>(PassType::TRANSPARENT),
+              "pass1 TRANSPARENT");
+    PT_ASSERT(transparent.sort_mode == static_cast<uint8_t>(SortMode::BACK_TO_FRONT),
+              "pass1 sort_mode");
+
+    const CompiledPass& composite = g.passes[2];
+    PT_ASSERT(composite.pass_type == static_cast<uint8_t>(PassType::POST_PROCESS),
+              "pass2 POST_PROCESS");
+    PT_ASSERT(composite.is_swapchain(), "pass2 swapchain flag (targets 'swapchain')");
+    PT_ASSERT(composite.is_host_recorded(), "pass2 host_recorded flag");
+    // swapchain pass は per-image (swap=3)、 それ以外は per-flight (flight=2)。
+    PT_ASSERT(composite.framebuffer_count == 3, "pass2 per-image fb slots");
+    PT_ASSERT(scene.framebuffer_count == 2, "pass0 per-flight fb slots");
+
+    const CompiledPass& compute = g.passes[3];
+    PT_ASSERT(compute.pass_type == static_cast<uint8_t>(PassType::COMPUTE),
+              "pass3 COMPUTE");
+    PT_ASSERT(compute.is_compute(), "pass3 compute flag");
+}
+
+// ---- 2. execute_compiled record order --------------------------------------
+
+void test_execute_compiled_record_order() {
+    PipelineProfileDef profile = make_test_profile();
+    Registries reg(profile);
+
+    RenderPassScheduler scheduler(profile);
+    scheduler.set_compiled_graph(PipelineCompiler::compile(
+        profile, reg.atts, reg.rps, reg.fbs, VK_NULL_HANDLE, 2, 3));
+    PT_ASSERT(scheduler.has_compiled_graph(), "graph installed");
+
+    // headless: render_pass / framebuffer が全て VK_NULL_HANDLE なので、
+    // execute_compiled は Begin/End を発行せず record のみ呼ぶ (安全)。
+    std::vector<uint8_t> seen_types;
+    scheduler.execute_compiled(
+        VK_NULL_HANDLE, /*flight*/ 0, /*image*/ 0,
+        [&seen_types](VkCommandBuffer, const CompiledPass& cp,
+                      uint32_t flight, uint32_t image) {
+            PT_ASSERT(flight == 0 && image == 0, "frame indices forwarded");
+            seen_types.push_back(cp.pass_type);
+        });
+
+    PT_ASSERT(seen_types.size() == 4, "record called once per pass");
+    if (seen_types.size() == 4) {
+        PT_ASSERT(seen_types[0] == static_cast<uint8_t>(PassType::OPAQUE),       "order[0]");
+        PT_ASSERT(seen_types[1] == static_cast<uint8_t>(PassType::TRANSPARENT),  "order[1]");
+        PT_ASSERT(seen_types[2] == static_cast<uint8_t>(PassType::POST_PROCESS), "order[2]");
+        PT_ASSERT(seen_types[3] == static_cast<uint8_t>(PassType::COMPUTE),      "order[3]");
+    }
+
+    // take_compiled_graph で回収したら空 graph に戻り、 record は呼ばれない。
+    CompiledGraph taken = scheduler.take_compiled_graph();
+    PT_ASSERT(taken.passes.size() == 4, "taken graph carries passes");
+    PT_ASSERT(!scheduler.has_compiled_graph(), "scheduler empty after take");
+
+    uint32_t calls_after_take = 0;
+    scheduler.execute_compiled(VK_NULL_HANDLE, 0, 0,
+        [&calls_after_take](VkCommandBuffer, const CompiledPass&, uint32_t, uint32_t) {
+            calls_after_take++;
+        });
+    PT_ASSERT(calls_after_take == 0, "no record after take");
+
+    taken.shutdown(VK_NULL_HANDLE); // headless — pool 無し、 状態 clear のみ
+}
+
+// ---- 3. CompiledPathDriver lifecycle ---------------------------------------
+
+void test_driver_engage_recompile_disengage() {
+    PipelineProfileDef profile = make_test_profile();
+    Registries reg(profile);
+    RenderPassScheduler scheduler(profile);
+
+    CompiledPathDriver driver;
+    PT_ASSERT(!driver.engaged(), "initially disengaged");
+
+    // registry 欠落は明示的に失敗する (§7.1: 無言フォールバック禁止)。
+    CompiledPathDriver::Deps bad;
+    bad.device = VK_NULL_HANDLE;
+    PT_ASSERT(!driver.engage(bad, profile, scheduler), "missing deps -> false");
+    PT_ASSERT(!driver.engaged(), "still disengaged after failed engage");
+
+    CompiledPathDriver::Deps deps;
+    deps.device                = VK_NULL_HANDLE; // headless
+    deps.attachments           = &reg.atts;
+    deps.render_passes         = &reg.rps;
+    deps.framebuffers          = &reg.fbs;
+    deps.flight_count          = 2;
+    deps.swapchain_image_count = 3;
+
+    PT_ASSERT(driver.engage(deps, profile, scheduler), "engage ok");
+    PT_ASSERT(driver.engaged(), "engaged");
+    PT_ASSERT(scheduler.compiled_graph().passes.size() == 4, "4-pass graph installed");
+
+    // プロファイル切替: pass 構成の違う profile で recompile → graph 差し替え。
+    PipelineProfileDef lite = PipelineProfileManager::create_lite_profile();
+    PT_ASSERT(driver.recompile(lite, scheduler), "recompile ok");
+    PT_ASSERT(scheduler.compiled_graph().passes.size() == lite.render_passes.size(),
+              "graph re-compiled to Lite pass count");
+
+    driver.disengage(scheduler);
+    PT_ASSERT(!driver.engaged(), "disengaged");
+    PT_ASSERT(!scheduler.has_compiled_graph(), "graph released from scheduler");
+}
+
+// ---- 4. CompiledBatchRecorder stats ----------------------------------------
+
+/// GPU 実体を一切返さないスタブ (headless — vkCmd* を発行させない)。
+class NullGpuSource : public IBatchGpuSource {
+public:
+    uint32_t resolve_calls = 0;
+    uint64_t last_shader_key = 0;
+
+    bool resolve(const RenderBatch&, uint64_t shader_key, PassType,
+                 BatchGpuResources&) override {
+        resolve_calls++;
+        last_shader_key = shader_key;
+        return false;
+    }
+};
+
+void test_batch_recorder_stats() {
+    NullGpuSource source;
+    CompiledBatchRecorder recorder(source);
+
+    std::vector<RenderBatch> batches(3);
+    batches[0].shaderKey = 0xA1;
+    batches[1].shaderKey = 0xA2;
+    batches[2].shaderKey = 0xA3;
+    recorder.begin_frame(&batches);
+
+    // OPAQUE: バッチごとに resolve が呼ばれ、 実体なし → skip 計上・draw 0。
+    CompiledPass opaque{};
+    opaque.pass_type = static_cast<uint8_t>(PassType::OPAQUE);
+    recorder.record(VK_NULL_HANDLE, opaque, 0, 0);
+    PT_ASSERT(source.resolve_calls == 3, "resolve per batch");
+    PT_ASSERT(source.last_shader_key == 0xA3, "shader key forwarded (no registry)");
+    PT_ASSERT(recorder.stats().draw_calls == 0, "no draws without GPU resources");
+    PT_ASSERT(recorder.stats().batches_skipped == 3, "skips counted");
+
+    // SHADOW / DEPTH_ONLY: 未実装は無言 skip ではなく明示計上 (§7.1)。
+    CompiledPass shadow{};
+    shadow.pass_type = static_cast<uint8_t>(PassType::SHADOW);
+    recorder.record(VK_NULL_HANDLE, shadow, 0, 0);
+    CompiledPass depth{};
+    depth.pass_type = static_cast<uint8_t>(PassType::DEPTH_ONLY);
+    recorder.record(VK_NULL_HANDLE, depth, 0, 0);
+    PT_ASSERT(recorder.stats().passes_unimplemented == 2, "unimplemented counted");
+
+    // COMPUTE / POST_PROCESS は本 recorder の対象外として計上。
+    CompiledPass post{};
+    post.pass_type = static_cast<uint8_t>(PassType::POST_PROCESS);
+    recorder.record(VK_NULL_HANDLE, post, 0, 0);
+    PT_ASSERT(recorder.stats().passes_not_recorded == 1, "not-recorded counted");
+
+    // begin_frame で統計はリセットされる。
+    recorder.begin_frame(&batches);
+    PT_ASSERT(recorder.stats().batches_skipped == 0, "stats reset on begin_frame");
+}
+
+// ---- 5. PictorRenderer wiring ----------------------------------------------
+
+void test_renderer_wiring_and_profile_switch() {
+    PipelineProfileDef standard = PipelineProfileManager::create_standard_profile();
+    Registries reg(standard);
+
+    PictorRenderer renderer;
+    renderer.initialize(); // initial_profile = "Standard"
+
+    PT_ASSERT(!renderer.has_compiled_render_graph(), "no graph before compile");
+
+    bool ok = renderer.compile_render_graph(VK_NULL_HANDLE, reg.atts, reg.rps,
+                                            reg.fbs, /*flight*/ 2, /*swap*/ 3);
+    PT_ASSERT(ok, "compile_render_graph ok (headless)");
+    PT_ASSERT(renderer.has_compiled_render_graph(), "graph installed");
+
+    // プロファイル切替 → apply_profile 経由で自動再 compile (§3.5:
+    // 再 compile はプロファイル切替時のみ。 毎フレームではない)。
+    PipelineProfileDef lite = PipelineProfileManager::create_lite_profile();
+    PT_ASSERT(renderer.set_profile("Lite"), "switch to Lite");
+    PT_ASSERT(renderer.has_compiled_render_graph(), "graph survives profile switch");
+
+    // 切替後の graph が Lite の pass 構成 (5 pass) を反映していることを、
+    // record 呼び出し回数で観測する (headless record-only 経路)。
+    uint32_t record_calls = 0;
+    renderer.render_compiled(VK_NULL_HANDLE, 0, 0,
+        [&record_calls](VkCommandBuffer, const CompiledPass&, uint32_t, uint32_t) {
+            record_calls++;
+        });
+    PT_ASSERT(record_calls == lite.render_passes.size(),
+              "record count matches Lite pass count after re-compile");
+
+    renderer.release_render_graph();
+    PT_ASSERT(!renderer.has_compiled_render_graph(), "released");
+
+    renderer.shutdown();
+}
+
+} // anon
+
+int main() {
+    test_compile_structure();
+    test_execute_compiled_record_order();
+    test_driver_engage_recompile_disengage();
+    test_batch_recorder_stats();
+    test_renderer_wiring_and_profile_switch();
+    return pictor_test::report("unit_compiled_graph_wiring_test");
+}
+
+#else // !PICTOR_HAS_VULKAN
+
+// Vulkan 無しビルドでは compile 経路自体が存在しない (PipelineCompiler は
+// 空 graph スタブ)。 テスト対象外として素通しする。
+int main() {
+    return pictor_test::report("unit_compiled_graph_wiring_test");
+}
+
+#endif // PICTOR_HAS_VULKAN

--- a/tests/unit_public_animation_header_test.cpp
+++ b/tests/unit_public_animation_header_test.cpp
@@ -1,0 +1,20 @@
+#include "pictor/pictor.h"
+#include "test_common.h"
+
+#include <type_traits>
+
+using namespace pictor_test;
+
+int main() {
+    static_assert(std::is_class_v<pictor::MontagePlayer>);
+    static_assert(std::is_same_v<decltype(pictor::MontageDescriptor::clip), pictor::AnimationClipHandle>);
+
+    pictor::MontageDescriptor desc;
+    desc.sections.push_back(pictor::MontageSection{"main", 0.0f, 1.0f, ""});
+    desc.notifies.push_back(pictor::MontageNotify{0.5f, "hit"});
+
+    PT_ASSERT_OP(desc.sections.size(), ==, 1u, "MontageSection visible through pictor.h");
+    PT_ASSERT_OP(desc.notifies.size(), ==, 1u, "MontageNotify visible through pictor.h");
+
+    return report("unit_public_animation_header_test");
+}


### PR DESCRIPTION
## 概要

Pictor の「レンダリング処理の不完備」の中核を解消する。実装済みの `PipelineCompiler::compile()` + `RenderPassScheduler::execute_compiled()` は**呼び出し元がリポ内にゼロ**で、毎フレーム呼ばれる managed 経路 `execute()` は全 PassType が空スタブだった (review/2026-06-11 D-2 「動いているように見えるスタブ」)。

## 変更

### 1. compiled 経路の配線 (本命)
- **`CompiledPathDriver`** (新規): CompiledGraph のライフサイクル管理 (engage / recompile / disengage、旧 graph の descriptor pool 解放含む)。再 compile は `apply_profile()` 経由 = プロファイル切替時のみ (毎フレーム compile なし)
- **`PictorRenderer::compile_render_graph()` / `render_compiled()`** (新規公開 API): host のコマンドバッファ記録中に呼ぶ (コマンドバッファは host 所有 — spec §1.2)。PassRecordFn 版と recorder 版の 2 オーバーロード
- **`CompiledBatchRecorder`** (新規): OPAQUE/TRANSPARENT の RenderBatch を simple_renderer と同型の `vkCmdBindPipeline → vkCmdDrawIndexed` (instanced) で実記録。メッシュ VkBuffer/VkPipeline は `IBatchGpuSource` 抽象で host が解決 (DIP)。SHADOW/DEPTH_ONLY は未実装として**明示 warn + stats 計上** (§7.1 無言 skip 禁止)
- **`execute()` の非推奨化**: custom pass 実行のみに縮退。compiled graph 未設置で built-in pass に遭遇したら 1 回明示 warn (無言 no-op の解消)

### 2. 虚偽統計の是正 (D-2)
- draw call / triangle は recorder の実測値を profiler に集計。GPUDrivenPipeline の placeholder 統計 (`visible=count` / `draw_calls=1` の偽値) は「未計測=0 + 初回 warn」に変更

### 3. 便乗修復 (main のビルド破損)
- `fix/text-effects-missing` (6f35809) を cherry-pick — demo/text の push-constant std430 alignment ズレで outline/glow が silently off だった 4 月からのマージ漏れ
- main の tests/CMakeLists.txt が参照するアニメーション系テスト 2 件が未コミットで**テストビルド不能**だった (origin/fix/add-missing-animation-test-files = PR #96 と同一パッチ。どちらが先に入っても衝突しない)
- demo/postprocess が削除済み API `set_postprocess_config` を呼んでいてビルド不能 → 除去

### 4. headless テスト
- `unit_compiled_graph_wiring_test` (新規): `device==VK_NULL_HANDLE` ガードを PipelineCompiler に入れ、compile→execute_compiled の構造検証を GPU なしで実行

## 検証

- `cmake --build build --config Debug` exit 0 (lib + 全 demo + 全テスト、新規 warning なし)
- `ctest -C Debug`: **18/18 Passed** (新規テスト含む)
- no-run 規約遵守 (GUI/exe 起動なし)。実画面での確認はユーザ側作業

## スコープ外 (今後)

- SHADOW / DEPTH_ONLY の実描画 (cascade 別 lightViewProj・専用 pipeline 変種の解決手段が現データに無い。`IBatchGpuSource::resolve` の `pass_type` 引数が拡張点)
- GPUDrivenPipeline の compute dispatch 本実装 (統計だけ是正)
- KS 側での compile_render_graph 呼び出し配線 (別リポ・別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu8GLMYaMzvjT8tbVBNqnH