### PR TITLE
feat(pipeline): パイプライン途中編集 API + 品質 3 段階プリセット Low/Mid/High

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,10 @@ if(PICTOR_BUILD_DEMO AND Vulkan_FOUND AND Vulkan_GLSLC_EXECUTABLE)
         ${CMAKE_SOURCE_DIR}/demo/shaders/text_overlay.vert
         ${CMAKE_SOURCE_DIR}/demo/shaders/text_overlay.frag
         ${CMAKE_SOURCE_DIR}/shaders/postprocess/fullscreen_quad.vert
+        ${CMAKE_SOURCE_DIR}/shaders/postprocess/bloom_extract.frag
+        ${CMAKE_SOURCE_DIR}/shaders/postprocess/bloom_blur.frag
+        ${CMAKE_SOURCE_DIR}/shaders/postprocess/color_grade.frag
+        ${CMAKE_SOURCE_DIR}/shaders/postprocess/dof.frag
         ${CMAKE_SOURCE_DIR}/shaders/postprocess/bloom_extract.comp
         ${CMAKE_SOURCE_DIR}/shaders/postprocess/bloom_downsample.comp
         ${CMAKE_SOURCE_DIR}/shaders/postprocess/bloom_upsample.comp

--- a/include/pictor/pipeline/pipeline_profile.h
+++ b/include/pictor/pipeline/pipeline_profile.h
@@ -8,6 +8,7 @@
 #include "pictor/postprocess/postprocess_effect.h"
 #include "pictor/pipeline/attachment_def.h"
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace pictor {
@@ -132,6 +133,46 @@ struct PipelineProfileDef {
     uint8_t                    msaa_samples         = 0;
 };
 
+// ============================================================
+// パイプライン途中編集 API (§12 拡張)
+// ============================================================
+/// `PipelineProfileDef` の render_passes / post_process_stack を anchor 名
+/// 基準で「途中から」 組み替えるための編集操作。 プリセットをコピーして
+/// pass を差し込む / 抜く → `PictorRenderer::register_custom_profile()` +
+/// `set_profile()` (または active profile を直接編集して
+/// `reload_active_profile()`) で実行時にも反映できる — 再 compile は
+/// `CompiledPathDriver::recompile()` が面倒を見る。
+///
+/// post-process 側のチェーン構造 (`PostProcessChain`) の途中編集は
+/// `postprocess_chain.h` の `insert_post_process_pass()` 系を使う。
+
+/// `pass_name` を持つ render pass の index。 見つからなければ -1。
+int find_render_pass(const PipelineProfileDef& def, std::string_view pass_name);
+
+/// `anchor` の直前 / 直後へ `pass` を挿入する。 anchor 不在または同名 pass
+/// が既に存在する場合は false (プロファイルは不変)。
+bool insert_render_pass_before(PipelineProfileDef& def, std::string_view anchor,
+                               RenderPassDef pass);
+bool insert_render_pass_after(PipelineProfileDef& def, std::string_view anchor,
+                              RenderPassDef pass);
+
+/// `pass_name` を持つ render pass を取り除く。 見つからなければ false。
+bool remove_render_pass(PipelineProfileDef& def, std::string_view pass_name);
+
+/// `name` を持つ post-process エフェクトの index。 見つからなければ -1。
+int find_post_process(const PipelineProfileDef& def, std::string_view name);
+
+/// `anchor` の直前 / 直後へ `effect` を挿入する。 `kind` が UNKNOWN なら
+/// `post_process_kind_from_name()` で補完する。 anchor 不在または同名
+/// エフェクトが既に存在する場合は false。
+bool insert_post_process_before(PipelineProfileDef& def, std::string_view anchor,
+                                PostProcessDef effect);
+bool insert_post_process_after(PipelineProfileDef& def, std::string_view anchor,
+                               PostProcessDef effect);
+
+/// `name` を持つ post-process エフェクトを取り除く。 見つからなければ false。
+bool remove_post_process(PipelineProfileDef& def, std::string_view name);
+
 /// Pipeline profile manager (§8.4, §12).
 /// Provides built-in presets and supports custom profile registration.
 class PipelineProfileManager {
@@ -139,7 +180,7 @@ public:
     PipelineProfileManager();
     ~PipelineProfileManager();
 
-    /// Register built-in profiles (Lite, Standard, Ultra)
+    /// Register built-in profiles (Low/Mid/High + Lite/Standard/Ultra)
     void register_defaults();
 
     /// Register a custom profile (§12)
@@ -149,8 +190,8 @@ public:
     bool set_profile(const std::string& name);
 
     /// Get current profile
-    const PipelineProfileDef& current_profile() const { return *current_; }
-    const std::string& current_profile_name() const { return current_->profile_name; }
+    const PipelineProfileDef& current_profile() const { return profiles_[current_]; }
+    const std::string& current_profile_name() const { return profiles_[current_].profile_name; }
 
     /// Get profile by name
     const PipelineProfileDef* get_profile(const std::string& name) const;
@@ -163,6 +204,16 @@ public:
     static PipelineProfileDef create_standard_profile();
     static PipelineProfileDef create_ultra_profile();
 
+    /// 既定パイプラインの品質 3 段階 (§8.1 拡張)。 途中編集 API で
+    /// Low → Mid → High と段階的に組み上がる (= 差分がそのまま仕様):
+    ///   - Low : FORWARD 最小構成。 post は Tonemapping のみ。
+    ///   - Mid : Low + Shadow/DepthPre pass、 post に Bloom / Vignette。
+    ///   - High: Mid + FORWARD_PLUS 相当 (DepthPre → LightCull → shading) +
+    ///           SSAO、 post に DepthOfField (深度をチェーンへ捩じ込む)。
+    static PipelineProfileDef create_low_profile();
+    static PipelineProfileDef create_mid_profile();
+    static PipelineProfileDef create_high_profile();
+
     /// Mobile presets (§8.1 extension).
     /// MobileLow targets bandwidth-bound tile-based GPUs (no shadows, FORWARD, no MSAA).
     /// MobileHigh targets modern mobile SoCs (FORWARD, 1-cascade PCF shadows, light post-process).
@@ -170,8 +221,12 @@ public:
     static PipelineProfileDef create_mobile_high_profile();
 
 private:
+    static constexpr size_t kNoProfile = static_cast<size_t>(-1);
+
     std::vector<PipelineProfileDef> profiles_;
-    const PipelineProfileDef*       current_ = nullptr;
+    // profiles_ への index。 生ポインタだと register_profile() の push_back
+    // 再確保で dangling するため index で保持する。
+    size_t                          current_ = kNoProfile;
 };
 
 } // namespace pictor

--- a/include/pictor/pipeline/pipeline_profile_loader.h
+++ b/include/pictor/pipeline/pipeline_profile_loader.h
@@ -10,8 +10,9 @@ namespace pictor {
 // ============================================================
 // Pipeline profile loader — built-in presets from external JSON
 // ============================================================
-// The five built-in presets (Lite / Standard / Ultra / MobileLow /
-// MobileHigh) are described declaratively in profiles/*.profile.json.
+// The built-in presets (Low / Mid / High / Lite / Standard / Ultra /
+// MobileLow / MobileHigh) are described declaratively in
+// profiles/*.profile.json.
 // This loader reads those files at startup and falls back to the
 // hardcoded C++ factories in PipelineProfileManager when a file is
 // missing or fails to parse — so the engine is always bootable.
@@ -30,13 +31,14 @@ struct PresetLoadResult {
 /// Resolve a built-in preset by canonical name.
 /// Tries `<profile_dir>/<lowercased-name>.profile.json` first; on any
 /// failure returns the hardcoded C++ factory result instead.
-/// `name` is one of: Lite, Standard, Ultra, MobileLow, MobileHigh.
+/// `name` is one of: Low, Mid, High, Lite, Standard, Ultra, MobileLow,
+/// MobileHigh.
 /// `out_result` (optional) receives load diagnostics.
 PipelineProfileDef load_builtin_preset(const std::string& name,
                                        const std::string& profile_dir,
                                        PresetLoadResult*   out_result = nullptr);
 
-/// Load all five built-in presets, preferring JSON files under
+/// Load all built-in presets, preferring JSON files under
 /// `profile_dir`, falling back to C++ factories per-preset.
 /// `out_results` (optional) receives one PresetLoadResult per preset.
 std::vector<PipelineProfileDef> load_builtin_presets(

--- a/include/pictor/postprocess/postprocess_chain.h
+++ b/include/pictor/postprocess/postprocess_chain.h
@@ -27,6 +27,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace pictor {
@@ -102,6 +103,13 @@ extern const char* const kPostProcessSceneTarget;    // "__scene__"
 /// `PostProcessPipeline` が所有する LUT テクスチャに解決される。
 extern const char* const kPostProcessLutTarget;      // "__lut__"
 
+/// シーン深度 (D32_SFLOAT) を指す予約済みターゲット名。
+/// `PostProcessPassDef::inputs` にこの名前を入れると、 その binding は
+/// `PostProcessPipeline` の scene 深度ビューに解決される (NEAREST サンプラ)。
+/// DoF / SSAO 等、 深度をパイプライン途中で要求する pass 用。
+/// 入力専用 — `output` には使えない。
+extern const char* const kPostProcessDepthTarget;    // "__depth__"
+
 // ============================================================
 // PostProcessChain — pass 列 + 中間ターゲット集合
 // ============================================================
@@ -122,6 +130,53 @@ struct PostProcessChain {
 };
 
 // ============================================================
+// チェーン途中編集 API — anchor pass 名基準の挿入 / 削除
+// ============================================================
+/// パイプラインを「途中で」 変えるための編集操作。 `build_post_process_chain()`
+/// が返した (あるいはホストが組んだ) チェーンに対して、 既存 pass 名を anchor
+/// に指定して任意 pass を差し込む / 抜く。 編集後は
+/// `rebuild_intermediate_targets()` が自動で走り、 新 pass が参照する中間
+/// ターゲットが `intermediate_names` へ反映される。
+///
+/// 実行中のチェーンへ反映するには編集後に
+/// `PostProcessPipeline::rebuild_chain()` を呼ぶ (構造変更はフレーム間のみ。
+/// push constant だけの更新は `refresh_post_process_chain()` で足りる)。
+
+/// pass の挿入位置 — anchor の直前か直後か。
+enum class PassInsertWhere : uint8_t {
+    BEFORE = 0,
+    AFTER  = 1,
+};
+
+/// `name` を持つ pass の index を返す。 見つからなければ -1。
+int find_post_process_pass(const PostProcessChain& chain, std::string_view name);
+
+/// `anchor` の直前 / 直後へ `pass` を挿入する。 anchor が見つからない、
+/// または同名 pass が既に存在する場合は false (チェーンは不変)。
+bool insert_post_process_pass(PostProcessChain&  chain,
+                              PostProcessPassDef pass,
+                              std::string_view   anchor,
+                              PassInsertWhere    where);
+
+/// `name` を持つ pass を取り除く。 見つからなければ false。
+bool remove_post_process_pass(PostProcessChain& chain, std::string_view name);
+
+/// `pass_name` の入力のうち `old_target` を `new_target` へ張り替える。
+/// 途中挿入した pass の出力を下流に読ませる配線替え用
+/// (例: scene → dof 挿入後、 bloom の入力を dof 出力へ)。
+/// pass か old_target が見つからなければ false。
+bool rebind_post_process_input(PostProcessChain& chain,
+                               std::string_view  pass_name,
+                               std::string_view  old_target,
+                               std::string_view  new_target);
+
+/// 全 pass の inputs / output を走査し、 予約名 (__scene__ / __output__ /
+/// __lut__ / __depth__) 以外を出現順に `intermediate_names` へ収集し直す。
+/// 挿入 / 削除 API は内部で自動的に呼ぶ — 手で passes を編集した場合のみ
+/// 明示的に呼ぶこと。
+void rebuild_intermediate_targets(PostProcessChain& chain);
+
+// ============================================================
 // build_post_process_chain — 組み込みエフェクト → 汎用チェーン
 // ============================================================
 /// `PostProcessConfig` (= `build_post_process_config()` の出力) を汎用
@@ -137,6 +192,13 @@ struct PostProcessChain {
 ///   - grade   : scene + ping → output、 push = GradePC レイアウト
 /// disabled なエフェクトは旧実装と同じ「push constant で恒等へ縮退」 する
 /// (Bloom 無効 → threshold 1e9、 tonemap 無効 → LINEAR_CLAMP 等)。
+///
+/// `cfg.depth_of_field.enabled` のとき、 チェーン先頭へ DoF pass を途中挿入
+/// する (High プリセットの経路):
+///   - dof : scene + __depth__ → pp_dof、 push = DofPC レイアウト
+/// 以降の extract / grade は scene の代わりに pp_dof を読む (配線替え)。
+/// DoF 無効時のチェーンは従来の 4 pass とバイト単位で同一 — 有効 / 無効の
+/// 切替は構造変更なので `PostProcessPipeline::rebuild_chain()` を要する。
 ///
 /// `shader_dir`        : 組み込みシェーダ SPIR-V のディレクトリ。
 /// `extent_w/extent_h` : blur の texel ステップ計算に使う描画解像度。

--- a/include/pictor/postprocess/postprocess_pipeline.h
+++ b/include/pictor/postprocess/postprocess_pipeline.h
@@ -122,6 +122,24 @@ public:
     /// `output_views` are the new swapchain image views.
     bool resize(uint32_t width, uint32_t height,
                 const std::vector<VkImageView>& output_views);
+
+    /// チェーンの「構造」 をフレーム間で差し替える (パイプライン途中変更)。
+    /// pass の挿入 / 削除 / 配線替え (`insert_post_process_pass()` 等) を
+    /// 反映するときに呼ぶ。 push constant 値だけの変更なら `config_mut()` +
+    /// 毎フレームの `refresh_post_process_chain()` で足りるので不要。
+    ///
+    /// 内部で GPU idle を待ち、 ターゲット / pipeline / descriptor を作り直す
+    /// (render pass / sampler / LUT / layout キャッシュは維持)。 resize と
+    /// 同じく scene ターゲットも再生成されるため、 呼出し後は
+    /// `scene_framebuffer()` / `scene_color_view()` / `scene_depth_view()` を
+    /// 取り直すこと。 `output_views` は現在の swapchain image views。
+    /// 失敗時は false (パイプラインは未初期化状態へ倒れる)。
+    bool rebuild_chain(const PostProcessChain& chain,
+                       const std::vector<VkImageView>& output_views);
+
+    /// 現在のチェーン記述。 コピーして編集 API で組み替え、
+    /// `rebuild_chain()` へ渡す用。
+    const PostProcessChain& chain() const { return chain_; }
 #endif
 
     void shutdown();
@@ -162,7 +180,7 @@ private:
         VkDescriptorSet       desc_set    = VK_NULL_HANDLE;
         uint32_t              input_count = 0;               ///< descriptor binding 数
         int32_t               output_index = -1;             ///< targets_ index / -1=swapchain
-        std::vector<int32_t>  input_indices;                 ///< targets_ index 列
+        std::vector<int32_t>  input_indices;                 ///< targets_ index 列 (-1=LUT / -2=scene depth)
         std::vector<uint8_t>  push_data;
         uint32_t              push_size = 0;
     };
@@ -183,6 +201,9 @@ private:
                                                 uint32_t push_size);
     bool create_pipelines_();
     bool create_output_framebuffers_(const std::vector<VkImageView>& views);
+    /// resize / rebuild_chain 共通のチェーン依存リソース破棄 (targets /
+    /// output framebuffers / pipelines / descriptor pool)。 GPU idle 前提。
+    void destroy_chain_resources_();
     VkShaderModule load_shader_(const std::string& path) const;
     uint32_t find_memory_type_(uint32_t filter, VkMemoryPropertyFlags props) const;
     /// 論理ターゲット名 → targets_ index。 不明名は -1。
@@ -212,6 +233,9 @@ private:
     Texture   lut_{};
     bool      lut_loaded_ = false;
     VkSampler sampler_ = VK_NULL_HANDLE;
+    // 深度入力 (__depth__) 用 NEAREST サンプラ。 D32 は LINEAR filter 対応が
+    // 保証されないため color 用の sampler_ と分ける。
+    VkSampler depth_sampler_ = VK_NULL_HANDLE;
 
     VkDescriptorPool desc_pool_ = VK_NULL_HANDLE;
     // input 数 → descriptor set layout。 組み込みチェーンは 1 と 3 を使う。

--- a/profiles/high.profile.json
+++ b/profiles/high.profile.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "profile_name": "High",
+  "rendering_path": "FORWARD_PLUS",
+  "max_lights": 256,
+  "msaa_samples": 0,
+  "gpu_driven_enabled": true,
+  "compute_update_enabled": false,
+  "render_passes": [
+    { "pass_name": "ShadowPass",      "pass_type": "SHADOW",       "sort_mode": "NONE",          "required_streams": ["bounds", "transforms"] },
+    { "pass_name": "DepthPrePass",    "pass_type": "DEPTH_ONLY",   "sort_mode": "FRONT_TO_BACK", "required_streams": ["bounds", "transforms"] },
+    { "pass_name": "LightCullPass",   "pass_type": "COMPUTE",      "sort_mode": "NONE" },
+    { "pass_name": "SSAOGen",         "pass_type": "COMPUTE",      "sort_mode": "NONE" },
+    { "pass_name": "OpaquePass",      "pass_type": "OPAQUE",       "sort_mode": "FRONT_TO_BACK", "required_streams": ["transforms", "shaderKeys"] },
+    { "pass_name": "TransparentPass", "pass_type": "TRANSPARENT",  "sort_mode": "BACK_TO_FRONT", "required_streams": ["transforms", "sortKeys"] },
+    { "pass_name": "PostProcess",     "pass_type": "POST_PROCESS", "sort_mode": "NONE" }
+  ],
+  "post_process": [
+    { "name": "DepthOfField", "enabled": true,
+      "depth_of_field": {
+        "enabled": true,
+        "focus_distance": 10.0,
+        "focus_range": 5.0,
+        "bokeh_radius": 4.0,
+        "near_start": 0.0,
+        "near_end": 3.0,
+        "far_start": 15.0,
+        "far_end": 50.0,
+        "sample_count": 16
+      }
+    },
+    { "name": "Bloom",       "enabled": true },
+    { "name": "Tonemapping", "enabled": true },
+    { "name": "Vignette",    "enabled": true }
+  ],
+  "shadow": {
+    "cascade_count": 3,
+    "resolution": 2048,
+    "filter_mode": "PCF"
+  },
+  "gi": {
+    "shadow_enabled": true,
+    "ssao_enabled": true,
+    "gi_probes_enabled": false,
+    "shadow": {
+      "cascade_count": 3,
+      "resolution": 2048,
+      "depth_bias": 0.005,
+      "filter_mode": "PCF"
+    },
+    "ssao": {
+      "sample_count": 32,
+      "radius": 0.5,
+      "intensity": 1.0
+    }
+  },
+  "memory": {
+    "frame_allocator_size": 16777216,
+    "flight_count": 3,
+    "gpu": {
+      "mesh_pool_size": 268435456,
+      "ssbo_pool_size": 134217728
+    }
+  },
+  "gpu_driven": {
+    "max_triangle_count": 50000,
+    "min_instance_count": 32,
+    "compute_update": false
+  },
+  "update": {
+    "chunk_size": 16384,
+    "nt_store_enabled": false
+  },
+  "profiler": {
+    "enabled": true,
+    "overlay_mode": "STANDARD"
+  }
+}

--- a/profiles/low.profile.json
+++ b/profiles/low.profile.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "profile_name": "Low",
+  "rendering_path": "FORWARD",
+  "max_lights": 16,
+  "msaa_samples": 0,
+  "gpu_driven_enabled": false,
+  "compute_update_enabled": false,
+  "render_passes": [
+    { "pass_name": "OpaquePass",      "pass_type": "OPAQUE",       "sort_mode": "FRONT_TO_BACK", "required_streams": ["transforms", "shaderKeys"] },
+    { "pass_name": "TransparentPass", "pass_type": "TRANSPARENT",  "sort_mode": "BACK_TO_FRONT", "required_streams": ["transforms", "sortKeys"] },
+    { "pass_name": "PostProcess",     "pass_type": "POST_PROCESS", "sort_mode": "NONE" }
+  ],
+  "post_process": [
+    { "name": "Tonemapping", "enabled": true }
+  ],
+  "shadow": {
+    "cascade_count": 0,
+    "resolution": 0,
+    "filter_mode": "NONE"
+  },
+  "gi": {
+    "shadow_enabled": false,
+    "ssao_enabled": false,
+    "gi_probes_enabled": false
+  },
+  "memory": {
+    "frame_allocator_size": 4194304,
+    "flight_count": 2
+  },
+  "gpu_driven": {
+    "compute_update": false
+  },
+  "update": {
+    "chunk_size": 16384,
+    "nt_store_enabled": false
+  },
+  "profiler": {
+    "enabled": true,
+    "overlay_mode": "MINIMAL"
+  }
+}

--- a/profiles/mid.profile.json
+++ b/profiles/mid.profile.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "profile_name": "Mid",
+  "rendering_path": "FORWARD",
+  "max_lights": 64,
+  "msaa_samples": 2,
+  "gpu_driven_enabled": false,
+  "compute_update_enabled": false,
+  "render_passes": [
+    { "pass_name": "ShadowPass",      "pass_type": "SHADOW",       "sort_mode": "NONE",          "required_streams": ["bounds", "transforms"] },
+    { "pass_name": "DepthPrePass",    "pass_type": "DEPTH_ONLY",   "sort_mode": "FRONT_TO_BACK", "required_streams": ["bounds", "transforms"] },
+    { "pass_name": "OpaquePass",      "pass_type": "OPAQUE",       "sort_mode": "FRONT_TO_BACK", "required_streams": ["transforms", "shaderKeys"] },
+    { "pass_name": "TransparentPass", "pass_type": "TRANSPARENT",  "sort_mode": "BACK_TO_FRONT", "required_streams": ["transforms", "sortKeys"] },
+    { "pass_name": "PostProcess",     "pass_type": "POST_PROCESS", "sort_mode": "NONE" }
+  ],
+  "post_process": [
+    { "name": "Bloom",       "enabled": true },
+    { "name": "Tonemapping", "enabled": true },
+    { "name": "Vignette",    "enabled": true }
+  ],
+  "shadow": {
+    "cascade_count": 2,
+    "resolution": 2048,
+    "filter_mode": "PCF"
+  },
+  "gi": {
+    "shadow_enabled": true,
+    "ssao_enabled": false,
+    "gi_probes_enabled": false,
+    "shadow": {
+      "cascade_count": 2,
+      "resolution": 2048,
+      "depth_bias": 0.005,
+      "filter_mode": "PCF"
+    }
+  },
+  "memory": {
+    "frame_allocator_size": 8388608,
+    "flight_count": 3,
+    "gpu": {
+      "mesh_pool_size": 134217728,
+      "ssbo_pool_size": 67108864
+    }
+  },
+  "gpu_driven": {
+    "compute_update": false
+  },
+  "update": {
+    "chunk_size": 16384,
+    "nt_store_enabled": false
+  },
+  "profiler": {
+    "enabled": true,
+    "overlay_mode": "STANDARD"
+  }
+}

--- a/review/2026-07-09/latest.json
+++ b/review/2026-07-09/latest.json
@@ -1,5 +1,5 @@
 {
-  "format_version": 1,
+  "format_version": 2,
   "repo": "LUDIARS/Pictor",
   "date": "2026-07-09",
   "style": "game",

--- a/review/2026-07-09/latest.json
+++ b/review/2026-07-09/latest.json
@@ -1,4 +1,5 @@
 {
+  "format_version": 1,
   "repo": "LUDIARS/Pictor",
   "date": "2026-07-09",
   "style": "game",

--- a/review/2026-07-09/latest.json
+++ b/review/2026-07-09/latest.json
@@ -5,20 +5,27 @@
   "style": "game",
   "weighted_score": "B",
   "scores": {
-    "vulnerability": "B",
-    "design_strength": "A",
+    "design_robustness": "A",
     "design_consistency": "B",
     "modularity": "A",
     "code_quality": "B",
-    "data_schema": "A",
-    "sre": "B",
-    "zero_trust": null,
-    "security": "B",
-    "test_strategy": "B",
-    "performance": "B",
+    "code_vulnerability": "B",
+    "cicd_supply_chain": null,
+    "test_coverage": "B",
     "license": "A",
-    "cross_platform": "B",
-    "documentation": "A"
+    "documentation": "A",
+    "llm_security": null,
+    "ai_code_acceptance": null,
+    "client_trust_boundary": null,
+    "anti_cheat": null,
+    "save_monetization_integrity": null,
+    "multiplayer_networking": null,
+    "save_data_design": null,
+    "asset_management": null,
+    "data_driven_design": "A",
+    "game_performance": "B",
+    "platform_compatibility": "B",
+    "accessibility_localization": null
   },
   "critical_count": 0,
   "high_count": 1,
@@ -33,5 +40,5 @@
     "dead_code": 1
   },
   "fix_pr": "https://github.com/LUDIARS/Pictor/pull/98",
-  "note": "設計 + 実装ギャップの追跡診断 (Fable)。vulnerability / sre / security / cross_platform は今回未再査 (前回 2026-06-11 の値を継続)。前回 38 指摘中 10 件が #80/#97 で修正済みを確認、残存 12 件 + 新規 High 1 件 (GIBakeSystem UAF) 含む 25 項目を自動修正 (回帰テスト 1 追加、ctest 19/19)。High 1 = 新規 N-H1 (修正済み)。詳細: review/2026-07-09/REVIEW.md"
+  "note": "設計 + 実装ギャップの追跡診断 (Fable)。vulnerability / sre / security / cross_platform は今回未再査 (前回 2026-06-11 の値を継続)。前回 38 指摘中 10 件が #80/#97 で修正済みを確認、残存 12 件 + 新規 High 1 件 (GIBakeSystem UAF) 含む 25 項目を自動修正 (回帰テスト 1 追加、ctest 19/19)。High 1 = 新規 N-H1 (修正済み)。詳細: review/2026-07-09/REVIEW.md / format_version 2 移行: scores を game 21 観点へ改名マッピング (design_strength→design_robustness, vulnerability→code_vulnerability, test_strategy→test_coverage, data_schema→data_driven_design, performance→game_performance, cross_platform→platform_compatibility)。旧 sre/zero_trust/security は game 体系に対応観点なし。新設観点 (cicd_supply_chain/llm_security/ai_code_acceptance/ゲーム固有 6 観点/accessibility_localization) は未評価のため null。"
 }

--- a/review/latest.json
+++ b/review/latest.json
@@ -1,5 +1,5 @@
 {
-  "format_version": 1,
+  "format_version": 2,
   "repo": "LUDIARS/Pictor",
   "date": "2026-07-09",
   "style": "game",

--- a/review/latest.json
+++ b/review/latest.json
@@ -1,4 +1,5 @@
 {
+  "format_version": 1,
   "repo": "LUDIARS/Pictor",
   "date": "2026-07-09",
   "style": "game",

--- a/review/latest.json
+++ b/review/latest.json
@@ -5,20 +5,27 @@
   "style": "game",
   "weighted_score": "B",
   "scores": {
-    "vulnerability": "B",
-    "design_strength": "A",
+    "design_robustness": "A",
     "design_consistency": "B",
     "modularity": "A",
     "code_quality": "B",
-    "data_schema": "A",
-    "sre": "B",
-    "zero_trust": null,
-    "security": "B",
-    "test_strategy": "B",
-    "performance": "B",
+    "code_vulnerability": "B",
+    "cicd_supply_chain": null,
+    "test_coverage": "B",
     "license": "A",
-    "cross_platform": "B",
-    "documentation": "A"
+    "documentation": "A",
+    "llm_security": null,
+    "ai_code_acceptance": null,
+    "client_trust_boundary": null,
+    "anti_cheat": null,
+    "save_monetization_integrity": null,
+    "multiplayer_networking": null,
+    "save_data_design": null,
+    "asset_management": null,
+    "data_driven_design": "A",
+    "game_performance": "B",
+    "platform_compatibility": "B",
+    "accessibility_localization": null
   },
   "critical_count": 0,
   "high_count": 1,
@@ -33,5 +40,5 @@
     "dead_code": 1
   },
   "fix_pr": "https://github.com/LUDIARS/Pictor/pull/98",
-  "note": "設計 + 実装ギャップの追跡診断 (Fable)。vulnerability / sre / security / cross_platform は今回未再査 (前回 2026-06-11 の値を継続)。前回 38 指摘中 10 件が #80/#97 で修正済みを確認、残存 12 件 + 新規 High 1 件 (GIBakeSystem UAF) 含む 25 項目を自動修正 (回帰テスト 1 追加、ctest 19/19)。High 1 = 新規 N-H1 (修正済み)。詳細: review/2026-07-09/REVIEW.md"
+  "note": "設計 + 実装ギャップの追跡診断 (Fable)。vulnerability / sre / security / cross_platform は今回未再査 (前回 2026-06-11 の値を継続)。前回 38 指摘中 10 件が #80/#97 で修正済みを確認、残存 12 件 + 新規 High 1 件 (GIBakeSystem UAF) 含む 25 項目を自動修正 (回帰テスト 1 追加、ctest 19/19)。High 1 = 新規 N-H1 (修正済み)。詳細: review/2026-07-09/REVIEW.md / format_version 2 移行: scores を game 21 観点へ改名マッピング (design_strength→design_robustness, vulnerability→code_vulnerability, test_strategy→test_coverage, data_schema→data_driven_design, performance→game_performance, cross_platform→platform_compatibility)。旧 sre/zero_trust/security は game 体系に対応観点なし。新設観点 (cicd_supply_chain/llm_security/ai_code_acceptance/ゲーム固有 6 観点/accessibility_localization) は未評価のため null。"
 }

--- a/shaders/postprocess/dof.frag
+++ b/shaders/postprocess/dof.frag
@@ -1,0 +1,103 @@
+// Pictor — Depth of Field (fullscreen fragment pass)
+// PostProcessChain 用の dof.comp 移植。 CoC 計算 + Poisson disc ブラー +
+// 合成を 1 pass で行う。 binding 0 = シーンカラー (HDR)、
+// binding 1 = シーン深度 (__depth__、 NEAREST サンプラ)。
+// bokeh_radius = 0 (DoF 無効) のとき CoC が常に 0.5 未満になり素通しする。
+
+#version 450
+
+layout(location = 0) in  vec2 inUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D sceneColor;
+layout(set = 0, binding = 1) uniform sampler2D sceneDepth;
+
+layout(push_constant) uniform DofPC {
+    float focus_distance;
+    float focus_range;
+    float bokeh_radius;
+    float near_start;
+    float near_end;
+    float far_start;
+    float far_end;
+    uint  sample_count;
+    float texel_x;
+    float texel_y;
+    float _pad0;
+    float _pad1;
+};
+
+// Poisson disc samples (16 points, normalized to unit disc) — dof.comp と同一。
+const vec2 poissonDisc[16] = vec2[](
+    vec2(-0.94201,  -0.39906),
+    vec2( 0.94558,  -0.76890),
+    vec2(-0.09418,  -0.92938),
+    vec2( 0.34495,   0.29387),
+    vec2(-0.91588,   0.45771),
+    vec2(-0.81544,  -0.87912),
+    vec2( 0.19984,  -0.29614),
+    vec2(-0.24188,   0.99706),
+    vec2( 0.44323,   0.93427),
+    vec2( 0.78583,   0.00399),
+    vec2(-0.52389,  -0.22294),
+    vec2( 0.36291,  -0.67380),
+    vec2(-0.54532,   0.63536),
+    vec2( 0.13980,   0.56616),
+    vec2(-0.30654,  -0.60812),
+    vec2( 0.74882,   0.56394)
+);
+
+float computeCoC(float depth) {
+    // Near field (negative CoC)
+    float nearCoC = smoothstep(near_end, near_start, depth);
+    // Far field (positive CoC)
+    float farCoC = smoothstep(far_start, far_end, depth);
+
+    // Focus region
+    float halfRange = focus_range * 0.5;
+    if (depth >= focus_distance - halfRange && depth <= focus_distance + halfRange) {
+        return 0.0;
+    }
+
+    return depth < focus_distance ? -nearCoC * bokeh_radius : farCoC * bokeh_radius;
+}
+
+void main() {
+    vec2 texelSize = vec2(texel_x, texel_y);
+
+    float centerDepth = texture(sceneDepth, inUV).r;
+    float coc = computeCoC(centerDepth);
+    float absCoC = abs(coc);
+
+    // If CoC is negligible, output sharp color
+    vec3 sharp = texture(sceneColor, inUV).rgb;
+    if (absCoC < 0.5) {
+        outColor = vec4(sharp, 1.0);
+        return;
+    }
+
+    // Variable-radius disc blur
+    vec3 colorSum = vec3(0.0);
+    float weightSum = 0.0;
+    uint samples = min(sample_count, 16u);
+
+    for (uint i = 0u; i < samples; ++i) {
+        vec2 offset = poissonDisc[i] * absCoC * texelSize;
+        vec2 sampleUV = inUV + offset;
+
+        vec3 sampleColor = texture(sceneColor, sampleUV).rgb;
+        float sampleDepth = texture(sceneDepth, sampleUV).r;
+        float sampleCoC = abs(computeCoC(sampleDepth));
+
+        // Weight: accept sample if its CoC covers the center pixel
+        float weight = smoothstep(0.0, 2.0, sampleCoC);
+        colorSum += sampleColor * weight;
+        weightSum += weight;
+    }
+
+    vec3 blurred = colorSum / max(weightSum, 0.001);
+
+    // Blend between sharp and blurred based on CoC magnitude
+    float blendFactor = smoothstep(0.5, 2.0, absCoC);
+    outColor = vec4(mix(sharp, blurred, blendFactor), 1.0);
+}

--- a/spec/plan/pipeline-design-review-2026-07-12.md
+++ b/spec/plan/pipeline-design-review-2026-07-12.md
@@ -1,0 +1,159 @@
+# レンダリングパイプライン設計レビュー実装資料 (2026-07-12)
+
+> 2026-07-12 起草。PR #99 (パイプライン途中編集 API + Low/Mid/High プリセット) と同時に実施した
+> レンダリングパイプライン全体の設計レビューを、次の実装作業の資料として整理したもの。
+> 前回レビュー: [`review/2026-07-09/`](../../review/2026-07-09/REVIEW.md)。既知指摘は状態のみ記載し重複させない。
+> 関連: [`rendering-extensibility-design.md`](../feature/rendering-extensibility-design.md)、
+> [`pipeline-system-b-config.md`](../feature/pipeline-system-b-config.md)。
+
+## 1. 総評
+
+系統A (宣言 profile) → 系統B (compiled flat 実行) の 2 層構造は健全。hot path の flat 化、
+名前解決の compile 時一括化、「無言 no-op 禁止」(warn + 専用 stat、§7.1) は一貫している。
+
+主要リスクは 2 つ:
+
+1. **宣言スキーマが実装より大きく先行** — profile の約半分のフィールドがランタイム未消費。
+2. **registry ↔ CompiledGraph の再構築を束ねる調整層の不在** — resize / 差し替えの順序が
+   暗黙契約のままで、dangling VkHandle の窓がある。
+
+## 2. 宣言と実体のギャップ (現状マップ)
+
+| 宣言 | 実体 | 根拠 |
+|---|---|---|
+| `rendering_path` (FORWARD_PLUS 等) | 未消費。ランタイム分岐ゼロ | 消費点は serializer / builder の round-trip のみ |
+| `max_lights` | 未消費。動的ライト配列自体が無い (実ライトは directional 1 灯 `gi_lighting_system.h:244`) | `PointLight` は GI bake 用データ型のみ |
+| `msaa_samples` | 未消費。VkPipeline multisample state に反映されない | `pipeline_compiler.cpp` は multisample を profile から組まない |
+| `LightCullPass` (High プリセット) | compute shader / dispatch とも存在しない。host record 前提の空 COMPUTE pass 宣言 | `shaders/` に light cull / tile / cluster 系 `.comp` なし |
+| SSAO / Shadow / GI probe | CPU 計算 (カスケード行列等) まで実装、GPU 発行は全てコメントアウト | `gi_lighting_system.cpp:266-399` の各 `execute_*` |
+| `post_process_stack` | `apply_profile()` は触れない。`PostProcessPipeline` は PictorRenderer 非統合、リポジトリ内プロダクション呼び出し元なし (tests のみ)。`demo/postprocess` も実チェーン不使用 (自前シェーダ近似) | `pictor_renderer.h:295-298` に host 責務と明記 |
+| `memory_config` | initialize 時のみ。profile 切替で反映されない (flight_count を変えても効かない) | `renderer_subsystem_manager.cpp:16` |
+
+補足:
+
+- Forward+ は現状「pass 列の宣言」であって実装ではない。High プリセットの `LightCullPass` /
+  `SSAOGen` は Standard の `HiZBuild` / `GPUCullPass` と同種の Phase 4 待ち宣言で、プリセット間の
+  整合は取れているが実体はない。
+- High の DoF はチェーン実装が存在する (`build_post_process_chain()` の dof pass +
+  `__depth__` 入力 + `dof.frag`)。ただし host が `PostProcessPipeline::initialize_vulkan()` /
+  `record()` を駆動して初めて動く。
+
+## 3. 指摘一覧
+
+### High
+
+**H-1. GI 系の正直性の非対称 (§7.1 違反)**
+GPU-driven パイプラインは「未実装は warn + 未計測 0」に是正済み (2026-06-11 D-2) だが、
+GI 系 (`gi_lighting_system.cpp` の `execute_shadow_pass` / `execute_ssao_pass` /
+`execute_gi_probe_pass`) は **dispatch を発行していないのに `shadow_casters` 等の stats へ
+見かけ上の値を書き、warn も出さない**。プロファイラを信じた性能判断を誤らせる。
+`upload_probe_data` も SH データを捨てて `stats_.active_probes` だけ書く (`:252-256`)。
+
+**H-2. resize 時の VkFramebuffer dangling 窓 (順序依存の暗黙契約)**
+`PipelineCompiler` は framebuffer handle を `CompiledPass` へ値コピーする
+(`pipeline_compiler.cpp:181-183`)。host が `FramebufferRegistry::resize()` (旧 fb を destroy、
+`framebuffer_registry.cpp:145-148`) を呼んで再 compile を忘れると、次の `execute_compiled` が
+破棄済み framebuffer で `vkCmdBeginRenderPass` → use-after-free。
+「atts.resize → fbs.resize → 再 compile」の 3 段順序を強制する調整層がない。
+`AttachmentRegistry::set_defs` / `RenderPassRegistry::set_passes` の内部 `shutdown_vulkan` も
+他 registry / CompiledGraph へ伝播しない。
+
+**H-3. filter_mask 無視による opaque/transparent 二重描画 (既知 N-M2 残存)**
+compile は `cp.filter_mask` を格納する (`pipeline_compiler.cpp:157`) が、
+`CompiledBatchRecorder::record_batches_` は `*batches_` を無フィルタ走査
+(`compiled_batch_recorder.cpp:100-151`)。OPAQUE / TRANSPARENT 両 pass を含む profile
+(Lite/Standard/Ultra/Low/Mid/High 全て) で全バッチ二重描画。`sort_mode` も宣言のみ未適用
+(`compiled_batch_recorder.cpp:96-97` が自認)。前回レビュー最優先アクションのまま。
+
+### Medium
+
+**M-1. pass の安定 ID が無い — Forward+ 実装の前提欠落**
+hot path の pass 識別子は `pass_type` (uint8) のみで、`debug_name` は「hot path で読まない」
+契約 (`compiled_graph.h:66-68`)。COMPUTE pass が 2 つ以上ある profile (High の LightCullPass /
+SSAOGen) では、host の `PassRecordFn` が両者を区別する正当な手段がなく、debug_name の
+per-frame strcmp (DoD 違反) を強いられる。**LightCullPass の実装より先に解決が必要。**
+
+**M-2. 未消費フィールドの「偽の構成可能性」**
+`rendering_path` / `max_lights` / `msaa_samples` は設定できるのに何も変えない。
+apply_profile 時に一回 warn するか、ヘッダに未配線と明記すべき
+(spec/feature/pipeline-profile-config.md:359 は値域検証を将来送りにしている)。
+
+**M-3. 未実装 SHADOW/DEPTH pass の空 Begin/End**
+render_pass / framebuffer が生成されるため `execute_compiled` が Begin/End + depth clear を
+毎フレーム発行するが recorder は draw を出さない (`compiled_batch_recorder.cpp:21-47`)。
+GPU 時間を捨てながら「動いて見える」。
+
+**M-4. profile 切替で GPU リソースサイズが追従しない**
+`GILightingSystem::set_config` は config 差し替えのみで shadow atlas 等の再確保をしない
+(`gi_lighting_system.cpp:258-260`)。cascade_count / resolution を切替えても既存インスタンス
+では GPU リソースが旧サイズのまま。`memory_config` も同様に切替非対応 (§2 参照)。
+
+### Low
+
+**L-1. `std::array<VkFramebuffer,4>` 固定上限**
+swapchain image 数 > 4 で該当 image への描画が黙って落ちる (`pipeline_compiler.cpp:179`、
+fb=NULL → BeginRenderPass せず `render_pass_scheduler.cpp:112-117`)。clear_values の 8 上限も
+同様 (`pipeline_compiler.cpp:59`)。compile 時に超過を error 化すべき。
+
+**L-2. 未知 attachment への寛容度が層で不一致**
+compiler / `fill_clear_values` は warn なし zero-clear で続行 (`pipeline_compiler.cpp:61-65`)、
+registry 側は build 失敗 (`render_pass_registry.cpp:99-103`、`framebuffer_registry.cpp:48-52`)。
+同じ設定ミスの現れ方が層で変わり診断を難しくする。
+
+**L-3. render_area の width/height 混成**
+最初の非ゼロ width と非ゼロ height を独立に採用するため、サイズの異なる複数 target を
+混ぜると width と height が別 attachment 由来になりうる (`pipeline_compiler.cpp:87-94`、
+`framebuffer_registry.cpp:59-60`)。
+
+**L-4. RenderPassScheduler の責務过多 + managed 経路の per-frame 文字列比較 (既知 L-5)**
+managed `execute()` (custom pass CPU dispatch、`render_pass_scheduler.cpp:32-38`) は
+compiled 経路導入後ほぼ vestigial だが毎フレーム `std::string ==` を含む。分離・整理の余地。
+
+**L-5. descriptor pool を確保するが誰も使わない**
+`pipeline_compiler.cpp:123-149` で pool 生成、`input_sets` は全 NULL (`:192-194`)、
+bind ブロックは空 (`render_pass_scheduler.cpp:89-96`)。input_textures 配線 (Phase 4) まで
+毎 compile で未使用 pool を確保している。
+
+**L-6. `take_compiled_graph` の解放責任が型で守られていない**
+scheduler は graph を解放しない契約がコメントのみ (`render_pass_scheduler.h:67-83`)。
+正規回収者は `CompiledPathDriver` だが、host が scheduler を直接触ると descriptor pool リーク。
+
+## 4. 維持すべき設計 (変えないこと)
+
+1. **CompiledPathDriver の SRP** — compile タイミングと旧 graph 解放の単責務 + headless 統合テスト。
+   Low/Mid/High 切替の recompile 経路はこの上に乗る。
+2. **hot path の DoD** — `execute_compiled` + recorder は string 無し flat 走査。
+3. **正直な計測方針** — GPU-driven 側の「warn + 未計測 0」。GI 系にも展開する (H-1)。
+4. **編集 API とプリセットの整合** — Mid/High はプリセット定義自体が途中編集 API で構築されるため
+   API とプリセットが乖離しない (`unit_pipeline_tiers_test` が構造を固定)。
+
+## 5. 実装アクション (優先順)
+
+| # | 対象 | 内容 | 規模感 |
+|---|---|---|---|
+| 1 | H-3 | `RenderBatch` へ transparency bit を追加し recorder で `filter_mask` を消費。両 pass profile での二重描画を解消 | 中 |
+| 2 | M-1 | compile 時に pass 名 → uint16 pass_id を解決し `CompiledPass` へ格納 (他の名前解決と同じパターン)。pass_id キーの record callback 表を `RenderPassScheduler` に追加 | 中 |
+| 3 | H-2 | `CompiledPathDriver::resize(w, h)` を追加し「attachments.resize → framebuffers.resize → recompile」を 1 API に束ねる。registry 個別 resize の直接呼び出しは非推奨化 | 小-中 |
+| 4 | H-1 | GI 3-pass を GPU-driven と同じ「一回 warn + 未計測 0」へ是正。stats の見かけ値を廃止 | 小 |
+| 5 | M-2 | 未配線フィールド (rendering_path / max_lights / msaa_samples) の apply_profile 時 warn + ヘッダ明記 | 小 |
+| 6 | — | Forward+ の実体: light cull compute (`light_cull.comp`) + per-tile light index buffer + ライト配列管理 (`max_lights` が初めて意味を持つ)。前提: #2 | 大 |
+| 7 | L-1 | framebuffer / clear_values の固定上限超過を compile error 化 | 小 |
+| 8 | M-3 | 未実装 pass の Begin/End skip (または profile から SHADOW/DEPTH を recorder 実装まで外す) | 小 |
+
+Phase 4 (既存 spec の呼称) と重なる項目は #6 と L-5 (input_textures 配線)。
+本資料のアクション #1-#5 は Phase 4 本体より先に片付ける前提の足場整備。
+
+## 6. アセット調達メモ (High ティア検証用)
+
+実装済みモデルローダは FBX のみ (`model_data_handler.cpp:351` — `FBXImporter`。
+glTF/GLB/OBJ/PMX は `detect_format()` の判定のみでロード経路未実装)。
+
+- **ヒーローシーン**: Amazon Lumberyard Bistro (NVIDIA ORCA、CC-BY 4.0、FBX 配布) —
+  多光源 (Forward+ 検証) と奥行き (DoF 検証) を 1 シーンで賄える。
+- **CC0 調達**: Poly Haven (FBX/glTF/Blend、クレジット不要)。
+- **PBR 正しさの定番**: Khronos glTF-Sample-Assets (DamagedHelmet 等。glTF なので Blender 変換要)。
+- **補助**: Intel Sponza 2022 (CC-BY 4.0)、Sketchfab (CC0/CC-BY フィルタ)。
+- 注意: Quixel Megascans は無料条件が Unreal Engine 利用に紐づくものが多く自社エンジン利用は
+  ライセンス確認必須。MMD (PMX/PMD) は作者ごとの利用規約が厳しく検証用途でも非推奨。
+- 運用: Blender CLI の glTF→FBX 一括変換スクリプトを tools に置く。中期では glTF ローダ実装が
+  費用対効果最大 (無料アセットの大半が glTF 配布)。

--- a/src/pipeline/pipeline_profile.cpp
+++ b/src/pipeline/pipeline_profile.cpp
@@ -43,10 +43,111 @@ PostProcessKind post_process_kind_from_name(const std::string& name) {
     return PostProcessKind::UNKNOWN;
 }
 
+// ============================================================
+// パイプライン途中編集 API (§12 拡張)
+// ============================================================
+
+namespace {
+
+/// 名前付き要素列から `name` の index を返す共通実装。 見つからなければ -1。
+template <typename Vec, typename NameOf>
+int find_by_name(const Vec& v, std::string_view name, NameOf name_of) {
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (name_of(v[i]) == name) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+/// anchor の直前 / 直後へ挿入する共通実装。 anchor 不在 / 同名重複は false。
+template <typename Vec, typename Elem, typename NameOf>
+bool insert_by_anchor(Vec& v, std::string_view anchor, Elem elem, bool after,
+                      NameOf name_of) {
+    const int at = find_by_name(v, anchor, name_of);
+    if (at < 0) return false;
+    if (find_by_name(v, name_of(elem), name_of) >= 0) return false;
+    v.insert(v.begin() + at + (after ? 1 : 0), std::move(elem));
+    return true;
+}
+
+} // namespace
+
+int find_render_pass(const PipelineProfileDef& def, std::string_view pass_name) {
+    return find_by_name(def.render_passes, pass_name,
+                        [](const RenderPassDef& p) -> const std::string& {
+                            return p.pass_name;
+                        });
+}
+
+bool insert_render_pass_before(PipelineProfileDef& def, std::string_view anchor,
+                               RenderPassDef pass) {
+    return insert_by_anchor(def.render_passes, anchor, std::move(pass), false,
+                            [](const RenderPassDef& p) -> const std::string& {
+                                return p.pass_name;
+                            });
+}
+
+bool insert_render_pass_after(PipelineProfileDef& def, std::string_view anchor,
+                              RenderPassDef pass) {
+    return insert_by_anchor(def.render_passes, anchor, std::move(pass), true,
+                            [](const RenderPassDef& p) -> const std::string& {
+                                return p.pass_name;
+                            });
+}
+
+bool remove_render_pass(PipelineProfileDef& def, std::string_view pass_name) {
+    const int at = find_render_pass(def, pass_name);
+    if (at < 0) return false;
+    def.render_passes.erase(def.render_passes.begin() + at);
+    return true;
+}
+
+int find_post_process(const PipelineProfileDef& def, std::string_view name) {
+    return find_by_name(def.post_process_stack, name,
+                        [](const PostProcessDef& p) -> const std::string& {
+                            return p.name;
+                        });
+}
+
+bool insert_post_process_before(PipelineProfileDef& def, std::string_view anchor,
+                                PostProcessDef effect) {
+    if (effect.kind == PostProcessKind::UNKNOWN) {
+        effect.kind = post_process_kind_from_name(effect.name);
+    }
+    return insert_by_anchor(def.post_process_stack, anchor, std::move(effect),
+                            false,
+                            [](const PostProcessDef& p) -> const std::string& {
+                                return p.name;
+                            });
+}
+
+bool insert_post_process_after(PipelineProfileDef& def, std::string_view anchor,
+                               PostProcessDef effect) {
+    if (effect.kind == PostProcessKind::UNKNOWN) {
+        effect.kind = post_process_kind_from_name(effect.name);
+    }
+    return insert_by_anchor(def.post_process_stack, anchor, std::move(effect),
+                            true,
+                            [](const PostProcessDef& p) -> const std::string& {
+                                return p.name;
+                            });
+}
+
+bool remove_post_process(PipelineProfileDef& def, std::string_view name) {
+    const int at = find_post_process(def, name);
+    if (at < 0) return false;
+    def.post_process_stack.erase(def.post_process_stack.begin() + at);
+    return true;
+}
+
 PipelineProfileManager::PipelineProfileManager() = default;
 PipelineProfileManager::~PipelineProfileManager() = default;
 
 void PipelineProfileManager::register_defaults() {
+    // 品質 3 段階の既定パイプライン (§8.1 拡張)。
+    register_profile(create_low_profile());
+    register_profile(create_mid_profile());
+    register_profile(create_high_profile());
+    // 従来プリセット (§8.1)。
     register_profile(create_lite_profile());
     register_profile(create_standard_profile());
     register_profile(create_ultra_profile());
@@ -54,26 +155,23 @@ void PipelineProfileManager::register_defaults() {
 }
 
 void PipelineProfileManager::register_profile(const PipelineProfileDef& def) {
-    // Replace if exists
+    // Replace if exists (index 保持なので current_ はそのまま有効)
     for (auto& p : profiles_) {
         if (p.profile_name == def.profile_name) {
             p = def;
-            if (current_ && current_->profile_name == def.profile_name) {
-                current_ = &p;
-            }
             return;
         }
     }
     profiles_.push_back(def);
-    if (!current_) {
-        current_ = &profiles_.back();
+    if (current_ == kNoProfile) {
+        current_ = profiles_.size() - 1;
     }
 }
 
 bool PipelineProfileManager::set_profile(const std::string& name) {
-    for (const auto& p : profiles_) {
-        if (p.profile_name == name) {
-            current_ = &p;
+    for (size_t i = 0; i < profiles_.size(); ++i) {
+        if (profiles_[i].profile_name == name) {
+            current_ = i;
             return true;
         }
     }
@@ -309,6 +407,144 @@ PipelineProfileDef PipelineProfileManager::create_ultra_profile() {
         {"TAA", true},
         {"VolumetricFog", true},
     };
+
+    normalize_post_process_kinds(def);
+    return def;
+}
+
+// ============================================================
+// Quality Tier Definitions — Low / Mid / High (§8.1 拡張)
+//
+// 既定パイプラインの品質 3 段階。 Mid は Low から、 High は Mid から
+// 途中編集 API (insert_render_pass_* / insert_post_process_*) で段階的に
+// 組み上げる — 「パイプラインを途中で変える」 経路そのものを既定
+// プリセットの構築に使うことで、 API とプリセットの整合を保証する。
+// ============================================================
+
+PipelineProfileDef PipelineProfileManager::create_low_profile() {
+    PipelineProfileDef def;
+    def.profile_name = "Low";
+    def.rendering_path = RenderingPath::FORWARD;
+    def.gpu_driven_enabled = false;
+    def.compute_update_enabled = false;
+    def.max_lights = 16;
+    def.msaa_samples = 0;
+
+    // 影なし — Low は最小構成 (forward 1 経路 + tonemap のみ)。
+    def.shadow_config.cascade_count = 0;
+    def.shadow_config.resolution    = 0;
+    def.shadow_config.filter_mode   = ShadowFilterMode::NONE;
+
+    def.memory_config.frame_allocator_size = 4 * 1024 * 1024; // 4MB
+    def.memory_config.flight_count = 2;
+    def.gpu_driven_config = {};
+    def.gpu_driven_config.compute_update = false;
+
+    def.update_config.chunk_size = 16384;
+    def.update_config.nt_store_enabled = false;
+
+    def.profiler_config.enabled      = true;
+    def.profiler_config.overlay_mode = OverlayMode::MINIMAL;
+
+    // GI: 全て off。
+    def.gi_config.shadow_enabled    = false;
+    def.gi_config.ssao_enabled      = false;
+    def.gi_config.gi_probes_enabled = false;
+
+    def.render_passes = {
+        {"OpaquePass",      PassType::OPAQUE,       INVALID_MESH, {}, {}, SortMode::FRONT_TO_BACK, 0xFFFF, false, {"transforms", "shaderKeys"}},
+        {"TransparentPass", PassType::TRANSPARENT,  INVALID_MESH, {}, {}, SortMode::BACK_TO_FRONT, 0xFFFF, false, {"transforms", "sortKeys"}},
+        {"PostProcess",     PassType::POST_PROCESS, INVALID_MESH, {}, {}, SortMode::NONE,          0xFFFF, false, {}},
+    };
+
+    def.post_process_stack = {
+        {"Tonemapping", true},
+    };
+
+    normalize_post_process_kinds(def);
+    return def;
+}
+
+PipelineProfileDef PipelineProfileManager::create_mid_profile() {
+    // Low を種に、 影 2 pass とポスト (Bloom / Vignette) を途中挿入する。
+    PipelineProfileDef def = create_low_profile();
+    def.profile_name = "Mid";
+    def.max_lights   = 64;
+    def.msaa_samples = 2;
+
+    // 影: 2 cascade / PCF。
+    def.shadow_config.cascade_count = 2;
+    def.shadow_config.resolution    = 2048;
+    def.shadow_config.filter_mode   = ShadowFilterMode::PCF;
+    def.gi_config.shadow_enabled          = true;
+    def.gi_config.shadow.cascade_count    = 2;
+    def.gi_config.shadow.resolution       = 2048;
+    def.gi_config.shadow.filter_mode      = ShadowFilterMode::PCF;
+    def.gi_config.shadow.depth_bias       = 0.005f;
+
+    def.memory_config.frame_allocator_size = 8 * 1024 * 1024; // 8MB
+    def.memory_config.flight_count = 3;
+    def.memory_config.gpu_config.mesh_pool_size = 128 * 1024 * 1024;
+    def.memory_config.gpu_config.ssbo_pool_size = 64 * 1024 * 1024;
+
+    def.profiler_config.overlay_mode = OverlayMode::STANDARD;
+
+    // Opaque の前段へ Shadow → DepthPre を途中挿入。
+    insert_render_pass_before(def, "OpaquePass",
+        {"ShadowPass",   PassType::SHADOW,     INVALID_MESH, {}, {}, SortMode::NONE,          0xFFFF, false, {"bounds", "transforms"}});
+    insert_render_pass_before(def, "OpaquePass",
+        {"DepthPrePass", PassType::DEPTH_ONLY, INVALID_MESH, {}, {}, SortMode::FRONT_TO_BACK, 0xFFFF, false, {"bounds", "transforms"}});
+
+    // ポスト: Bloom を Tonemapping の前、 Vignette を後へ (Mid = Bloom 等が
+    // 載るパイプライン)。
+    insert_post_process_before(def, "Tonemapping", {"Bloom", true});
+    insert_post_process_after(def, "Tonemapping", {"Vignette", true});
+
+    normalize_post_process_kinds(def);
+    return def;
+}
+
+PipelineProfileDef PipelineProfileManager::create_high_profile() {
+    // Mid を種に、 Forward+ 相当の pass 列 (DepthPre → LightCull → shading)
+    // と DoF を途中挿入する。
+    PipelineProfileDef def = create_mid_profile();
+    def.profile_name = "High";
+    def.rendering_path = RenderingPath::FORWARD_PLUS;
+    def.gpu_driven_enabled = true;
+    def.max_lights   = 256;
+    def.msaa_samples = 0; // フル解像度ポスト前提 (AA はポスト側の領分)
+
+    // 影: 3 cascade へ増強。
+    def.shadow_config.cascade_count    = 3;
+    def.gi_config.shadow.cascade_count = 3;
+
+    // SSAO on (深度 prepass があるので流用できる)。
+    def.gi_config.ssao_enabled      = true;
+    def.gi_config.ssao.sample_count = 32;
+    def.gi_config.ssao.radius       = 0.5f;
+    def.gi_config.ssao.intensity    = 1.0f;
+
+    def.memory_config.frame_allocator_size = 16 * 1024 * 1024; // 16MB
+    def.memory_config.gpu_config.mesh_pool_size = 256 * 1024 * 1024;
+    def.memory_config.gpu_config.ssbo_pool_size = 128 * 1024 * 1024;
+
+    def.gpu_driven_config.max_triangle_count = 50000;
+    def.gpu_driven_config.min_instance_count = 32;
+
+    // Forward+ 相当: DepthPrePass の直後へタイル光源カリングの compute を
+    // 途中挿入する (depth prepass → light cull → forward shading)。
+    insert_render_pass_after(def, "DepthPrePass",
+        {"LightCullPass", PassType::COMPUTE, INVALID_MESH, {}, {}, SortMode::NONE, 0xFFFF, false, {}});
+    insert_render_pass_after(def, "LightCullPass",
+        {"SSAOGen",       PassType::COMPUTE, INVALID_MESH, {}, {}, SortMode::NONE, 0xFFFF, false, {}});
+
+    // ポスト: DoF を Bloom の前へ (チェーン上も dof → bloom → grade の順で
+    // 深度をパイプラインへ捩じ込む — `build_post_process_chain()` 参照)。
+    PostProcessDef dof;
+    dof.name    = "DepthOfField";
+    dof.enabled = true;
+    dof.depth_of_field.enabled = true;
+    insert_post_process_before(def, "Bloom", dof);
 
     normalize_post_process_kinds(def);
     return def;

--- a/src/pipeline/pipeline_profile_loader.cpp
+++ b/src/pipeline/pipeline_profile_loader.cpp
@@ -12,6 +12,9 @@ namespace {
 // Canonical preset name -> hardcoded C++ factory. This is the always-available
 // fallback when the JSON file is missing or malformed.
 PipelineProfileDef cpp_fallback(const std::string& name) {
+    if (name == "Low")        return PipelineProfileManager::create_low_profile();
+    if (name == "Mid")        return PipelineProfileManager::create_mid_profile();
+    if (name == "High")       return PipelineProfileManager::create_high_profile();
     if (name == "Lite")       return PipelineProfileManager::create_lite_profile();
     if (name == "Standard")   return PipelineProfileManager::create_standard_profile();
     if (name == "Ultra")      return PipelineProfileManager::create_ultra_profile();
@@ -38,8 +41,8 @@ std::string preset_file_path(const std::string& dir, const std::string& name) {
     return path;
 }
 
-constexpr std::array<const char*, 5> kBuiltinPresetNames = {
-    "Lite", "Standard", "Ultra", "MobileLow", "MobileHigh"};
+constexpr std::array<const char*, 8> kBuiltinPresetNames = {
+    "Low", "Mid", "High", "Lite", "Standard", "Ultra", "MobileLow", "MobileHigh"};
 
 } // namespace
 

--- a/src/postprocess/postprocess_chain.cpp
+++ b/src/postprocess/postprocess_chain.cpp
@@ -10,12 +10,14 @@ namespace pictor {
 const char* const kPostProcessOutputTarget = "__output__";
 const char* const kPostProcessSceneTarget  = "__scene__";
 const char* const kPostProcessLutTarget    = "__lut__";
+const char* const kPostProcessDepthTarget  = "__depth__";
 
 namespace {
 
-// 組み込みチェーンの中間ターゲット論理名 (ping-pong)。
+// 組み込みチェーンの中間ターゲット論理名 (ping-pong / DoF 出力)。
 constexpr const char* kPingTarget = "pp_ping";
 constexpr const char* kPongTarget = "pp_pong";
+constexpr const char* kDofTarget  = "pp_dof";
 
 // 旧 PostProcessPipeline の push constant 構造体と同一レイアウト。
 // build_post_process_chain() / refresh_post_process_chain() はこの構造体を
@@ -29,6 +31,13 @@ struct GradePC {
     float    vignette_intensity, vignette_radius, vignette_softness;
     float    lut_intensity, lut_size;
     float    vig_r, vig_g, vig_b;
+};
+// dof.frag の push constant (shaders/postprocess/dof.frag と同一レイアウト)。
+struct DofPC {
+    float    focus_distance, focus_range, bokeh_radius;
+    float    near_start, near_end, far_start, far_end;
+    uint32_t sample_count;
+    float    texel_x, texel_y, pad0, pad1;
 };
 
 // 構造体を push_data バイト列へ詰める。
@@ -55,6 +64,23 @@ BlurPC make_blur_h_pc(const PostProcessConfig& cfg, uint32_t w) {
 BlurPC make_blur_v_pc(const PostProcessConfig& cfg, uint32_t h) {
     const float radius = cfg.bloom.enabled ? cfg.bloom.radius : 1.0f;
     return BlurPC{0.0f, 1.0f / static_cast<float>(h ? h : 1), radius, 0.0f};
+}
+
+DofPC make_dof_pc(const PostProcessConfig& cfg, uint32_t w, uint32_t h) {
+    const auto& dof = cfg.depth_of_field;
+    DofPC pc{};
+    pc.focus_distance = dof.focus_distance;
+    pc.focus_range    = dof.focus_range;
+    // disabled → bokeh 半径 0 で恒等へ縮退 (シェーダは CoC < 0.5 で素通し)。
+    pc.bokeh_radius   = dof.enabled ? dof.bokeh_radius : 0.0f;
+    pc.near_start     = dof.near_start;
+    pc.near_end       = dof.near_end;
+    pc.far_start      = dof.far_start;
+    pc.far_end        = dof.far_end;
+    pc.sample_count   = dof.sample_count;
+    pc.texel_x        = 1.0f / static_cast<float>(w ? w : 1);
+    pc.texel_y        = 1.0f / static_cast<float>(h ? h : 1);
+    return pc;
 }
 
 GradePC make_grade_pc(const PostProcessConfig& cfg, bool output_is_srgb,
@@ -100,6 +126,22 @@ std::vector<PushFieldDesc> blur_layout() {
         {"_pad0",  PushFieldType::FLOAT, 12},
     };
 }
+std::vector<PushFieldDesc> dof_layout() {
+    return {
+        {"focus_distance", PushFieldType::FLOAT, 0},
+        {"focus_range",    PushFieldType::FLOAT, 4},
+        {"bokeh_radius",   PushFieldType::FLOAT, 8},
+        {"near_start",     PushFieldType::FLOAT, 12},
+        {"near_end",       PushFieldType::FLOAT, 16},
+        {"far_start",      PushFieldType::FLOAT, 20},
+        {"far_end",        PushFieldType::FLOAT, 24},
+        {"sample_count",   PushFieldType::UINT,  28},
+        {"texel_x",        PushFieldType::FLOAT, 32},
+        {"texel_y",        PushFieldType::FLOAT, 36},
+        {"_pad0",          PushFieldType::FLOAT, 40},
+        {"_pad1",          PushFieldType::FLOAT, 44},
+    };
+}
 std::vector<PushFieldDesc> grade_layout() {
     return {
         {"bloom_intensity",    PushFieldType::FLOAT, 0},
@@ -132,10 +174,29 @@ PostProcessChain build_post_process_chain(const PostProcessConfig& cfg,
 
     const std::string fs_vert = shader_dir + "/fullscreen_quad.vert.spv";
 
-    // ── 組み込み pass テンプレート: extract → blur H → blur V → grade ──
+    // ── 組み込み pass テンプレート: [dof →] extract → blur H → blur V → grade ──
     //    旧 PostProcessPipeline::record() の 4-pass と同一構造。 disabled な
     //    エフェクトは push constant で恒等へ縮退するため、 4 pass は常に
     //    実行され中間 image レイアウトを毎フレーム有効に保つ。
+    //    DoF は有効時のみ pass を挿入する構造変更 (深度をパイプラインへ
+    //    捩じ込む必要があるため常設にしない) — 無効時は旧 4-pass と同一。
+
+    // 後段が「シーンカラー」 として読む論理名。 DoF 有効時は DoF 出力へ差替わる。
+    const char* scene_src = kPostProcessSceneTarget;
+
+    // Pass 0 (optional): depth of field  scene + depth → pp_dof
+    if (cfg.depth_of_field.enabled) {
+        PostProcessPassDef p;
+        p.name        = "dof";
+        p.vert_spv    = fs_vert;
+        p.frag_spv    = shader_dir + "/dof.frag.spv";
+        p.inputs      = {kPostProcessSceneTarget, kPostProcessDepthTarget};
+        p.output      = kDofTarget;
+        p.push_layout = dof_layout();
+        store_pc(p.push_data, make_dof_pc(cfg, extent_w, extent_h));
+        chain.passes.push_back(std::move(p));
+        scene_src = kDofTarget;
+    }
 
     // Pass 1: bright-pass extraction  scene → ping
     {
@@ -143,7 +204,7 @@ PostProcessChain build_post_process_chain(const PostProcessConfig& cfg,
         p.name        = "bloom_extract";
         p.vert_spv    = fs_vert;
         p.frag_spv    = shader_dir + "/bloom_extract.frag.spv";
-        p.inputs      = {kPostProcessSceneTarget};
+        p.inputs      = {scene_src};
         p.output      = kPingTarget;
         p.push_layout = extract_layout();
         store_pc(p.push_data, make_extract_pc(cfg));
@@ -179,8 +240,7 @@ PostProcessChain build_post_process_chain(const PostProcessConfig& cfg,
         p.name        = "color_grade";
         p.vert_spv    = fs_vert;
         p.frag_spv    = shader_dir + "/color_grade.frag.spv";
-        p.inputs      = {kPostProcessSceneTarget, kPingTarget,
-                         kPostProcessLutTarget};
+        p.inputs      = {scene_src, kPingTarget, kPostProcessLutTarget};
         p.output      = kPostProcessOutputTarget;
         p.push_layout = grade_layout();
         store_pc(p.push_data, make_grade_pc(cfg, output_is_srgb, lut_loaded));
@@ -190,8 +250,8 @@ PostProcessChain build_post_process_chain(const PostProcessConfig& cfg,
     // ── 任意追加 pass (SSAO / FXAA 等)。 現状 KS は空で呼ぶ ──────────────
     for (const auto& e : extra) chain.passes.push_back(e);
 
-    // 中間ターゲット (scene / output / lut を除く) を収集する。
-    chain.intermediate_names = {kPingTarget, kPongTarget};
+    // 中間ターゲット (予約名を除く) を pass の入出力から収集する。
+    rebuild_intermediate_targets(chain);
 
     return chain;
 }
@@ -202,8 +262,10 @@ void refresh_post_process_chain(PostProcessChain&        chain,
                                 uint32_t                 extent_h,
                                 bool                     output_is_srgb,
                                 bool                     lut_loaded) {
-    // 組み込み 4 pass の push_data だけを config / 解像度に合わせて詰め直す。
-    // pass 名で識別する (任意 extra pass は触らない)。
+    // 組み込み pass の push_data だけを config / 解像度に合わせて詰め直す。
+    // pass 名で識別する (任意 extra pass は触らない)。 DoF の有効 / 無効
+    // 切替は pass の増減 = 構造変更なのでここでは扱わない
+    // (`PostProcessPipeline::rebuild_chain()` の領分)。
     for (auto& p : chain.passes) {
         if (p.name == "bloom_extract") {
             store_pc(p.push_data, make_extract_pc(cfg));
@@ -213,7 +275,79 @@ void refresh_post_process_chain(PostProcessChain&        chain,
             store_pc(p.push_data, make_blur_v_pc(cfg, extent_h));
         } else if (p.name == "color_grade") {
             store_pc(p.push_data, make_grade_pc(cfg, output_is_srgb, lut_loaded));
+        } else if (p.name == "dof") {
+            store_pc(p.push_data, make_dof_pc(cfg, extent_w, extent_h));
         }
+    }
+}
+
+// ============================================================
+// チェーン途中編集 API
+// ============================================================
+
+int find_post_process_pass(const PostProcessChain& chain, std::string_view name) {
+    for (size_t i = 0; i < chain.passes.size(); ++i) {
+        if (chain.passes[i].name == name) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+bool insert_post_process_pass(PostProcessChain&  chain,
+                              PostProcessPassDef pass,
+                              std::string_view   anchor,
+                              PassInsertWhere    where) {
+    const int at = find_post_process_pass(chain, anchor);
+    if (at < 0) return false;                                   // anchor 不在
+    if (find_post_process_pass(chain, pass.name) >= 0) return false;  // 重複名
+
+    const size_t pos = static_cast<size_t>(at) +
+                       (where == PassInsertWhere::AFTER ? 1u : 0u);
+    chain.passes.insert(chain.passes.begin() + static_cast<ptrdiff_t>(pos),
+                        std::move(pass));
+    rebuild_intermediate_targets(chain);
+    return true;
+}
+
+bool remove_post_process_pass(PostProcessChain& chain, std::string_view name) {
+    const int at = find_post_process_pass(chain, name);
+    if (at < 0) return false;
+    chain.passes.erase(chain.passes.begin() + at);
+    rebuild_intermediate_targets(chain);
+    return true;
+}
+
+bool rebind_post_process_input(PostProcessChain& chain,
+                               std::string_view  pass_name,
+                               std::string_view  old_target,
+                               std::string_view  new_target) {
+    const int at = find_post_process_pass(chain, pass_name);
+    if (at < 0) return false;
+    bool rebound = false;
+    for (auto& in : chain.passes[static_cast<size_t>(at)].inputs) {
+        if (in == old_target) {
+            in = std::string(new_target);
+            rebound = true;
+        }
+    }
+    if (rebound) rebuild_intermediate_targets(chain);
+    return rebound;
+}
+
+void rebuild_intermediate_targets(PostProcessChain& chain) {
+    auto is_reserved = [](const std::string& n) {
+        return n == kPostProcessSceneTarget || n == kPostProcessOutputTarget ||
+               n == kPostProcessLutTarget   || n == kPostProcessDepthTarget;
+    };
+    chain.intermediate_names.clear();
+    auto add_unique = [&](const std::string& n) {
+        if (n.empty() || is_reserved(n)) return;
+        for (const auto& have : chain.intermediate_names)
+            if (have == n) return;
+        chain.intermediate_names.push_back(n);
+    };
+    for (const auto& p : chain.passes) {
+        for (const auto& in : p.inputs) add_unique(in);
+        add_unique(p.output);
     }
 }
 

--- a/src/postprocess/postprocess_pipeline.cpp
+++ b/src/postprocess/postprocess_pipeline.cpp
@@ -377,7 +377,15 @@ bool PostProcessPipeline::create_samplers_() {
     si.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     si.maxLod       = 1.0f;
-    return vkCreateSampler(device_, &si, nullptr, &sampler_) == VK_SUCCESS;
+    if (vkCreateSampler(device_, &si, nullptr, &sampler_) != VK_SUCCESS)
+        return false;
+
+    // 深度入力 (__depth__) 用。 D32_SFLOAT の LINEAR filter はデバイス保証が
+    // ないため NEAREST に倒す。
+    si.magFilter  = VK_FILTER_NEAREST;
+    si.minFilter  = VK_FILTER_NEAREST;
+    si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    return vkCreateSampler(device_, &si, nullptr, &depth_sampler_) == VK_SUCCESS;
 }
 
 bool PostProcessPipeline::upload_lut_(const unsigned char* rgba, int w, int h) {
@@ -563,15 +571,25 @@ void PostProcessPipeline::write_descriptor_sets_() {
         std::vector<VkDescriptorImageInfo> infos(cp.input_count);
         std::vector<VkWriteDescriptorSet>  writes(cp.input_count);
         for (uint32_t i = 0; i < cp.input_count; ++i) {
-            // 入力 index < 0 のときは LUT (専用 Texture)。 それ以外は targets_。
-            VkImageView view = VK_NULL_HANDLE;
+            // 入力 index >= 0 は targets_、 -1 は LUT (専用 Texture)、
+            // -2 は scene 深度 (__depth__、 NEAREST サンプラ)。
             const int32_t idx = cp.input_indices[i];
-            if (idx >= 0) view = targets_[static_cast<size_t>(idx)].view;
-            else          view = lut_.view;
-
-            infos[i].sampler     = sampler_;
-            infos[i].imageView   = view;
-            infos[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            if (idx >= 0) {
+                infos[i].sampler     = sampler_;
+                infos[i].imageView   = targets_[static_cast<size_t>(idx)].view;
+                infos[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            } else if (idx == -1) {
+                infos[i].sampler     = sampler_;
+                infos[i].imageView   = lut_.view;
+                infos[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+            } else {
+                // scene render pass の finalLayout (DEPTH_STENCIL_READ_ONLY)
+                // と一致させる。
+                infos[i].sampler     = depth_sampler_;
+                infos[i].imageView   = scene_depth_view();
+                infos[i].imageLayout =
+                    VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+            }
 
             writes[i] = VkWriteDescriptorSet{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
             writes[i].dstSet          = cp.desc_set;
@@ -698,6 +716,10 @@ bool PostProcessPipeline::build_from_chain_(
         for (const auto& in_name : def.inputs) {
             if (in_name == kPostProcessLutTarget) {
                 cp.input_indices.push_back(-1);  // LUT (専用 Texture)
+                continue;
+            }
+            if (in_name == kPostProcessDepthTarget) {
+                cp.input_indices.push_back(-2);  // scene 深度ビュー
                 continue;
             }
             int32_t idx = resolve_target_(in_name);
@@ -886,9 +908,49 @@ bool PostProcessPipeline::resize(uint32_t width, uint32_t height,
     vkDeviceWaitIdle(device_);
 
     // サイズ依存リソースのみ破棄 (render pass / sampler / LUT / descriptor
-    // set layout / pipeline layout は維持)。 pipeline / descriptor pool は
-    // pass 数に依存しないが、 descriptor set は target view に紐づくため
-    // 再生成する。
+    // set layout / pipeline layout は維持)。
+    destroy_chain_resources_();
+
+    width_  = width;
+    height_ = height;
+    extent_ = {width, height};
+
+    // build_from_chain_ は render pass を再利用 (rp_* が非 null なら維持)。
+    if (!build_from_chain_(output_format_, output_views)) {
+        std::fprintf(stderr, "[postprocess] resize: rebuild failed\n");
+        vulkan_ready_ = false;
+        return false;
+    }
+    return true;
+}
+
+bool PostProcessPipeline::rebuild_chain(
+        const PostProcessChain& chain,
+        const std::vector<VkImageView>& output_views) {
+    if (!vulkan_ready_) return false;
+
+    vkDeviceWaitIdle(device_);
+
+    // resize と同じチェーン依存リソースを破棄し、 新チェーン記述で組み直す。
+    // pass 数 / 入出力配線 / シェーダが変わるため pipeline / descriptor も
+    // 全て作り直しになる (render pass / sampler / LUT / layout キャッシュは
+    // input 数 / push サイズ単位の共有物なので維持できる)。
+    destroy_chain_resources_();
+    chain_ = chain;
+
+    if (!build_from_chain_(output_format_, output_views)) {
+        std::fprintf(stderr, "[postprocess] rebuild_chain: rebuild failed\n");
+        vulkan_ready_ = false;
+        return false;
+    }
+    std::fprintf(stderr, "[postprocess] chain rebuilt: %zu pass\n",
+                 compiled_.size());
+    return true;
+}
+
+// targets / output framebuffers / pipelines / descriptor pool を破棄する。
+// 呼出し側で GPU idle を保証すること (resize / rebuild_chain 共通ボディ)。
+void PostProcessPipeline::destroy_chain_resources_() {
     auto destroy_rt = [&](RenderTarget& rt) {
         if (rt.fb)           vkDestroyFramebuffer(device_, rt.fb, nullptr);
         if (rt.view)         vkDestroyImageView(device_, rt.view, nullptr);
@@ -912,18 +974,6 @@ bool PostProcessPipeline::resize(uint32_t width, uint32_t height,
     if (desc_pool_) vkDestroyDescriptorPool(device_, desc_pool_, nullptr);
     desc_pool_ = VK_NULL_HANDLE;
     compiled_.clear();
-
-    width_  = width;
-    height_ = height;
-    extent_ = {width, height};
-
-    // build_from_chain_ は render pass を再利用 (rp_* が非 null なら維持)。
-    if (!build_from_chain_(output_format_, output_views)) {
-        std::fprintf(stderr, "[postprocess] resize: rebuild failed\n");
-        vulkan_ready_ = false;
-        return false;
-    }
-    return true;
 }
 
 #endif // PICTOR_HAS_VULKAN
@@ -970,11 +1020,13 @@ void PostProcessPipeline::shutdown() {
             if (kv.second) vkDestroyDescriptorSetLayout(device_, kv.second, nullptr);
         dsl_by_input_count_.clear();
 
-        if (sampler_)   vkDestroySampler(device_, sampler_, nullptr);
+        if (sampler_)       vkDestroySampler(device_, sampler_, nullptr);
+        if (depth_sampler_) vkDestroySampler(device_, depth_sampler_, nullptr);
         if (rp_scene_)  vkDestroyRenderPass(device_, rp_scene_, nullptr);
         if (rp_inter_)  vkDestroyRenderPass(device_, rp_inter_, nullptr);
         if (rp_output_) vkDestroyRenderPass(device_, rp_output_, nullptr);
         sampler_  = VK_NULL_HANDLE;
+        depth_sampler_ = VK_NULL_HANDLE;
         rp_scene_ = rp_inter_ = rp_output_ = VK_NULL_HANDLE;
         device_   = VK_NULL_HANDLE;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(PICTOR_TESTS
     unit_visus_instantiator_test
     unit_shader_registry_test
     unit_pipeline_profile_serializer_test
+    unit_pipeline_tiers_test
     unit_postprocess_chain_test
     unit_attachment_def_test
     unit_pipeline_registries_test

--- a/tests/unit_pipeline_profile_serializer_test.cpp
+++ b/tests/unit_pipeline_profile_serializer_test.cpp
@@ -165,12 +165,12 @@ void test_builder_structured_pass() {
 
 void test_preset_loader_fallback() {
     // With no profile directory, the loader must fall back to C++ factories
-    // and still produce all five named presets.
+    // and still produce all eight named presets.
     std::vector<PresetLoadResult> results;
     auto profiles = load_builtin_presets("", &results);
 
-    PT_ASSERT_OP(profiles.size(), ==, 5u, "loader returns 5 presets");
-    PT_ASSERT_OP(results.size(), ==, 5u, "loader returns 5 results");
+    PT_ASSERT_OP(profiles.size(), ==, 8u, "loader returns 8 presets");
+    PT_ASSERT_OP(results.size(), ==, 8u, "loader returns 8 results");
 
     bool any_from_file = false;
     for (const auto& r : results) {
@@ -179,15 +179,18 @@ void test_preset_loader_fallback() {
     PT_ASSERT(!any_from_file, "empty dir -> all presets from C++ fallback");
 
     // Names must match the C++ factory output exactly.
-    PT_ASSERT(profiles[0].profile_name == "Lite",       "preset[0] = Lite");
-    PT_ASSERT(profiles[1].profile_name == "Standard",   "preset[1] = Standard");
-    PT_ASSERT(profiles[2].profile_name == "Ultra",      "preset[2] = Ultra");
-    PT_ASSERT(profiles[3].profile_name == "MobileLow",  "preset[3] = MobileLow");
-    PT_ASSERT(profiles[4].profile_name == "MobileHigh", "preset[4] = MobileHigh");
+    PT_ASSERT(profiles[0].profile_name == "Low",        "preset[0] = Low");
+    PT_ASSERT(profiles[1].profile_name == "Mid",        "preset[1] = Mid");
+    PT_ASSERT(profiles[2].profile_name == "High",       "preset[2] = High");
+    PT_ASSERT(profiles[3].profile_name == "Lite",       "preset[3] = Lite");
+    PT_ASSERT(profiles[4].profile_name == "Standard",   "preset[4] = Standard");
+    PT_ASSERT(profiles[5].profile_name == "Ultra",      "preset[5] = Ultra");
+    PT_ASSERT(profiles[6].profile_name == "MobileLow",  "preset[6] = MobileLow");
+    PT_ASSERT(profiles[7].profile_name == "MobileHigh", "preset[7] = MobileHigh");
 
     // Fallback content must equal the C++ factory directly.
     PipelineProfileDef std_cpp = PipelineProfileManager::create_standard_profile();
-    PT_ASSERT_OP(profiles[1].render_passes.size(), ==, std_cpp.render_passes.size(),
+    PT_ASSERT_OP(profiles[4].render_passes.size(), ==, std_cpp.render_passes.size(),
                  "fallback Standard matches C++ factory pass count");
 }
 

--- a/tests/unit_pipeline_tiers_test.cpp
+++ b/tests/unit_pipeline_tiers_test.cpp
@@ -1,0 +1,197 @@
+/// Low / Mid / High 品質 3 段階プリセットと、 パイプライン途中編集 API の検証.
+///
+/// 対象:
+///   - `PipelineProfileManager::create_low/mid/high_profile()` の構造
+///     (Mid = Bloom 系ポスト、 High = DoF + Forward+ 相当の pass 列)
+///   - `insert_render_pass_before/after()` / `remove_render_pass()` /
+///     `insert_post_process_before/after()` / `remove_post_process()`
+///   - プリセット → `build_post_process_config()` →
+///     `build_post_process_chain()` の通し (High で DoF pass が途中挿入
+///     されること)
+///
+/// Vulkan device は不要 (宣言データの検証のみ)。
+
+#include "pictor/pipeline/pipeline_profile.h"
+#include "pictor/postprocess/postprocess_chain.h"
+#include "pictor/postprocess/postprocess_config_bridge.h"
+#include "test_common.h"
+
+using namespace pictor;
+using namespace pictor_test;
+
+int main() {
+    // 1. Low — FORWARD 最小構成。 post は Tonemapping のみ。
+    {
+        PipelineProfileDef low = PipelineProfileManager::create_low_profile();
+        PT_ASSERT(low.profile_name == "Low", "Low: name");
+        PT_ASSERT(low.rendering_path == RenderingPath::FORWARD, "Low: FORWARD");
+        PT_ASSERT(!low.gpu_driven_enabled, "Low: gpu driven off");
+        PT_ASSERT_OP(low.render_passes.size(), ==, size_t{3},
+                     "Low: 3 render passes (Opaque/Transparent/Post)");
+        PT_ASSERT_OP(low.post_process_stack.size(), ==, size_t{1},
+                     "Low: post = Tonemapping only");
+        PT_ASSERT(low.post_process_stack[0].kind == PostProcessKind::TONE_MAPPING,
+                  "Low: tonemapping kind normalized");
+    }
+
+    // 2. Mid — Low + Shadow/DepthPre、 post に Bloom / Vignette (Bloom 等が
+    //    載るパイプライン)。
+    {
+        PipelineProfileDef mid = PipelineProfileManager::create_mid_profile();
+        PT_ASSERT(mid.profile_name == "Mid", "Mid: name");
+        PT_ASSERT(mid.rendering_path == RenderingPath::FORWARD, "Mid: FORWARD");
+
+        // 途中挿入の結果: Shadow → DepthPre → Opaque の順。
+        const int shadow = find_render_pass(mid, "ShadowPass");
+        const int depth  = find_render_pass(mid, "DepthPrePass");
+        const int opaque = find_render_pass(mid, "OpaquePass");
+        PT_ASSERT(shadow >= 0 && depth >= 0 && opaque >= 0,
+                  "Mid: Shadow/DepthPre/Opaque present");
+        PT_ASSERT(shadow < depth && depth < opaque,
+                  "Mid: Shadow -> DepthPre -> Opaque order");
+
+        // post: Bloom は Tonemapping の前、 Vignette は後。
+        const int bloom = find_post_process(mid, "Bloom");
+        const int tm    = find_post_process(mid, "Tonemapping");
+        const int vig   = find_post_process(mid, "Vignette");
+        PT_ASSERT(bloom >= 0 && tm >= 0 && vig >= 0, "Mid: Bloom/TM/Vignette");
+        PT_ASSERT(bloom < tm && tm < vig, "Mid: Bloom -> TM -> Vignette order");
+        PT_ASSERT(mid.post_process_stack[static_cast<size_t>(bloom)].kind ==
+                      PostProcessKind::BLOOM,
+                  "Mid: Bloom kind normalized");
+        PT_ASSERT(mid.shadow_config.filter_mode == ShadowFilterMode::PCF,
+                  "Mid: PCF shadows");
+    }
+
+    // 3. High — Forward+ 相当 (DepthPre → LightCull → shading) + DoF。
+    {
+        PipelineProfileDef high = PipelineProfileManager::create_high_profile();
+        PT_ASSERT(high.profile_name == "High", "High: name");
+        PT_ASSERT(high.rendering_path == RenderingPath::FORWARD_PLUS,
+                  "High: FORWARD_PLUS");
+
+        // LightCullPass は DepthPrePass の直後 (Forward+ の depth prepass →
+        // tiled light culling)。
+        const int depth = find_render_pass(high, "DepthPrePass");
+        const int cull  = find_render_pass(high, "LightCullPass");
+        const int ssao  = find_render_pass(high, "SSAOGen");
+        const int opaque = find_render_pass(high, "OpaquePass");
+        PT_ASSERT(depth >= 0 && cull >= 0 && ssao >= 0, "High: FW+ passes present");
+        PT_ASSERT_OP(cull, ==, depth + 1, "High: LightCull right after DepthPre");
+        PT_ASSERT(ssao < opaque, "High: SSAO before shading");
+        PT_ASSERT(high.render_passes[static_cast<size_t>(cull)].pass_type ==
+                      PassType::COMPUTE,
+                  "High: LightCull is a compute pass");
+
+        // post: DoF が Bloom より前 (深度をチェーンへ捩じ込む)。
+        const int dof   = find_post_process(high, "DepthOfField");
+        const int bloom = find_post_process(high, "Bloom");
+        PT_ASSERT(dof >= 0 && bloom >= 0, "High: DoF + Bloom present");
+        PT_ASSERT(dof < bloom, "High: DoF before Bloom");
+        const auto& dof_def = high.post_process_stack[static_cast<size_t>(dof)];
+        PT_ASSERT(dof_def.kind == PostProcessKind::DEPTH_OF_FIELD,
+                  "High: DoF kind normalized");
+        PT_ASSERT(dof_def.enabled, "High: DoF enabled");
+    }
+
+    // 4. High プリセット → config → チェーンの通し: DoF pass がチェーン先頭へ
+    //    途中挿入され、 後段が DoF 出力を読むよう配線替えされる。
+    {
+        PipelineProfileDef high = PipelineProfileManager::create_high_profile();
+        PostProcessConfig cfg = build_post_process_config(high);
+        PT_ASSERT(cfg.depth_of_field.enabled, "High config: DoF enabled");
+
+        PostProcessChain chain = build_post_process_chain(
+            cfg, "shaders", 1920, 1080, /*srgb=*/false, /*lut=*/false);
+        PT_ASSERT_OP(chain.passes.size(), ==, size_t{5},
+                     "High chain: dof + built-in 4");
+        PT_ASSERT(chain.passes[0].name == "dof", "High chain: dof first");
+        PT_ASSERT_OP(chain.passes[0].inputs.size(), ==, size_t{2},
+                     "High chain: dof reads scene + depth");
+        PT_ASSERT(chain.passes[0].inputs[0] == kPostProcessSceneTarget,
+                  "High chain: dof input0 = scene");
+        PT_ASSERT(chain.passes[0].inputs[1] == kPostProcessDepthTarget,
+                  "High chain: dof input1 = depth");
+        PT_ASSERT(chain.passes[1].inputs[0] == "pp_dof",
+                  "High chain: extract rewired to dof output");
+        PT_ASSERT(chain.passes[4].inputs[0] == "pp_dof",
+                  "High chain: grade rewired to dof output");
+    }
+
+    // 5. Mid (DoF 無し) のチェーンは従来どおり 4 pass — 構造の後方互換。
+    {
+        PipelineProfileDef mid = PipelineProfileManager::create_mid_profile();
+        PostProcessConfig cfg = build_post_process_config(mid);
+        PT_ASSERT(!cfg.depth_of_field.enabled, "Mid config: DoF off");
+        PostProcessChain chain = build_post_process_chain(
+            cfg, "shaders", 1920, 1080, false, false);
+        PT_ASSERT_OP(chain.passes.size(), ==, size_t{4},
+                     "Mid chain: built-in 4 passes only");
+        PT_ASSERT(chain.passes[0].inputs[0] == kPostProcessSceneTarget,
+                  "Mid chain: extract reads scene directly");
+    }
+
+    // 6. render pass 途中編集 API — anchor 基準の挿入 / 削除。
+    {
+        PipelineProfileDef def = PipelineProfileManager::create_low_profile();
+
+        RenderPassDef custom;
+        custom.pass_name = "OutlinePass";
+        custom.pass_type = PassType::CUSTOM;
+        PT_ASSERT(insert_render_pass_after(def, "OpaquePass", custom),
+                  "edit: insert after OpaquePass");
+        PT_ASSERT_OP(find_render_pass(def, "OutlinePass"), ==,
+                     find_render_pass(def, "OpaquePass") + 1,
+                     "edit: OutlinePass sits right after OpaquePass");
+
+        // 同名の再挿入は拒否 (チェーン不変)。
+        PT_ASSERT(!insert_render_pass_before(def, "OpaquePass", custom),
+                  "edit: duplicate pass name rejected");
+        // 不在 anchor は拒否。
+        PT_ASSERT(!insert_render_pass_after(def, "NoSuchPass", custom),
+                  "edit: unknown anchor rejected");
+
+        PT_ASSERT(remove_render_pass(def, "OutlinePass"), "edit: remove pass");
+        PT_ASSERT_OP(find_render_pass(def, "OutlinePass"), ==, -1,
+                     "edit: pass gone after removal");
+        PT_ASSERT(!remove_render_pass(def, "OutlinePass"),
+                  "edit: double removal rejected");
+    }
+
+    // 7. post-process 途中編集 API — kind 補完も確認。
+    {
+        PipelineProfileDef def = PipelineProfileManager::create_mid_profile();
+
+        PostProcessDef dof;
+        dof.name    = "DoF";  // エイリアス表記 -> kind 補完される
+        dof.enabled = true;
+        PT_ASSERT(insert_post_process_before(def, "Bloom", dof),
+                  "edit: insert DoF before Bloom");
+        const int at = find_post_process(def, "DoF");
+        PT_ASSERT(at >= 0 && at < find_post_process(def, "Bloom"),
+                  "edit: DoF sits before Bloom");
+        PT_ASSERT(def.post_process_stack[static_cast<size_t>(at)].kind ==
+                      PostProcessKind::DEPTH_OF_FIELD,
+                  "edit: kind inferred from alias name");
+
+        PT_ASSERT(remove_post_process(def, "DoF"), "edit: remove effect");
+        PT_ASSERT(!insert_post_process_after(def, "NoSuchEffect", dof),
+                  "edit: unknown post anchor rejected");
+    }
+
+    // 8. Manager: register_defaults が 3 段階 + 従来プリセットを提供する。
+    {
+        PipelineProfileManager mgr;
+        mgr.register_defaults();
+        PT_ASSERT(mgr.get_profile("Low")  != nullptr, "mgr: Low registered");
+        PT_ASSERT(mgr.get_profile("Mid")  != nullptr, "mgr: Mid registered");
+        PT_ASSERT(mgr.get_profile("High") != nullptr, "mgr: High registered");
+        PT_ASSERT(mgr.get_profile("Standard") != nullptr, "mgr: Standard kept");
+        PT_ASSERT(mgr.current_profile_name() == "Standard",
+                  "mgr: active default unchanged (Standard)");
+        PT_ASSERT(mgr.set_profile("High"), "mgr: switch to High");
+        PT_ASSERT(mgr.current_profile_name() == "High", "mgr: High active");
+    }
+
+    return report("unit_pipeline_tiers_test");
+}

--- a/tests/unit_postprocess_chain_test.cpp
+++ b/tests/unit_postprocess_chain_test.cpp
@@ -229,5 +229,121 @@ int main() {
                   "refresh leaves extra pass push_data untouched");
     }
 
+    // 7. DoF 有効時はチェーン先頭へ dof pass が途中挿入され、 後段の scene
+    //    入力が dof 出力 (pp_dof) へ配線替えされる。
+    {
+        PostProcessConfig cfg;
+        cfg.depth_of_field.enabled        = true;
+        cfg.depth_of_field.focus_distance = 12.0f;
+        cfg.depth_of_field.bokeh_radius   = 3.0f;
+
+        PostProcessChain chain = build_post_process_chain(
+            cfg, "shaders", 1600, 900, false, false);
+
+        PT_ASSERT_OP(chain.passes.size(), ==, size_t{5}, "dof chain: 5 passes");
+        PT_ASSERT(chain.passes[0].name == "dof", "dof chain: dof first");
+        PT_ASSERT(chain.passes[0].inputs[0] == kPostProcessSceneTarget,
+                  "dof chain: dof reads scene");
+        PT_ASSERT(chain.passes[0].inputs[1] == kPostProcessDepthTarget,
+                  "dof chain: dof reads depth");
+        PT_ASSERT(chain.passes[0].output == "pp_dof", "dof chain: dof -> pp_dof");
+        PT_ASSERT(chain.passes[1].inputs[0] == "pp_dof",
+                  "dof chain: extract rewired to pp_dof");
+        PT_ASSERT(chain.passes[4].inputs[0] == "pp_dof",
+                  "dof chain: grade rewired to pp_dof");
+        PT_ASSERT_OP(chain.intermediate_names.size(), ==, size_t{3},
+                     "dof chain: pp_dof + ping + pong");
+
+        // push constant: focus_distance が先頭 float、 texel が 1/w, 1/h。
+        struct DofPC {
+            float    focus_distance, focus_range, bokeh_radius;
+            float    near_start, near_end, far_start, far_end;
+            uint32_t sample_count;
+            float    texel_x, texel_y, pad0, pad1;
+        };
+        DofPC pc = read_pc<DofPC>(chain.passes[0]);
+        PT_ASSERT(feq(pc.focus_distance, 12.0f), "dof pc: focus distance");
+        PT_ASSERT(feq(pc.bokeh_radius, 3.0f),    "dof pc: bokeh radius");
+        PT_ASSERT(feq(pc.texel_x, 1.0f / 1600.0f), "dof pc: texel x");
+        PT_ASSERT(feq(pc.texel_y, 1.0f / 900.0f),  "dof pc: texel y");
+
+        // refresh が dof の push_data も詰め直す (構造は不変)。
+        cfg.depth_of_field.focus_distance = 20.0f;
+        refresh_post_process_chain(chain, cfg, 1600, 900, false, false);
+        pc = read_pc<DofPC>(chain.passes[0]);
+        PT_ASSERT(feq(pc.focus_distance, 20.0f), "dof pc: refresh updates focus");
+        PT_ASSERT_OP(chain.passes.size(), ==, size_t{5},
+                     "refresh keeps dof chain structure");
+    }
+
+    // 8. チェーン途中編集 API — anchor 基準の挿入 / 削除 / 配線替え。
+    {
+        PostProcessConfig cfg;
+        PostProcessChain chain = build_post_process_chain(
+            cfg, "shaders", 800, 600, false, false);
+
+        // blur H の後へ SSAO 風の pass を途中挿入。 新しい中間ターゲット名は
+        // intermediate_names へ自動反映される。
+        PostProcessPassDef ssao;
+        ssao.name     = "ssao";
+        ssao.vert_spv = "shaders/fullscreen_quad.vert.spv";
+        ssao.frag_spv = "shaders/ssao.frag.spv";
+        ssao.inputs   = {kPostProcessSceneTarget, kPostProcessDepthTarget};
+        ssao.output   = "pp_ssao";
+        PT_ASSERT(insert_post_process_pass(chain, ssao, "bloom_blur_h",
+                                           PassInsertWhere::AFTER),
+                  "chain edit: insert after blur H");
+        PT_ASSERT_OP(find_post_process_pass(chain, "ssao"), ==, 2,
+                     "chain edit: ssao at index 2 (after blur H)");
+        bool has_ssao_target = false;
+        for (const auto& n : chain.intermediate_names)
+            if (n == "pp_ssao") has_ssao_target = true;
+        PT_ASSERT(has_ssao_target, "chain edit: pp_ssao auto-collected");
+
+        // 同名 / 不在 anchor は拒否 (チェーン不変)。
+        PT_ASSERT(!insert_post_process_pass(chain, ssao, "color_grade",
+                                            PassInsertWhere::BEFORE),
+                  "chain edit: duplicate name rejected");
+        PT_ASSERT(!insert_post_process_pass(chain, PostProcessPassDef{"x"},
+                                            "no_such_pass",
+                                            PassInsertWhere::BEFORE),
+                  "chain edit: unknown anchor rejected");
+
+        // 配線替え: grade の scene 入力を ssao 出力へ。
+        PT_ASSERT(rebind_post_process_input(chain, "color_grade",
+                                            kPostProcessSceneTarget, "pp_ssao"),
+                  "chain edit: rebind grade input");
+        const PostProcessPassDef* gr = find_pass(chain, "color_grade");
+        PT_ASSERT(gr != nullptr && gr->inputs[0] == "pp_ssao",
+                  "chain edit: grade reads pp_ssao");
+        PT_ASSERT(!rebind_post_process_input(chain, "color_grade",
+                                             "not_an_input", "x"),
+                  "chain edit: rebind unknown input rejected");
+
+        // 削除: ssao を抜くと pass 数が戻る。 pp_ssao はまだ grade が読むので
+        // intermediate には残る。
+        PT_ASSERT(remove_post_process_pass(chain, "ssao"),
+                  "chain edit: remove ssao");
+        PT_ASSERT_OP(chain.passes.size(), ==, size_t{4},
+                     "chain edit: back to 4 passes");
+        has_ssao_target = false;
+        for (const auto& n : chain.intermediate_names)
+            if (n == "pp_ssao") has_ssao_target = true;
+        PT_ASSERT(has_ssao_target,
+                  "chain edit: target kept while grade still reads it");
+
+        // grade の入力を scene へ戻すと pp_ssao は intermediate から消える。
+        PT_ASSERT(rebind_post_process_input(chain, "color_grade", "pp_ssao",
+                                            kPostProcessSceneTarget),
+                  "chain edit: rebind back to scene");
+        has_ssao_target = false;
+        for (const auto& n : chain.intermediate_names)
+            if (n == "pp_ssao") has_ssao_target = true;
+        PT_ASSERT(!has_ssao_target, "chain edit: unused target dropped");
+
+        PT_ASSERT(!remove_post_process_pass(chain, "ssao"),
+                  "chain edit: double removal rejected");
+    }
+
     return report("unit_postprocess_chain_test");
 }


### PR DESCRIPTION
## 概要

「ポストプロセスだがパイプラインへ捩じ込む必要があるエフェクト」 を扱えるよう、パイプラインを **途中で変えられる編集経路** を追加し、その上に既定パイプラインの品質 3 段階 **Low / Mid / High** を構築する。

## 途中編集 API

### PostProcessChain (`postprocess_chain.h`)
- `insert_post_process_pass()` / `remove_post_process_pass()` / `rebind_post_process_input()` / `find_post_process_pass()` — anchor pass 名基準でチェーンの途中へ pass を挿入 / 削除 / 配線替え
- `rebuild_intermediate_targets()` — pass の入出力から中間ターゲットを自動再収集 (編集 API から自動で走る)
- `__depth__` 予約ターゲット新設 — scene 深度をチェーン pass の入力へ解決 (NEAREST サンプラ、`DEPTH_STENCIL_READ_ONLY` layout)。DoF / SSAO 等の深度依存 pass 用
- `PostProcessPipeline::rebuild_chain()` — チェーン構造のフレーム間差し替え (resize と共通の teardown を `destroy_chain_resources_()` へ抽出)

### PipelineProfileDef (`pipeline_profile.h`)
- `insert_render_pass_before/after()` / `remove_render_pass()` / `find_render_pass()`
- `insert_post_process_before/after()` / `remove_post_process()` / `find_post_process()` (kind は名前から自動補完)
- 実行時反映は既存の `register_custom_profile()` + `set_profile()` / `reload_active_profile()` → `CompiledPathDriver::recompile()` に乗る

## DoF の組み込み pass 化

- `shaders/postprocess/dof.frag` 新規 (`dof.comp` の fragment 移植、CoC + Poisson disc ブラー)
- `cfg.depth_of_field.enabled` 時、`build_post_process_chain()` がチェーン先頭へ `dof` pass (scene + `__depth__` → `pp_dof`) を途中挿入し、後段 extract / grade の scene 入力を `pp_dof` へ配線替え
- **無効時は従来 4-pass とバイト単位で同一** (既存テストで担保)。`refresh_post_process_chain()` は DoF の push constant も毎フレーム更新

## 品質 3 段階プリセット

| Tier | Path | Render passes | Post |
|---|---|---|---|
| Low  | FORWARD | Opaque → Transparent → Post | Tonemapping |
| Mid  | FORWARD | + Shadow / DepthPre | + **Bloom** / Vignette |
| High | **FORWARD_PLUS 相当** | + LightCull (DepthPre 直後) / SSAOGen | + **DoF** (Bloom の前) |

- Mid は Low から、High は Mid から **途中編集 API で段階構築** — API とプリセットの整合をコードで保証
- `register_defaults()` / preset loader / `profiles/{low,mid,high}.profile.json` へ登録 (既存 Lite/Standard/Ultra/Mobile* は維持、既定 active は Standard のまま)

## バグ修正 (関連)

- `PipelineProfileManager::current_` を生ポインタ → index 化。`register_profile()` の `push_back` 再確保で dangling する潜在バグ (プリセット数増で顕在化しやすくなるため同時修正)

## テスト

- `unit_pipeline_tiers_test` 新規: 3 プリセット構造 / 編集 API / High → config → chain の通し (DoF 途中挿入 + 配線替え)
- `unit_postprocess_chain_test` 拡張: DoF チェーン構造 / push constant / チェーン編集 API
- `unit_pipeline_profile_serializer_test`: loader 8 プリセット化に追随
- Linux + Vulkan ヘッダ環境でビルド (`dof.frag` は glslc 検証済み)、ヘッドレステスト **20/20 PASS**。JSON プリセット 8 件のファイルロードも確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TNirGpPSS6dr74A72vgiC

---
_Generated by [Claude Code](https://claude.ai/code/session_016TNirGpPSS6dr74A72vgiC)_